### PR TITLE
DRAFT — tallriksvis sandboxing (Issue #14, Option A)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,39 +1,45 @@
 # Grimnir System — Status
 
-**Last session:** 2026-04-11
-**Branch:** main
+**Last session:** 2026-06-11
+**Branch:** feat/tallriksvis-sandbox (PR #19 still DRAFT, pending Pi-side verification)
 
-## Completed This Session
+## Completed This Session (2026-06-11)
 
-### Pi grimnir repo drift — fixed
-- Pi's `/home/magnus/repos/grimnir` was 29 commits behind `origin/main` with a pile of uncommitted modifications and untracked files
-- Verified every local change was stale echo of origin before touching anything:
-  - Tracked modifications were either byte-identical to origin (Makefile, scripts/security-scan.sh) or older versions of files origin had since rewritten
-  - Untracked files (services.json, scripts/deploy.sh, scripts/lib/registry.js, docs/scheduled-tasks.md, systemd/grimnir-validate.*) were byte-identical to origin — leftover from a pre-commit manual copy
-  - services.json was the only outlier — older, missing the verdandi block
-  - `git log origin/main..HEAD` empty; reflog's only local commit (`4d30000`, SCION plan) reachable from origin
-- Cleaned the conflicting files, discarded stale tracked modifications via `git checkout -- .`, fast-forwarded from `a3818b9` to `c6d54b0`
-- `.claude/` preserved (not touched)
-- Root cause not diagnosed — grimnir-validate.timer is supposed to catch drift like this, but didn't surface it; possibly the timer isn't installed on the Pi yet (it was listed as an open next-step from the 2026-04-01 session)
+### Merged PR #20 — user-scoped systemd units in deploy.sh
+- `fix(deploy): support user-scoped systemd units` — squash-merged to `main` (`c5f5303`), branch `fix/deploy-user-units` deleted
+- Adds optional `systemd_units[].scope` (`"user"` for `hugin`/`verdandi`, `"system"` default); `registry.js` emits a 7th `unit_scope` field; `deploy.sh` syncs user units to `~/.config/systemd/user` and restarts via `systemctl --user` — no sudo, no destructive stop/disable
+- Fixes the live bug where `deploy.sh hugin` took Hugin offline mid-deploy (`5/NOTINSTALLED`)
+- Verified before merge: 7-field registry output correct (hugin/verdandi=user, rest=system), `bash -n` clean
+- NOTE: local working branch is `feat/tallriksvis-sandbox`; the merge landed remotely, so local `main` is behind until pulled
 
-### Prior session context (2026-04-09)
-- Ecosystem review plan committed at `docs/ecosystem-review-plan.md`, tracking issue grimnir#7, plan stress-tested via Codex debate
-- Debate corpus now tracked in git via upgraded gitignore
-- Debate-codex skill updated with new default git-handling pattern
+## Prior Session (2026-05-29)
+
+### Investigation: telemetry/measurement landscape
+- Mapped what's actually running vs. just designed across Grimnir:
+  - **Munin retrieval measurement**: real and active — `retrieval_events` + `retrieval_outcomes` + live `memory_retrieval_feedback` tool, benchmark harness with 30 reports
+  - **Grimnir-wide Execute→Trace→Score→Reflect loop**: design-only (`docs/observability-and-improvement.md`, 2026-04-02) — no trace writer, no `traces/<agent>` data, not built
+  - **Hugin task telemetry**: planned (Step 4 of obs doc), not built — Hugin is still on orchestration plumbing (#68 artefact delivery, #77 crash-recovery liveness bug)
+
+### munin-memory eval harness: closed #19, created #70
+- Audited #19 checklist: Phases 1 (static benchmark) and 2 (live monitoring) fully shipped — scorer, runner, snapshot script, curated query sets, `npm run benchmark`, report schema v2, `production_ranker` parity, LongMemEval/LoCoMo/BEIR adapters, retrieval_feedback table and tool, `memory_insights` health metrics
+- Closed #19 with summary comment
+- Created follow-up **munin-memory #70**: "Retrieval eval harness — Phase 3 + CI regression gate"
+  - P1: CI regression gate (wire benchmark into ci.yml with pass/fail threshold — highest value)
+  - P2: ground-truth pipeline (derive/curate/synthetic query scripts)
+  - P3: stretch (memory_retrieval_report tool, LLM-as-judge)
+- Added #70 to roadmap board, logged decision to Munin
+
+## Blockers
+- **grimnir PR #19** (tallriksvis sandbox): DRAFT, blocked on 4 Pi-side TODOs — confirm static vs backend, read live Caddyfile, confirm deploy path, notify wife of URL change. Cloudflare Access policy must be created before DNS flip.
+- **munin-memory synthesis entry**: still tagged `blocked` (paused at PR 4 hard checkpoint from quality-metrics loop) — separate from #19/#70, review when picking up munin-memory work.
+- **Hugin #77**: crash-recovery liveness bug (delivery crash + auto-restart doesn't auto-reconcile) — blocks declaring #68 e2e fully green.
 
 ## Next Steps
 
-0. **Verify grimnir-validate.timer is installed on the Pi** — if it's missing, drift can reach 29+ commits unseen. Check `systemctl list-timers | grep grimnir-validate` on huginmunin. If absent, `systemctl enable --now grimnir-validate.timer` via deploy.
-1. **Step 0 — Write cross-service contracts section in `docs/architecture.md`** (grimnir#7). This blocks everything else in the ecosystem review program. Named contracts, named owners per contract, regression matrix, evolution rules.
-2. **Phase A — Integration fixes** (2-3 sessions). MuninClient copy for Ratatoskr, CommonJS adapter for Heimdall, Skuld interface wrap, three contract tests, per-file contract ownership comments.
-3. **Phase B — Targeted `/security-review`** (3 sessions, concurrent with A). munin-memory first (sharded), ratatoskr next, hugin after Phase A #1 stabilizes. Draft `docs/threat-model.md` afterward.
-4. **Phase C — Minimum CI floor** (1 session, conditional). Only if Phase A tests aren't already catching drift.
-5. Review OpenClaw research spike results (`tasks/20260407-203751-openclaw-vs-grimnir`)
-6. **heimdall#7** — Boot health check
-7. **hugin#26** — Plan autonomous dependency bump workflow
-8. **grimnir#5** — Plan doc drift detection
-9. **Hugin security hardening** — issues #7–#13
-10. **UPS for both Pis** — grimnir#4
-
-## Blockers
-- None
+1. **munin-memory #70 P1** — Wire benchmark into CI (`.github/workflows/ci.yml`) with a committed baseline report and pass/fail threshold on R@5/nDCG@5
+2. **grimnir PR #19** — SSH to huginmunin, fill in the 4 TODOs, create CF Access policy, then un-draft and merge
+3. **Hugin #77** — fix crash-recovery liveness, re-run S3, then close #68 e2e
+4. **Hugin next** — enable broker (scripts/enable-broker.sh), register hugin-mcp, dogfood /delegate
+5. **Grimnir obs loop Step 1** — trace writer library (shared module) is unbuilt; nothing downstream of it works until it exists
+6. Verify grimnir-validate.timer installed on Pi (`systemctl list-timers | grep grimnir-validate`)
+7. grimnir#7 — Write cross-service contracts section in `docs/architecture.md`

--- a/pi-config/README.md
+++ b/pi-config/README.md
@@ -9,6 +9,9 @@ Version-controlled snapshot of host-level config files on `huginmunin` that aren
 | `cloudflared/config.yml` | `/etc/cloudflared/config.yml` | root |
 | `systemd/mimir-reading-sync.service` | `~magnus/.config/systemd/user/mimir-reading-sync.service` | magnus (user unit) |
 | `systemd/mimir-reading-sync.timer` | `~magnus/.config/systemd/user/mimir-reading-sync.timer` | magnus (user unit) |
+| `caddy/tallriksvis.Caddyfile` | merge into `/etc/caddy/Caddyfile` | root |
+| `systemd/tallriksvis.service` | `/etc/systemd/system/tallriksvis.service` | root (only if backend process; skip for static-only) |
+| `nftables/tallriksvis-egress.nft` | `/etc/nftables.d/tallriksvis-egress.nft` | root |
 
 The cloudflared tunnel credentials file (`/etc/cloudflared/<tunnel-uuid>.json`) is a secret and is NOT tracked here.
 
@@ -29,9 +32,73 @@ ssh magnus@huginmunin 'systemctl --user daemon-reload \
   && systemctl --user enable --now mimir-reading-sync.timer'
 ```
 
+### tallriksvis sandboxing (Issue #14, Option A)
+
+Goal: remove LAN-anonymous access to tallriksvis, route external access through
+Cloudflare Tunnel + Cloudflare Access, and confine the process if it's a backend.
+Apply in this order — each step is reversible on its own.
+
+**Pre-flight (read first):**
+
+1. SSH to `huginmunin`, read `/etc/caddy/Caddyfile`, identify the existing
+   tallriksvis stanza. Decide: static files (`root` + `file_server`) or backend
+   process (`reverse_proxy` to a port)?
+2. If backend: confirm the runtime user, deploy path, and command line. The
+   systemd unit assumes Node + `/opt/tallriksvis/server.js` — adjust as needed.
+3. Tell anyone else who uses tallriksvis (wife) that the URL changes from the
+   LAN IP to `tallriksvis.gille.ai`.
+
+**1. Cloudflare Tunnel ingress** (add `tallriksvis.gille.ai` to the existing
+tunnel — edit `pi-config/cloudflared/config.yml` to add the entry, then apply
+via the cloudflared block above). Also create a Cloudflare Access policy for
+the hostname before flipping DNS.
+
+**2. Caddy site** — merge `caddy/tallriksvis.Caddyfile` into the existing
+`/etc/caddy/Caddyfile` (do NOT overwrite). The block binds to `127.0.0.1:8080`
+so the only path in is via the tunnel.
+
+```bash
+ssh magnus@huginmunin 'sudo nano /etc/caddy/Caddyfile'   # merge by hand
+ssh magnus@huginmunin 'sudo caddy validate --config /etc/caddy/Caddyfile \
+  && sudo systemctl reload caddy'
+```
+
+**3. systemd unit** (only if tallriksvis is a backend process; skip for
+static-only deploys — Caddy is already the only process in that case):
+
+```bash
+ssh magnus@huginmunin 'sudo useradd --system --no-create-home \
+  --shell /usr/sbin/nologin tallriksvis || true'
+ssh magnus@huginmunin 'sudo chown -R tallriksvis:tallriksvis /opt/tallriksvis'
+scp pi-config/systemd/tallriksvis.service magnus@huginmunin:/tmp/
+ssh magnus@huginmunin 'sudo install -m 644 /tmp/tallriksvis.service \
+    /etc/systemd/system/tallriksvis.service \
+  && sudo systemctl daemon-reload \
+  && sudo systemctl enable --now tallriksvis.service'
+```
+
+**4. nftables egress** — restrict the `tallriksvis` user to tcp/443 + DNS.
+
+```bash
+scp pi-config/nftables/tallriksvis-egress.nft magnus@huginmunin:/tmp/
+ssh magnus@huginmunin 'sudo install -m 644 /tmp/tallriksvis-egress.nft \
+    /etc/nftables.d/tallriksvis-egress.nft'
+# Confirm /etc/nftables.conf includes /etc/nftables.d/*.nft, then:
+ssh magnus@huginmunin 'sudo nft -f /etc/nftables.d/tallriksvis-egress.nft \
+  && sudo nft list chain inet filter output_tallriksvis'
+```
+
+**Rollback:** any step can be reverted independently — remove the include /
+disable the unit / drop the chain — but check the others still make sense
+without it.
+
 ## Verify after change
 
 ```bash
 ssh magnus@huginmunin 'systemctl status cloudflared --no-pager | head'
 ssh magnus@huginmunin 'systemctl --user list-timers mimir-reading-sync.timer'
+ssh magnus@huginmunin 'systemctl status tallriksvis --no-pager | head'
+ssh magnus@huginmunin 'sudo nft list chain inet filter output_tallriksvis'
+ssh magnus@huginmunin 'curl -sv http://192.168.0.139:8080 || echo "good — LAN access blocked"'
+ssh magnus@huginmunin 'curl -sv http://127.0.0.1:8080 | head'
 ```

--- a/pi-config/caddy/tallriksvis.Caddyfile
+++ b/pi-config/caddy/tallriksvis.Caddyfile
@@ -1,0 +1,55 @@
+# Caddy site for tallriksvis — sandbox config (Issue #14, Option A).
+#
+# Goal: remove LAN-anonymous access. External access is via Cloudflare Tunnel
+# only, which routes tallriksvis.gille.ai → http://127.0.0.1:8080. Cloudflare
+# Access policy gates who can reach it.
+#
+# Pi path: /etc/caddy/Caddyfile  (merge this block; do not overwrite the file).
+#
+# BEFORE APPLYING:
+#   1. SSH to huginmunin, read current /etc/caddy/Caddyfile, identify the
+#      existing tallriksvis site stanza (currently serving on :80).
+#   2. Confirm whether tallriksvis is static files or a backend process.
+#      - Static: keep `root` + `file_server` below; set `root` to actual path.
+#      - Backend: replace `file_server` with `reverse_proxy 127.0.0.1:<port>`.
+#   3. Verify whoever else (wife) uses it knows the URL is changing
+#      (LAN IP → tallriksvis.gille.ai).
+
+:8080 {
+    bind 127.0.0.1
+
+    # TODO(verify on Pi): set to the actual deploy path of tallriksvis static
+    # files, or replace this block with `reverse_proxy 127.0.0.1:<port>` if
+    # tallriksvis runs its own backend.
+    root * /var/www/tallriksvis
+    file_server
+
+    encode zstd gzip
+
+    # Trust Cloudflare proxy headers — see
+    # https://www.cloudflare.com/ips-v4 / https://www.cloudflare.com/ips-v6
+    # for the up-to-date list. Locking this down means client IP / geo come
+    # from CF, not from the loopback.
+    @cf {
+        remote_ip 173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 \
+                  141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20 \
+                  197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13 \
+                  104.24.0.0/14 172.64.0.0/13 131.0.72.0/22
+    }
+    handle @cf {
+        # noop — passes through to file_server / reverse_proxy above
+    }
+    handle {
+        # Anything not from Cloudflare → 403. Defense-in-depth in case the
+        # bind to 127.0.0.1 ever leaks (misconfig, IPv6 fall-through, etc.).
+        respond "Forbidden" 403
+    }
+
+    log {
+        output file /var/log/caddy/tallriksvis.log {
+            roll_size 10mb
+            roll_keep 5
+        }
+        format json
+    }
+}

--- a/pi-config/nftables/tallriksvis-egress.nft
+++ b/pi-config/nftables/tallriksvis-egress.nft
@@ -1,0 +1,55 @@
+# Egress restriction for the tallriksvis service user (Issue #14, Option A).
+#
+# Pi path: /etc/nftables.d/tallriksvis-egress.nft
+# (or merged into /etc/nftables.conf — depends on existing layout)
+#
+# Apply:
+#   sudo nft -f /etc/nftables.d/tallriksvis-egress.nft
+#   sudo nft list chain inet filter output_tallriksvis
+#
+# Persist across reboot:
+#   Ensure /etc/nftables.conf includes this file (e.g. `include "/etc/nftables.d/*.nft"`).
+#
+# IMPORTANT — fundamental limitation:
+#   nftables filters by IP, not domain. We can't say "allow only api.anthropic.com"
+#   directly because Anthropic uses Cloudflare/AWS IP ranges that change.
+#
+#   Realistic restriction here is "allow tcp/443 only, deny everything else
+#   from the tallriksvis user" — blocks UDP exfil, weird protocols, raw sockets.
+#
+#   For true domain-allowlisting: run an outbound HTTPS proxy (Squid with
+#   ssl-bump, or `tinyproxy` with an upstream allowlist) and force tallriksvis
+#   through HTTPS_PROXY env var. Document that as a follow-up if needed.
+
+table inet filter {
+    chain output_tallriksvis {
+        # This chain is jumped to from the main output chain — see the jump
+        # rule below. Set type/hook/priority on the parent chain, not here.
+
+        # Loopback always
+        oifname "lo" accept
+
+        # Established / related
+        ct state established,related accept
+
+        # DNS — needed to resolve api.anthropic.com. Restrict to common
+        # resolvers; adjust if your local resolver IP differs.
+        meta skuid "tallriksvis" ip daddr { 1.1.1.1, 1.0.0.1, 8.8.8.8, 8.8.4.4 } udp dport 53 accept
+        meta skuid "tallriksvis" ip daddr { 1.1.1.1, 1.0.0.1, 8.8.8.8, 8.8.4.4 } tcp dport 53 accept
+
+        # HTTPS only
+        meta skuid "tallriksvis" tcp dport 443 accept
+
+        # Log + drop everything else from this user
+        meta skuid "tallriksvis" log prefix "tallriksvis-egress-drop: " drop
+    }
+
+    # Hook into the main output chain. If you already have a chain named
+    # "output" with type/hook/priority set, add the jump rule there instead.
+    chain output {
+        type filter hook output priority 0; policy accept;
+
+        # Send tallriksvis user traffic through the restricted chain
+        meta skuid "tallriksvis" jump output_tallriksvis
+    }
+}

--- a/pi-config/systemd/tallriksvis.service
+++ b/pi-config/systemd/tallriksvis.service
@@ -1,0 +1,79 @@
+# Hardened systemd unit for tallriksvis (Issue #14, Option A).
+#
+# Pi path: /etc/systemd/system/tallriksvis.service
+#
+# ONLY APPLY IF tallriksvis is a Node/backend process. If it's static files
+# served by Caddy, this unit is not needed — Caddy is the only process and
+# we don't want to lock down system-wide Caddy here (it serves other things).
+#
+# BEFORE APPLYING:
+#   1. Create a dedicated system user:
+#        sudo useradd --system --no-create-home --shell /usr/sbin/nologin tallriksvis
+#   2. Move the deploy directory ownership:
+#        sudo chown -R tallriksvis:tallriksvis /opt/tallriksvis
+#   3. Confirm `ExecStart` and `WorkingDirectory` match the actual layout.
+#   4. Confirm any required env vars (e.g. ANTHROPIC_API_KEY) are set in
+#      /etc/tallriksvis/env (mode 0640, owner root:tallriksvis).
+
+[Unit]
+Description=tallriksvis (sandboxed)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=tallriksvis
+Group=tallriksvis
+
+# Adjust to actual layout:
+WorkingDirectory=/opt/tallriksvis
+ExecStart=/usr/bin/node /opt/tallriksvis/server.js
+EnvironmentFile=-/etc/tallriksvis/env
+
+# Restart policy
+Restart=on-failure
+RestartSec=5s
+
+# ─── Sandboxing ─────────────────────────────────────────────────────────
+# Filesystem
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/log/tallriksvis
+ReadOnlyPaths=/opt/tallriksvis
+
+# Privileges
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictNamespaces=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+ProcSubset=pid
+
+# Capabilities — drop all (Node doesn't need any for HTTP on >1024)
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# Memory / CPU caps (adjust if app needs more)
+MemoryMax=256M
+TasksMax=64
+
+# System calls — allow common ones, deny obscure
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# Network — see nftables/tallriksvis-egress.nft for egress filtering
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+PrivateDevices=true
+DevicePolicy=closed
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #14 (once applied — leaving as DRAFT until verified on the Pi).

## Summary

Defends the deploy boundary for tallriksvis (third-party app, source not ours)
without modifying its code. Three layered controls + a documented apply
procedure in \`pi-config/README.md\`.

- **Caddy**: bind to \`127.0.0.1:8080\`, Cloudflare IP allowlist as
  defense-in-depth. External access only via the existing Cloudflare Tunnel
  (\`tallriksvis.gille.ai\`) gated by a Cloudflare Access policy.
- **systemd**: hardened unit (dedicated \`tallriksvis\` user,
  \`ProtectSystem=strict\`, capability drop, \`@system-service\` syscall filter,
  256M memory cap). Only needed if tallriksvis is a backend process — skip for
  static-only.
- **nftables**: \`output_tallriksvis\` chain restricts skuid \`tallriksvis\` to
  DNS + tcp/443; logs and drops everything else. Note: filters by IP, not
  domain — true domain-allowlisting would need an outbound HTTPS proxy.

The leaked Anthropic key (Codex F-01, rotated 2026-04-15) was the trigger; this
PR shrinks the blast radius if a future bundle leaks again.

## Why DRAFT

All three files have \`TODO\` markers that need Pi-side verification before
they're safe to apply:

1. Confirm tallriksvis is static vs backend — branches the systemd unit
   decision and the Caddy block (\`file_server\` vs \`reverse_proxy\`).
2. Confirm the current \`/etc/caddy/Caddyfile\` stanza so we can merge cleanly
   instead of overwriting (Caddy serves other things on this Pi).
3. Confirm the actual deploy path of tallriksvis (\`/var/www/tallriksvis\` is a
   placeholder).
4. Wife uses tallriksvis — she needs to know the URL is changing from the LAN
   IP to \`tallriksvis.gille.ai\` before we flip it.

Cloudflare Tunnel ingress for \`tallriksvis.gille.ai\` is **not** added to
\`pi-config/cloudflared/config.yml\` in this PR — needs a Cloudflare Access
policy created first; will follow up as a separate change.

## Test plan

- [ ] SSH to huginmunin, read current \`/etc/caddy/Caddyfile\`, fill in actual
      deploy path and static-vs-backend decision in this PR
- [ ] Decide & note the \`Service:\` for the new \`tallriksvis.gille.ai\`
      tunnel ingress (likely \`http://localhost:8080\`)
- [ ] Create Cloudflare Access policy for \`tallriksvis.gille.ai\` in CF
      dashboard before flipping DNS
- [ ] Apply Caddy change, \`caddy validate\`, reload, confirm
      \`curl http://192.168.0.139:8080\` returns no longer reachable
      from LAN
- [ ] If backend: create \`tallriksvis\` user + chown, install unit, confirm
      \`systemctl status tallriksvis\` healthy
- [ ] Apply nftables, confirm \`nft list chain inet filter output_tallriksvis\`
      shows the rules; tail \`journalctl -k -f | grep tallriksvis-egress-drop\`
      to see what's actually being blocked
- [ ] Smoke-test tallriksvis end-to-end via the new tunnel hostname
- [ ] Tell wife the URL changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)