### PR TITLE
fix(deploy): support user-scoped systemd units

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,7 @@ GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
 REGISTRY="$GRIMNIR_DIR/services.json"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 
-# Read deployable services from registry: name|repo|host|deploy_path|unit_type|needs_build
+# Read deployable services from registry: name|repo|host|deploy_path|unit_type|needs_build|unit_scope
 SERVICES=()
 while IFS= read -r line; do
   [[ -n "$line" ]] && SERVICES+=("$line")
@@ -95,7 +95,7 @@ resolve_local_path() {
 }
 
 deploy_service() {
-  local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6
+  local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system}
   local local_path
   local remote_host
   local remote
@@ -173,8 +173,19 @@ deploy_service() {
   fi
 
   local cmd="cd '$deploy_path' && "
-  if [[ "$unit_type" == "service" ]]; then
-    # Sync unit file from repo's systemd/ subdir if present (no placeholders expected there)
+  if [[ "$unit_type" == "service" && "$unit_scope" == "user" ]]; then
+    # User unit (systemctl --user). Sync unit file from repo's systemd/
+    # subdir if present, then restart via the *user* manager. No sudo, and
+    # critically no stop/disable of the user instance — for a user-scoped
+    # service that instance IS the service, not a stray leftover.
+    cmd+="if [ -f systemd/${name}.service ]; then"
+    cmd+=" install -D -m644 systemd/${name}.service \"\$HOME/.config/systemd/user/${name}.service\""
+    cmd+=" && systemctl --user daemon-reload"
+    cmd+=" && echo '  user unit file synced'; fi && "
+    cmd+="systemctl --user restart ${name} && "
+  elif [[ "$unit_type" == "service" ]]; then
+    # System unit. Sync unit file from repo's systemd/ subdir if present
+    # (no placeholders expected there).
     cmd+="if [ -f systemd/${name}.service ]; then"
     cmd+=" sudo cp systemd/${name}.service /etc/systemd/system/${name}.service"
     cmd+=" && sudo systemctl daemon-reload"
@@ -210,7 +221,7 @@ deploy_service() {
 requested=("$@")
 
 for entry in "${SERVICES[@]}"; do
-  IFS='|' read -r name repo host deploy_path unit_type needs_build <<< "$entry"
+  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope <<< "$entry"
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false
@@ -220,7 +231,7 @@ for entry in "${SERVICES[@]}"; do
     $match || continue
   fi
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build"
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}"
 done
 
 # Summary

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -47,18 +47,23 @@ var components = data.components;
 switch (query) {
   case 'deploy': {
     // Output format matches what deploy.sh needs:
-    // name|repo|host|deploy_path|primary_unit_type|needs_build
+    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope
     var deployable = components.filter(function (c) { return c.deploy; });
     deployable.forEach(function (c) {
-      // Determine primary unit type from first systemd unit, default to "service"
+      // Determine primary unit type/scope from first systemd unit.
+      // type defaults to "service"; scope defaults to "system" (system
+      // manager). Units running under `systemctl --user` must set
+      // scope:"user" so deploy.sh restarts them correctly.
       var unitType = 'service';
+      var unitScope = 'system';
       if (c.systemd_units && c.systemd_units.length > 0) {
         unitType = c.systemd_units[0].type;
+        unitScope = c.systemd_units[0].scope || 'system';
       }
       var deployPath = c.deploy_path || ('/home/magnus/repos/' + c.repo);
       var needsBuild = c.needs_build ? 'true' : 'false';
       process.stdout.write(
-        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '\n'
+        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '\n'
       );
     });
     break;

--- a/services.json
+++ b/services.json
@@ -23,7 +23,7 @@
       "deploy_path": "/home/magnus/repos/hugin",
       "needs_build": true,
       "systemd_units": [
-        { "name": "hugin", "type": "service" }
+        { "name": "hugin", "type": "service", "scope": "user" }
       ]
     },
     {
@@ -114,7 +114,7 @@
       "deploy_path": "/home/magnus/repos/verdandi",
       "needs_build": true,
       "systemd_units": [
-        { "name": "verdandi", "type": "service" }
+        { "name": "verdandi", "type": "service", "scope": "user" }
       ]
     }
   ]


### PR DESCRIPTION
## Problem

`deploy.sh` assumed every service is a **system** unit. For each service it would `systemctl --user stop/disable <name>` then `sudo systemctl restart <name>`. For user-scoped services (`hugin`, `verdandi`) this is destructive: the `--user` instance *is* the service, and there is no system unit to restart — so the deploy took the service **offline** and failed with `status 5/NOTINSTALLED`.

This was hit live: a routine `deploy.sh hugin` took Hugin down mid-deploy.

## Fix

- **services.json**: optional `systemd_units[].scope` (`"system"` default, `"user"` for `hugin` and `verdandi`)
- **registry.js**: emit `unit_scope` as a 7th field in the `deploy` query (only consumer is deploy.sh)
- **deploy.sh**: for `scope=user` — sync the unit into `~/.config/systemd/user`, `systemctl --user daemon-reload`, `systemctl --user restart` — **no sudo, no stop/disable** of the legitimate user instance. System-unit path unchanged.

## Verification

- `bash -n` clean; registry `deploy` query emits correct 7-field lines (hugin/verdandi=`user`, rest=`system`)
- Redeployed `hugin` end-to-end with the fix: user unit restarted, **zero downtime**, health OK
- System-unit services (munin-memory, heimdall, ratatoskr, mimir) keep existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)