### PR TITLE
feat: stamp deployed commit into deploy_path for drift detection

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -117,6 +117,7 @@ deploy_service() {
 
   branch=$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   commit=$(git -C "$local_path" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  commit_full=$(git -C "$local_path" rev-parse HEAD 2>/dev/null || echo "$commit")
   if [[ -n "$(git -C "$local_path" status --porcelain 2>/dev/null)" ]]; then
     dirty_state="dirty"
     echo -e "${YELLOW}WARN${NC} Deploying local working tree with uncommitted changes"
@@ -157,6 +158,7 @@ deploy_service() {
     --exclude='.env' \
     --exclude='tests/' \
     --exclude='.DS_Store' \
+    --exclude='.deployed-commit' \
     "$local_path/" "$remote:$deploy_path/"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
@@ -195,6 +197,11 @@ deploy_service() {
     cmd+="systemctl --user disable ${name} 2>/dev/null || true && "
     cmd+="sudo systemctl restart ${name} && "
   fi
+  # Stamp the deployed commit so Heimdall's drift detector has an authoritative
+  # source (excluded from rsync above so --delete won't clobber it). Heimdall
+  # reads <deploy_path>/.deployed-commit instead of trusting /health (often no
+  # commit) or the on-Pi .git (stale — rsync excludes it).
+  cmd+="printf '%s\\n' '${commit_full}' > .deployed-commit && "
   cmd+="echo 'DEPLOY_OK'"
 
   local output


### PR DESCRIPTION
## Why
Heimdall's drift detector has no reliable way to know what commit is actually deployed: service \`/health\` endpoints mostly omit a commit, and the on-Pi git checkouts are stale because these deploys rsync working files but exclude \`.git/\`. Result: permanent false "Deploy drift" warnings for munin-memory, hugin, and mimir regardless of real state.

## Change
On every successful deploy, write the source commit (full SHA) to \`<deploy_path>/.deployed-commit\`, and add it to the rsync \`--exclude\` list so \`--delete\` won't clobber it. Heimdall reads this stamp as the authoritative deployed commit (paired PR: Magnus-Gille/heimdall \`fix/drift-deployed-commit-stamp\`).

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)