### PR TITLE
feat: automated software updates across both Pis and the laptop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 *.log
 docs/snapshot.md
 docs/full-architecture.md
+.playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy
+.PHONY: docs clean security security-dry deploy patching maintenance-os maintenance-deps
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -11,6 +11,15 @@ security-dry: ## Run security scan (dry run, no Munin writes)
 
 deploy: ## Deploy all services to Pi (or: make deploy ARGS="munin-memory hugin")
 	@./scripts/deploy.sh $(ARGS)
+
+patching: ## Install/refresh unattended-upgrades on all Pi hosts (ARGS="--dry-run" or a host)
+	@./scripts/setup-host-patching.sh $(ARGS)
+
+maintenance-os: ## Run the OS maintenance report on the Pi now (ARGS="--dry-run --verbose")
+	@ssh magnus@huginmunin.local 'cd /home/magnus/repos/grimnir && bash scripts/maintenance-report.sh os $(ARGS)'
+
+maintenance-deps: ## Run the npm dependency report on the Pi now (ARGS="--dry-run --verbose")
+	@ssh magnus@huginmunin.local 'cd /home/magnus/repos/grimnir && bash scripts/maintenance-report.sh deps $(ARGS)'
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -54,6 +54,8 @@ Repos are named after the component, lowercase. The GitHub org matches the opera
 | `skuld.timer` | Daily 06:00 | Morning intelligence briefing |
 | `grimnir-security-scan.timer` | Weekly Sun 03:00 | Dependency audit + secret scan across all repos |
 | `grimnir-validate.timer` | Daily 04:30 | Registry vs live state validation, results to Munin |
+| `grimnir-maintenance-os.timer` | Daily 07:00 | OS patch status (pending security, reboot-required, disk) across all Pis → Munin + Telegram |
+| `grimnir-maintenance-deps.timer` | Weekly Mon 02:10 | npm outdated across service repos → Munin (detect+report only) |
 
 ## Service patterns
 

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -1,7 +1,7 @@
 # Scheduled Tasks Registry
 
 > All automated tasks running on Grimnir infrastructure.
-> Last updated: 2026-03-30.
+> Last updated: 2026-06-15.
 
 ---
 
@@ -71,6 +71,30 @@ All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where no
 | **Output** | Munin: `security/scans/{date}`, per-repo results in `security/repos/*` |
 | **Why it exists** | Automated dependency vulnerability and secret leak detection |
 
+### OS Maintenance Report
+
+| Field | Value |
+|-------|-------|
+| **Schedule** | Daily 07:00 local (+5 min jitter) |
+| **Unit** | `grimnir-maintenance-os.timer` / `grimnir-maintenance-os.service` |
+| **Repo** | `grimnir` |
+| **Script** | `scripts/maintenance-report.sh os` |
+| **Purpose** | Report pending security updates, reboot-required, and disk usage for every Pi host (local + SSH to nas) |
+| **Output** | Munin: `maintenance/os/{host}` and `maintenance/os/{date}`; Telegram alert on action-needed (reboot pending, security updates outstanding, disk tight, patcher missing) |
+| **Why it exists** | Surfaces the half of OS patching that unattended-upgrades cannot do itself — visibility + reboot prompting |
+
+### npm Dependency Report
+
+| Field | Value |
+|-------|-------|
+| **Schedule** | Weekly, Monday 02:10 local (+10 min jitter) |
+| **Unit** | `grimnir-maintenance-deps.timer` / `grimnir-maintenance-deps.service` |
+| **Repo** | `grimnir` |
+| **Script** | `scripts/maintenance-report.sh deps` |
+| **Purpose** | Run `npm outdated` across every service repo under ~/repos and count outdated/major deps |
+| **Output** | Munin: `maintenance/deps/{repo}` and `maintenance/deps/{date}`; weekly Telegram summary when anything is outdated |
+| **Why it exists** | Detect+report only — surfaces stale service dependencies for deliberate, human-approved upgrades (auto-ops debate verdict: never blind auto-bump) |
+
 ### Claude CLI Update
 
 | Field | Value |
@@ -83,10 +107,20 @@ All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where no
 
 ---
 
+## OS auto-patching (unattended-upgrades)
+
+Both Pi hosts run `unattended-upgrades`, installed and configured by `scripts/setup-host-patching.sh` (`make patching`) from version-controlled config in `host-config/apt/`:
+- `20auto-upgrades` — enables the stock `apt-daily`/`apt-daily-upgrade` timers to refresh lists and run unattended-upgrades.
+- `50unattended-upgrades` — **security archive only** (`origin=Debian,...-security,label=Debian-Security`), **no automatic reboot**.
+
+Regular Debian and Raspberry Pi Foundation packages (including kernel/firmware) are deliberately NOT auto-upgraded — those surface via the daily OS Maintenance Report for deliberate, human-approved updates. Reboot-required is detected and pushed to Telegram by `grimnir-maintenance-os`; reboots are done by hand. Re-run `make patching` after changing the apt config; `make patching ARGS="--dry-run"` to preview.
+
+---
+
 ## Adding a new scheduled task
 
 1. Create the script in the relevant repo's `scripts/` directory.
 2. Create `systemd/{name}.service` (Type=oneshot) and `systemd/{name}.timer` in the same repo.
 3. Add the timer to Heimdall's `heimdall.config.json` as a `"type": "timer"` service entry.
 4. Update this document.
-5. Deploy: copy units to `/etc/systemd/system/`, `daemon-reload`, `enable --now`.
+5. Deploy: `make deploy ARGS="grimnir"` — `scripts/deploy.sh` now has a timer-install branch that copies units from `systemd/` to `/etc/systemd/system/`, runs `daemon-reload`, and `enable --now`s all timers automatically. No manual systemctl step needed for grimnir-repo timers.

--- a/host-config/apt/20auto-upgrades
+++ b/host-config/apt/20auto-upgrades
@@ -1,0 +1,7 @@
+// Grimnir-managed — installed by scripts/setup-host-patching.sh
+// Enables the stock apt-daily / apt-daily-upgrade timers to actually
+// refresh package lists and run unattended-upgrades.
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "7";

--- a/host-config/apt/50unattended-upgrades
+++ b/host-config/apt/50unattended-upgrades
@@ -1,0 +1,41 @@
+// Grimnir-managed unattended-upgrades policy — installed by
+// scripts/setup-host-patching.sh onto every Pi host in services.json.
+//
+// Policy decisions (see docs/scheduled-tasks.md "OS auto-patching"):
+//   * SECURITY ONLY. Only the Debian-Security archive is auto-applied.
+//     Regular Debian and Raspberry Pi Foundation packages (incl. kernel /
+//     firmware) are deliberately NOT auto-upgraded — those land via the
+//     weekly maintenance report for deliberate, human-approved updates
+//     (the "deliberate-over-automatic" principle from the auto-ops debate).
+//   * NO automatic reboot. A kernel/libc patch that needs a reboot is
+//     surfaced by grimnir-maintenance-os (reboot-required → Munin + Telegram);
+//     Magnus reboots when convenient.
+
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
+};
+
+// No packages held back.
+Unattended-Upgrade::Package-Blacklist {
+};
+
+// Repair a dpkg state interrupted by a crash/power loss on the next run.
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+
+// Upgrade in minimal increments so a power loss leaves a consistent system.
+Unattended-Upgrade::MinimalSteps "true";
+
+// Keep the boot partition tidy — superseded kernels are auto-removed.
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "false";
+
+// Do not reboot automatically — surfaced + done by hand instead.
+Unattended-Upgrade::Automatic-Reboot "false";
+Unattended-Upgrade::Automatic-Reboot-WithUsers "false";
+
+// No MTA on these hosts; rely on Grimnir's Munin/Telegram reporting instead.
+Unattended-Upgrade::Mail "";
+
+// Log to syslog so journalctl / the maintenance report can read outcomes.
+Unattended-Upgrade::SyslogEnable "true";

--- a/host-config/apt/50unattended-upgrades
+++ b/host-config/apt/50unattended-upgrades
@@ -4,9 +4,9 @@
 // Policy decisions (see docs/scheduled-tasks.md "OS auto-patching"):
 //   * SECURITY ONLY. Only the Debian-Security archive is auto-applied.
 //     Regular Debian and Raspberry Pi Foundation packages (incl. kernel /
-//     firmware) are deliberately NOT auto-upgraded — those land via the
-//     weekly maintenance report for deliberate, human-approved updates
-//     (the "deliberate-over-automatic" principle from the auto-ops debate).
+//     firmware) are deliberately NOT auto-upgraded — those surface via the
+//     daily OS maintenance report (grimnir-maintenance-os) for deliberate,
+//     human-approved updates (the "deliberate-over-automatic" principle).
 //   * NO automatic reboot. A kernel/libc patch that needs a reboot is
 //     surfaced by grimnir-maintenance-os (reboot-required → Munin + Telegram);
 //     Magnus reboots when convenient.

--- a/host-config/laptop/com.magnusgille.brew-update.plist
+++ b/host-config/laptop/com.magnusgille.brew-update.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.magnusgille.brew-update</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/magnus/.local/bin/grimnir-brew-update.sh</string>
+    </array>
+
+    <!-- Weekly: Sunday 11:00 local. launchd runs a missed calendar job on next wake. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>11</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/magnus/.local/share/grimnir-maintenance/logs/brew-update.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/magnus/.local/share/grimnir-maintenance/logs/brew-update.log</string>
+</dict>
+</plist>

--- a/host-config/laptop/grimnir-brew-update.sh
+++ b/host-config/laptop/grimnir-brew-update.sh
@@ -26,19 +26,22 @@ echo "=== grimnir-brew-update $ts ==="
 
 [[ -x "$BREW" ]] || { echo "brew not found at $BREW"; exit 1; }
 
-"$BREW" update >/dev/null 2>&1 || echo "warn: brew update failed"
+# Track failures so a broken update/upgrade is surfaced (not logged as healthy).
+fail=0
+"$BREW" update >/dev/null 2>&1 || { echo "warn: brew update failed"; fail=1; }
 
 # Formulae — auto-upgrade.
 n_formulae="$("$BREW" outdated --formula --quiet 2>/dev/null | grep -c . || true)"
 echo "upgrading $n_formulae outdated formula(e)…"
-"$BREW" upgrade --formula 2>&1 | tail -8
+if ! "$BREW" upgrade --formula 2>&1 | tail -8; then echo "warn: brew upgrade --formula had failures"; fail=1; fi
 "$BREW" cleanup -s >/dev/null 2>&1 || true
 
 # Casks — report only.
 casks="$("$BREW" outdated --cask --quiet 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')"
 n_casks="$(printf '%s' "$casks" | wc -w | tr -d ' ')"
 
-summary="brew (laptop) @ $ts: upgraded ${n_formulae} formula(e); ${n_casks} cask(s) need manual upgrade${casks:+: $casks}"
+fail_note=""; [ "$fail" -eq 1 ] && fail_note=" [UPGRADE ERRORS — see log]"
+summary="brew (laptop) @ $ts: upgraded ${n_formulae} formula(e); ${n_casks} cask(s) need manual upgrade${casks:+: $casks}${fail_note}"
 echo "$summary"
 
 # ── Report to Munin + Telegram via a SINGLE heredoc-free SSH command into
@@ -49,7 +52,7 @@ b64="$(printf '%s' "$summary" | base64 | tr -d '\n')"
 reported=""
 for hop in $HOPS; do
   if ssh -o ConnectTimeout=10 -o BatchMode=yes "$hop" \
-       "BREW_SUMMARY_B64='$b64' BREW_NCASKS='$n_casks' bash /home/magnus/repos/grimnir/scripts/maintenance-report.sh brew"; then
+       "BREW_SUMMARY_B64='$b64' BREW_NCASKS='$n_casks' BREW_ALERT='$fail' bash /home/magnus/repos/grimnir/scripts/maintenance-report.sh brew"; then
     reported="$hop"; break
   fi
   echo "  report hop to $hop failed; trying next…"

--- a/host-config/laptop/grimnir-brew-update.sh
+++ b/host-config/laptop/grimnir-brew-update.sh
@@ -30,14 +30,21 @@ echo "=== grimnir-brew-update $ts ==="
 fail=0
 "$BREW" update >/dev/null 2>&1 || { echo "warn: brew update failed"; fail=1; }
 
-# Formulae — auto-upgrade.
-n_formulae="$("$BREW" outdated --formula --quiet 2>/dev/null | grep -c . || true)"
+# Formulae — auto-upgrade. Capture the outdated query separately so a failed
+# query (vs. genuinely nothing outdated) is flagged, not silently read as 0.
+if ! formula_list="$("$BREW" outdated --formula --quiet 2>/dev/null)"; then
+  echo "warn: brew outdated --formula query failed"; fail=1; formula_list=""
+fi
+n_formulae="$(printf '%s' "$formula_list" | grep -c . || true)"
 echo "upgrading $n_formulae outdated formula(e)…"
 if ! "$BREW" upgrade --formula 2>&1 | tail -8; then echo "warn: brew upgrade --formula had failures"; fail=1; fi
 "$BREW" cleanup -s >/dev/null 2>&1 || true
 
 # Casks — report only.
-casks="$("$BREW" outdated --cask --quiet 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')"
+if ! casks_raw="$("$BREW" outdated --cask --quiet 2>/dev/null)"; then
+  echo "warn: brew outdated --cask query failed"; fail=1; casks_raw=""
+fi
+casks="$(printf '%s' "$casks_raw" | tr '\n' ' ' | sed 's/ *$//')"
 n_casks="$(printf '%s' "$casks" | wc -w | tr -d ' ')"
 
 fail_note=""; [ "$fail" -eq 1 ] && fail_note=" [UPGRADE ERRORS — see log]"

--- a/host-config/laptop/grimnir-brew-update.sh
+++ b/host-config/laptop/grimnir-brew-update.sh
@@ -14,7 +14,10 @@ set -uo pipefail
 # launchd runs with a minimal environment — set PATH explicitly.
 export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
 BREW="/opt/homebrew/bin/brew"
-HOP="magnus@huginmunin.local"
+# Reporting hop targets, tried in order. .local (mDNS) is flaky under launchd
+# ("No route to host"), so fall back to the bare name over Tailscale MagicDNS —
+# same strategy as deploy.sh's resolve_host.
+HOPS="magnus@huginmunin.local magnus@huginmunin"
 LOGDIR="$HOME/.local/share/grimnir-maintenance/logs"
 mkdir -p "$LOGDIR"
 
@@ -38,18 +41,20 @@ n_casks="$(printf '%s' "$casks" | wc -w | tr -d ' ')"
 summary="brew (laptop) @ $ts: upgraded ${n_formulae} formula(e); ${n_casks} cask(s) need manual upgrade${casks:+: $casks}"
 echo "$summary"
 
-# ── Report to Munin + Telegram via SSH-hop into huginmunin (best-effort) ──
-# base64 the message to sidestep all remote-shell quoting issues.
-b64="$(printf '%s' "$summary" | base64)"
-ssh -o ConnectTimeout=8 -o BatchMode=yes "$HOP" "N_CASKS=${n_casks} bash -s" <<REMOTE 2>/dev/null || echo "warn: report hop failed (offline?)"
-set -u
-MSG="\$(printf '%s' '$b64' | base64 -d)"
-source /home/magnus/repos/grimnir/scripts/lib/munin.sh
-source /home/magnus/repos/grimnir/scripts/lib/notify.sh
-munin_discover_token /home/magnus/repos || true
-ARGS="\$(NS='maintenance/brew/laptop' K='latest' C="\$MSG" T='["maintenance","brew","laptop","automated"]' node --input-type=commonjs -e 'console.log(JSON.stringify({namespace:process.env.NS,key:process.env.K,content:process.env.C,tags:JSON.parse(process.env.T)}))')"
-munin_tool_call memory_write "\$ARGS" >/dev/null 2>&1 || true
-if [ "\${N_CASKS:-0}" -gt 0 ]; then notify_telegram "🍺 \$MSG"; fi
-REMOTE
+# ── Report to Munin + Telegram via a SINGLE heredoc-free SSH command into
+# huginmunin, which runs the deployed reporter's `brew` mode. A single ssh
+# command (no heredoc on stdin) is robust under launchd; base64 sidesteps all
+# remote-shell quoting. Best-effort: stderr captured to the log, never fatal.
+b64="$(printf '%s' "$summary" | base64 | tr -d '\n')"
+reported=""
+for hop in $HOPS; do
+  if ssh -o ConnectTimeout=10 -o BatchMode=yes "$hop" \
+       "BREW_SUMMARY_B64='$b64' BREW_NCASKS='$n_casks' bash /home/magnus/repos/grimnir/scripts/maintenance-report.sh brew"; then
+    reported="$hop"; break
+  fi
+  echo "  report hop to $hop failed; trying next…"
+done
+[[ -n "$reported" ]] && echo "reported to Munin/Telegram via $reported" \
+  || echo "warn: report hop failed on all targets — formulae were still upgraded"
 
 echo "done."

--- a/host-config/laptop/grimnir-brew-update.sh
+++ b/host-config/laptop/grimnir-brew-update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# grimnir-brew-update.sh — weekly Homebrew maintenance on Magnus's laptop.
+#
+# Auto-upgrades FORMULAE (CLI tools). Casks (GUI apps) are NOT auto-upgraded —
+# they are reported for deliberate manual upgrade, so apps never restart/change
+# under you unexpectedly. Status → Munin, action-needed (casks/failure) →
+# Telegram, both via an SSH-hop into huginmunin (no secrets stored on the laptop).
+#
+# Installed to ~/.local/bin and driven by the com.magnusgille.brew-update
+# LaunchAgent (weekly). Run by hand any time: ~/.local/bin/grimnir-brew-update.sh
+set -uo pipefail
+
+# launchd runs with a minimal environment — set PATH explicitly.
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
+BREW="/opt/homebrew/bin/brew"
+HOP="magnus@huginmunin.local"
+LOGDIR="$HOME/.local/share/grimnir-maintenance/logs"
+mkdir -p "$LOGDIR"
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=== grimnir-brew-update $ts ==="
+
+[[ -x "$BREW" ]] || { echo "brew not found at $BREW"; exit 1; }
+
+"$BREW" update >/dev/null 2>&1 || echo "warn: brew update failed"
+
+# Formulae — auto-upgrade.
+n_formulae="$("$BREW" outdated --formula --quiet 2>/dev/null | grep -c . || true)"
+echo "upgrading $n_formulae outdated formula(e)…"
+"$BREW" upgrade --formula 2>&1 | tail -8
+"$BREW" cleanup -s >/dev/null 2>&1 || true
+
+# Casks — report only.
+casks="$("$BREW" outdated --cask --quiet 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')"
+n_casks="$(printf '%s' "$casks" | wc -w | tr -d ' ')"
+
+summary="brew (laptop) @ $ts: upgraded ${n_formulae} formula(e); ${n_casks} cask(s) need manual upgrade${casks:+: $casks}"
+echo "$summary"
+
+# ── Report to Munin + Telegram via SSH-hop into huginmunin (best-effort) ──
+# base64 the message to sidestep all remote-shell quoting issues.
+b64="$(printf '%s' "$summary" | base64)"
+ssh -o ConnectTimeout=8 -o BatchMode=yes "$HOP" "N_CASKS=${n_casks} bash -s" <<REMOTE 2>/dev/null || echo "warn: report hop failed (offline?)"
+set -u
+MSG="\$(printf '%s' '$b64' | base64 -d)"
+source /home/magnus/repos/grimnir/scripts/lib/munin.sh
+source /home/magnus/repos/grimnir/scripts/lib/notify.sh
+munin_discover_token /home/magnus/repos || true
+ARGS="\$(NS='maintenance/brew/laptop' K='latest' C="\$MSG" T='["maintenance","brew","laptop","automated"]' node --input-type=commonjs -e 'console.log(JSON.stringify({namespace:process.env.NS,key:process.env.K,content:process.env.C,tags:JSON.parse(process.env.T)}))')"
+munin_tool_call memory_write "\$ARGS" >/dev/null 2>&1 || true
+if [ "\${N_CASKS:-0}" -gt 0 ]; then notify_telegram "🍺 \$MSG"; fi
+REMOTE
+
+echo "done."

--- a/host-config/laptop/install.sh
+++ b/host-config/laptop/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# install.sh — install the laptop-local Grimnir Homebrew maintenance job.
+# Idempotent. Run on Magnus's macOS laptop:  host-config/laptop/install.sh
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN_DIR="$HOME/.local/bin"
+AGENT_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/.local/share/grimnir-maintenance/logs"
+PLIST="com.magnusgille.brew-update.plist"
+LABEL="com.magnusgille.brew-update"
+
+mkdir -p "$BIN_DIR" "$AGENT_DIR" "$LOG_DIR"
+
+install -m755 "$SRC_DIR/grimnir-brew-update.sh" "$BIN_DIR/grimnir-brew-update.sh"
+install -m644 "$SRC_DIR/$PLIST" "$AGENT_DIR/$PLIST"
+
+# Reload the LaunchAgent.
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$AGENT_DIR/$PLIST"
+launchctl enable "gui/$(id -u)/$LABEL"
+
+echo "Installed $LABEL (weekly Sunday 11:00)."
+echo "Run now with: launchctl kickstart -k gui/$(id -u)/$LABEL"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -196,6 +196,17 @@ deploy_service() {
     cmd+="systemctl --user stop ${name} 2>/dev/null || true && "
     cmd+="systemctl --user disable ${name} 2>/dev/null || true && "
     cmd+="sudo systemctl restart ${name} && "
+  elif [[ "$unit_type" == "timer" ]]; then
+    # Timer component (e.g. grimnir, skuld). These have no long-running service
+    # to restart; instead install ALL oneshot services + timers from systemd/,
+    # daemon-reload, and enable --now every timer. Idempotent — safe per deploy.
+    # (Previously timers were installed entirely by hand; this closes that gap.)
+    # `|| continue` keeps a non-matching glob (left literal when nullglob is
+    # unset) from leaking a failed `[ -f ]` status into the && chain.
+    cmd+="for u in systemd/*.service systemd/*.timer; do [ -f \"\$u\" ] || continue; sudo cp \"\$u\" /etc/systemd/system/; done && "
+    cmd+="sudo systemctl daemon-reload && "
+    cmd+="for t in systemd/*.timer; do [ -f \"\$t\" ] || continue; sudo systemctl enable --now \"\$(basename \"\$t\")\"; done && "
+    cmd+="echo '  timers synced & enabled' && "
   fi
   # Stamp the deployed commit so Heimdall's drift detector has an authoritative
   # source (excluded from rsync above so --delete won't clobber it). Heimdall

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -203,9 +203,9 @@ deploy_service() {
     # (Previously timers were installed entirely by hand; this closes that gap.)
     # `|| continue` keeps a non-matching glob (left literal when nullglob is
     # unset) from leaking a failed `[ -f ]` status into the && chain.
-    cmd+="for u in systemd/*.service systemd/*.timer; do [ -f \"\$u\" ] || continue; sudo cp \"\$u\" /etc/systemd/system/; done && "
+    cmd+="for u in systemd/*.service systemd/*.timer; do [ -f \"\$u\" ] || continue; sudo cp \"\$u\" /etc/systemd/system/ || exit 1; done && "
     cmd+="sudo systemctl daemon-reload && "
-    cmd+="for t in systemd/*.timer; do [ -f \"\$t\" ] || continue; sudo systemctl enable --now \"\$(basename \"\$t\")\"; done && "
+    cmd+="for t in systemd/*.timer; do [ -f \"\$t\" ] || continue; sudo systemctl enable --now \"\$(basename \"\$t\")\" || exit 1; done && "
     cmd+="echo '  timers synced & enabled' && "
   fi
   # Stamp the deployed commit so Heimdall's drift detector has an authoritative

--- a/scripts/lib/munin.sh
+++ b/scripts/lib/munin.sh
@@ -1,0 +1,65 @@
+# shellcheck shell=bash
+# ─── Grimnir shared Munin helpers ────────────────────────────────────────────
+#
+# Sourceable library factoring the Munin JSON-RPC plumbing that was previously
+# copy-pasted across security-scan.sh and generate-architecture.sh (flagged in
+# debate/auto-ops-codex-critique.md as "duplication with nicer intent"). New
+# on-Pi maintenance scripts source THIS instead of adding a divergent 4th copy.
+#
+# Usage:
+#   source "$(dirname "$0")/lib/munin.sh"
+#   munin_discover_token              # sets MUNIN_TOKEN from a service .env
+#   munin_tool_call memory_write "$json_args"
+#
+# Honours a pre-set $MUNIN_TOKEN (e.g. from --munin-token) and a $MUNIN_URL
+# override (defaults to the local MCP endpoint). Never echoes the token value.
+# Compatible with bash 3.2+ (macOS default).
+
+MUNIN_URL="${MUNIN_URL:-http://localhost:3030/mcp}"
+
+# ─── Find the Munin bearer token from a service .env ─────────────────────────
+# Mirrors security-scan.sh: walk the usual repos' .env files for MUNIN_API_KEY.
+munin_discover_token() {
+  local repos_dir="${1:-${REPOS_DIR:-$HOME/repos}}"
+  [[ -n "${MUNIN_TOKEN:-}" ]] && return 0
+  local envfile val
+  for envfile in "$repos_dir/hugin/.env" "$repos_dir/ratatoskr/.env" "$repos_dir/heimdall/.env"; do
+    if [[ -f "$envfile" ]]; then
+      val="$(grep -E '^MUNIN_API_KEY=' "$envfile" 2>/dev/null | head -1 | cut -d= -f2-)"
+      if [[ -n "$val" ]]; then
+        MUNIN_TOKEN="$val"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# ─── Low-level: POST a raw JSON-RPC payload, return the first SSE data line ───
+munin_call() {
+  local payload="$1"
+  if [[ -z "${MUNIN_TOKEN:-}" ]]; then
+    echo "(Munin token not available)"
+    return 1
+  fi
+  curl -s --max-time 10 \
+    -X POST "$MUNIN_URL" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $MUNIN_TOKEN" \
+    -d "$payload" 2>/dev/null | \
+    sed -n 's/^data: //p' | head -1 || echo "{}"
+}
+
+# ─── High-level: call a Munin MCP tool with a JSON arguments object ───────────
+munin_tool_call() {
+  local tool_name="$1" args_json="$2"
+  local payload
+  payload=$(TOOL_NAME="$tool_name" ARGS_JSON="$args_json" node --input-type=commonjs -e '
+    console.log(JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: process.env.TOOL_NAME, arguments: JSON.parse(process.env.ARGS_JSON) }
+    }))
+  ')
+  munin_call "$payload"
+}

--- a/scripts/lib/notify.sh
+++ b/scripts/lib/notify.sh
@@ -1,0 +1,66 @@
+# shellcheck shell=bash
+# ─── Grimnir shared Telegram-notify helper ───────────────────────────────────
+#
+# notify_telegram "message"  → pushes a one-line alert to Magnus's Telegram.
+#
+# Preferred path: the running Ratatoskr bot's local HTTP endpoint
+#   POST http://127.0.0.1:3034/api/send  {chat_id:<number>, text:<string>}
+# (no auth header — the socket is 127.0.0.1-only and gated by an allowlist).
+# Falls back to the direct Telegram Bot API if Ratatoskr is unreachable.
+#
+# Both paths source TELEGRAM_ALLOWED_USERS (chat id) and TELEGRAM_BOT_TOKEN
+# (fallback only) from the Ratatoskr .env — never hardcoded, never echoed.
+# Best-effort by design: a notify failure NEVER fails the calling script.
+# Compatible with bash 3.2+.
+
+RATATOSKR_URL="${RATATOSKR_URL:-http://127.0.0.1:3034/api/send}"
+RATATOSKR_ENV="${RATATOSKR_ENV:-$HOME/repos/ratatoskr/.env}"
+
+# JSON-escape an arbitrary string into a quoted JSON string literal.
+_notify_json_string() {
+  MSG="$1" node --input-type=commonjs -e 'process.stdout.write(JSON.stringify(process.env.MSG||""))'
+}
+
+notify_telegram() {
+  local msg="$1"
+  [[ -z "$msg" ]] && return 0
+
+  # Load chat id (+ token, used only by the fallback) from Ratatoskr's .env.
+  local chat_id="" bot_token=""
+  if [[ -f "$RATATOSKR_ENV" ]]; then
+    chat_id="$(grep -E '^TELEGRAM_ALLOWED_USERS=' "$RATATOSKR_ENV" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"' )"
+    chat_id="${chat_id%%,*}"   # first allowed user if comma-separated
+    bot_token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$RATATOSKR_ENV" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"')"
+  fi
+  if [[ -z "$chat_id" ]]; then
+    echo "  notify: no Telegram chat id available — skipping alert" >&2
+    return 0
+  fi
+  if [[ ! "$chat_id" =~ ^-?[0-9]+$ ]]; then
+    echo "  notify: TELEGRAM_ALLOWED_USERS first entry '$chat_id' is not numeric — skipping alert" >&2
+    return 0
+  fi
+
+  local text_json
+  text_json="$(_notify_json_string "$msg")"
+
+  # Preferred: Ratatoskr local endpoint (chat_id MUST be an unquoted JSON number).
+  local code
+  code="$(curl -sS -m 8 -o /dev/null -w '%{http_code}' -X POST "$RATATOSKR_URL" \
+       -H "Content-Type: application/json" \
+       -d "{\"chat_id\": ${chat_id}, \"text\": ${text_json}}" 2>/dev/null || echo 000)"
+  if [[ "$code" == "200" ]]; then
+    return 0
+  fi
+
+  # Fallback: direct Telegram Bot API.
+  if [[ -n "$bot_token" ]]; then
+    curl -sS -m 8 -o /dev/null \
+      "https://api.telegram.org/bot${bot_token}/sendMessage" \
+      --data-urlencode "chat_id=${chat_id}" \
+      --data-urlencode "text=${msg}" 2>/dev/null || true
+  else
+    echo "  notify: Ratatoskr unreachable and no bot token for fallback" >&2
+  fi
+  return 0
+}

--- a/scripts/lib/notify.sh
+++ b/scripts/lib/notify.sh
@@ -53,10 +53,11 @@ notify_telegram() {
     return 0
   fi
 
-  # Fallback: direct Telegram Bot API.
+  # Fallback: direct Telegram Bot API. Pass the token-bearing URL via curl's
+  # --config (stdin) so the bot token never appears in the process argv (ps).
   if [[ -n "$bot_token" ]]; then
-    curl -sS -m 8 -o /dev/null \
-      "https://api.telegram.org/bot${bot_token}/sendMessage" \
+    printf 'url = "https://api.telegram.org/bot%s/sendMessage"\n' "$bot_token" | \
+    curl -sS -m 8 -o /dev/null --config - \
       --data-urlencode "chat_id=${chat_id}" \
       --data-urlencode "text=${msg}" 2>/dev/null || true
   else

--- a/scripts/maintenance-report.sh
+++ b/scripts/maintenance-report.sh
@@ -114,6 +114,19 @@ echo "SEC_PENDING=${SEC:-0}"; echo "ALL_PENDING=${ALLUP:-0}"; echo "DISK=${DISK:
 PROBE
 }
 
+# Resolve a host to a usable SSH target, mirroring deploy.sh/setup-host-patching:
+# "LOCAL" if it's this machine, else user@.local, else user@bare (Tailscale),
+# else empty (unreachable). Avoids a transient mDNS blip false-flagging a host.
+resolve_remote() {
+  local host="$1" short="${1%%.*}" bare="${1%.local}"
+  if [[ "$short" == "$LOCAL_HOST" ]]; then echo "LOCAL"; return 0; fi
+  if ssh -o ConnectTimeout=6 -o BatchMode=yes "$DEPLOY_USER@$host" true 2>/dev/null; then
+    echo "$DEPLOY_USER@$host"; return 0; fi
+  if [[ "$bare" != "$host" ]] && ssh -o ConnectTimeout=6 -o BatchMode=yes "$DEPLOY_USER@$bare" true 2>/dev/null; then
+    echo "$DEPLOY_USER@$bare"; return 0; fi
+  return 1
+}
+
 run_os() {
   echo "Grimnir OS maintenance report — $TIMESTAMP (v$REPORT_VERSION)"
   echo
@@ -129,12 +142,16 @@ run_os() {
   local summary="OS patch status ($RUN_DATE):" alerts="" any_action=false
 
   for host in "${HOSTS[@]}"; do
-    local short="${host%%.*}" blob
+    local short="${host%%.*}" blob target
     echo "▶ $host"
-    if [[ "$short" == "$LOCAL_HOST" ]]; then
-      blob="$(bash -c "$probe" 2>/dev/null || true)"
+    if target="$(resolve_remote "$host")"; then
+      if [[ "$target" == "LOCAL" ]]; then
+        blob="$(bash -c "$probe" 2>/dev/null || true)"
+      else
+        blob="$(ssh -o ConnectTimeout=8 -o BatchMode=yes "$target" "$probe" 2>/dev/null || true)"
+      fi
     else
-      blob="$(ssh -o ConnectTimeout=8 -o BatchMode=yes "$DEPLOY_USER@$host" "$probe" 2>/dev/null || true)"
+      target=""; blob=""
     fi
     if [[ -z "$blob" ]]; then
       echo "  unreachable"
@@ -177,7 +194,7 @@ run_os() {
       "[\"maintenance\",\"os\",\"$short\",\"automated\"]"
 
     # Action-needed conditions
-    [[ "$rr" == "yes" ]] && { alerts+=$'\n'"🔁 $short needs a REBOOT ($rrpkgs pkg(s)): $(ssh_pkglist "$host" "$short")"; any_action=true; }
+    [[ "$rr" == "yes" ]] && { alerts+=$'\n'"🔁 $short needs a REBOOT ($rrpkgs pkg(s)): $(ssh_pkglist "$target")"; any_action=true; }
     [[ "${sec:-0}" -gt 0 ]] 2>/dev/null && { alerts+=$'\n'"🔒 $short has $sec security update(s) still pending"; any_action=true; }
     [[ "${uu:-0}" -eq 0 ]] 2>/dev/null && { alerts+=$'\n'"❗ $short: unattended-upgrades NOT installed"; any_action=true; }
     [[ "${disk:-0}" -ge "$DISK_WARN_PCT" ]] 2>/dev/null && { alerts+=$'\n'"💾 $short disk at ${disk}%"; any_action=true; }
@@ -198,11 +215,12 @@ run_os() {
   $any_action && echo "Action needed (alert sent)." || echo "All hosts patched & healthy."
 }
 
-# Best-effort fetch of the reboot-required package list (short) for the alert.
-ssh_pkglist() {  # host short
-  local host="$1" short="$2" cmd='head -3 /var/run/reboot-required.pkgs 2>/dev/null | tr "\n" "," | sed "s/,$//"'
-  if [[ "$short" == "$LOCAL_HOST" ]]; then bash -c "$cmd" 2>/dev/null || true
-  else ssh -o ConnectTimeout=6 -o BatchMode=yes "$DEPLOY_USER@$host" "$cmd" 2>/dev/null || true; fi
+# Best-effort fetch of the reboot-required package list for the alert.
+# Arg is a resolved target from resolve_remote ("LOCAL" or user@host).
+ssh_pkglist() {  # target
+  local target="$1" cmd='head -3 /var/run/reboot-required.pkgs 2>/dev/null | tr "\n" "," | sed "s/,$//"'
+  if [[ "$target" == "LOCAL" ]]; then bash -c "$cmd" 2>/dev/null || true
+  else ssh -o ConnectTimeout=6 -o BatchMode=yes "$target" "$cmd" 2>/dev/null || true; fi
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -234,12 +252,19 @@ run_deps() {
       let o;
       try { o = out === "" ? {} : JSON.parse(out); }
       catch (e) { process.stdout.write("ERR"); process.exit(0); }
-      if (out === "" && rc !== "0") { process.stdout.write("ERR"); process.exit(0); }
+      // Error states (only when rc!=0): empty output, or npm error envelope
+      // {"error":{code,summary,...}}. Distinguish that from a real dependency
+      // literally named "error" (which has current/wanted/latest fields).
+      const errEnv = o && o.error && typeof o.error === "object" &&
+        !("latest" in o.error || "current" in o.error || "wanted" in o.error);
+      if (rc !== "0" && (out === "" || errEnv)) { process.stdout.write("ERR"); process.exit(0); }
       let total=0, major=0;
       for (const k of Object.keys(o)) {
+        const e = o[k];
+        if (!e || typeof e !== "object") continue;   // skip non-dependency entries
         total++;
-        const cur=(o[k].current||o[k].wanted||"0").split(".")[0];
-        const lat=(o[k].latest||"0").split(".")[0];
+        const cur=(e.current||e.wanted||"0").split(".")[0];
+        const lat=(e.latest||"0").split(".")[0];
         if (Number(lat) > Number(cur)) major++;
       }
       process.stdout.write(total+" "+major);

--- a/scripts/maintenance-report.sh
+++ b/scripts/maintenance-report.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# maintenance-report.sh — Grimnir software-update visibility layer.
+#
+# Two modes (run as separate oneshot timers on huginmunin):
+#
+#   os    Daily. For EVERY Pi host in services.json (local + SSH to the rest),
+#         report: pending security updates, reboot-required, disk usage, and
+#         whether unattended-upgrades is installed/healthy. The actual patching
+#         is done autonomously by unattended-upgrades (see setup-host-patching.sh);
+#         this mode is the detect-and-surface half. Pushes an action-needed
+#         Telegram alert when a reboot is pending, security updates are still
+#         outstanding, disk is tight, or a host lacks the patcher.
+#
+#   deps  Weekly. Run `npm outdated` across every service repo checked out under
+#         ~/repos and report counts (total + major bumps) to Munin. DETECT +
+#         REPORT ONLY — never auto-applies (per the auto-ops debate verdict).
+#
+# Results go to Munin (maintenance/* namespace) and Heimdall; alerts go to
+# Telegram via Ratatoskr. Mirrors security-scan.sh conventions and reuses the
+# shared lib/munin.sh + lib/notify.sh helpers. Compatible with bash 3.2+.
+#
+# Usage:
+#   scripts/maintenance-report.sh os    [--dry-run] [--verbose] [--munin-token T]
+#   scripts/maintenance-report.sh deps  [--dry-run] [--verbose] [--munin-token T]
+set -euo pipefail
+
+REPORT_VERSION="1.0.0"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
+REGISTRY="$GRIMNIR_DIR/services.json"
+REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
+REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
+DEPLOY_USER="${DEPLOY_USER:-magnus}"
+
+# shellcheck source=scripts/lib/munin.sh
+source "$SCRIPT_DIR/lib/munin.sh"
+# shellcheck source=scripts/lib/notify.sh
+source "$SCRIPT_DIR/lib/notify.sh"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RUN_DATE="$(date -u +%Y-%m-%d)"
+LOCAL_HOST="$(hostname -s)"
+DISK_WARN_PCT=85
+
+# ─── Args ────────────────────────────────────────────────────────────────────
+MODE="${1:-}"; shift || true
+DRY_RUN=false; VERBOSE=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --verbose) VERBOSE=true; shift ;;
+    --munin-token) MUNIN_TOKEN="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+case "$MODE" in
+  os|deps) ;;
+  *) echo "Usage: $0 {os|deps} [--dry-run] [--verbose] [--munin-token T]" >&2; exit 1 ;;
+esac
+
+log_verbose() { $VERBOSE && echo "  $*" >&2 || true; }
+
+munin_discover_token "$REPOS_DIR" || true
+if [[ -z "${MUNIN_TOKEN:-}" ]]; then
+  echo "WARNING: no Munin token found — Munin writes will be skipped" >&2
+fi
+
+# memory_write/memory_log wrappers honouring --dry-run and missing token.
+report_write() {  # namespace key content tags_json
+  $DRY_RUN && { log_verbose "[dry-run] memory_write $1/$2"; return 0; }
+  [[ -z "${MUNIN_TOKEN:-}" ]] && return 0
+  local args
+  args=$(NS="$1" K="$2" C="$3" T="$4" node --input-type=commonjs -e '
+    console.log(JSON.stringify({namespace:process.env.NS,key:process.env.K,content:process.env.C,tags:JSON.parse(process.env.T)}))') \
+    || { echo "WARNING: Munin payload build failed ($1/$2)" >&2; return 0; }
+  munin_tool_call memory_write "$args" >/dev/null || echo "WARNING: Munin write failed ($1/$2)" >&2
+}
+report_log() {    # namespace content tags_json
+  $DRY_RUN && { log_verbose "[dry-run] memory_log $1"; return 0; }
+  [[ -z "${MUNIN_TOKEN:-}" ]] && return 0
+  local args
+  args=$(NS="$1" C="$2" T="$3" node --input-type=commonjs -e '
+    console.log(JSON.stringify({namespace:process.env.NS,content:process.env.C,tags:JSON.parse(process.env.T)}))') \
+    || { echo "WARNING: Munin payload build failed ($1)" >&2; return 0; }
+  munin_tool_call memory_log "$args" >/dev/null || echo "WARNING: Munin log failed ($1)" >&2
+}
+alert() { $DRY_RUN && { echo "  [dry-run] telegram: $1"; return 0; }; notify_telegram "$1"; }
+
+# ═════════════════════════════════════════════════════════════════════════════
+# OS MODE
+# ═════════════════════════════════════════════════════════════════════════════
+os_probe_cmd() {
+cat <<'PROBE'
+RR=no; [ -e /var/run/reboot-required ] && RR=yes
+RRPKGS=0; [ -f /var/run/reboot-required.pkgs ] && RRPKGS=$(wc -l < /var/run/reboot-required.pkgs)
+UU=$(dpkg -l unattended-upgrades 2>/dev/null | grep -c '^ii' || true)
+if [ -x /usr/lib/update-notifier/apt-check ]; then
+  AC=$(/usr/lib/update-notifier/apt-check 2>&1); ALLUP=${AC%;*}; SEC=${AC#*;}
+else
+  ALLUP=$(apt-get -s upgrade 2>/dev/null | grep -c '^Inst' || true)
+  SEC=$(apt-get -s upgrade 2>/dev/null | awk '/^Inst/ && /security/{c++} END{print c+0}')
+fi
+DISK=$(df -P / | awk 'NR==2{gsub(/%/,"",$5); print $5}')
+echo "REBOOT=$RR"; echo "REBOOT_PKGS=$RRPKGS"; echo "UU_INSTALLED=$UU"
+echo "SEC_PENDING=${SEC:-0}"; echo "ALL_PENDING=${ALLUP:-0}"; echo "DISK=${DISK:-0}"; echo "KERNEL=$(uname -r)"
+PROBE
+}
+
+run_os() {
+  echo "Grimnir OS maintenance report — $TIMESTAMP (v$REPORT_VERSION)"
+  echo
+
+  local HOSTS=()
+  while IFS= read -r h; do
+    [[ -n "$h" ]] && HOSTS+=("$h")
+  done < <(REGISTRY_PATH="$REGISTRY" QUERY=deploy \
+    node --input-type=commonjs "$REGISTRY_JS" | cut -d'|' -f3 | grep -v '^$' | sort -u)
+  [[ ${#HOSTS[@]} -gt 0 ]] || { echo "No deploy hosts found in $REGISTRY" >&2; exit 1; }
+
+  local probe; probe="$(os_probe_cmd)"
+  local summary="OS patch status ($RUN_DATE):" alerts="" any_action=false
+
+  for host in "${HOSTS[@]}"; do
+    local short="${host%%.*}" blob
+    echo "▶ $host"
+    if [[ "$short" == "$LOCAL_HOST" ]]; then
+      blob="$(bash -c "$probe" 2>/dev/null || true)"
+    else
+      blob="$(ssh -o ConnectTimeout=8 -o BatchMode=yes "$DEPLOY_USER@$host" "$probe" 2>/dev/null || true)"
+    fi
+    if [[ -z "$blob" ]]; then
+      echo "  unreachable"
+      summary+=$'\n'"  $short: UNREACHABLE"
+      alerts+=$'\n'"⚠️ $short unreachable for OS maintenance check"
+      any_action=true
+      continue
+    fi
+    local rr rrpkgs uu sec all disk kern
+    rr=$(grep '^REBOOT=' <<<"$blob" | cut -d= -f2)
+    rrpkgs=$(grep '^REBOOT_PKGS=' <<<"$blob" | cut -d= -f2)
+    uu=$(grep '^UU_INSTALLED=' <<<"$blob" | cut -d= -f2)
+    sec=$(grep '^SEC_PENDING=' <<<"$blob" | cut -d= -f2)
+    all=$(grep '^ALL_PENDING=' <<<"$blob" | cut -d= -f2)
+    disk=$(grep '^DISK=' <<<"$blob" | cut -d= -f2)
+    kern=$(grep '^KERNEL=' <<<"$blob" | cut -d= -f2)
+
+    # Sanitize numeric fields — apt-check writes to stderr and can emit a
+    # non-numeric error (e.g. apt-lock contention); a non-numeric value would
+    # make the `[[ x -gt 0 ]]` tests below return 2 and abort under set -e.
+    local v
+    for v in rrpkgs uu sec all disk; do
+      case "${!v}" in *[!0-9]*|'') printf -v "$v" '%s' 0 ;; esac
+    done
+
+    printf "  reboot=%s(%s) security_pending=%s all_pending=%s uu=%s disk=%s%% kernel=%s\n" \
+      "$rr" "$rrpkgs" "$sec" "$all" "$uu" "$disk" "$kern"
+
+    local line="  $short: security_pending=$sec, all_pending=$all, reboot=$rr, disk=${disk}%, uu_installed=$uu, kernel=$kern"
+    summary+=$'\n'"$line"
+
+    # Per-host Munin state
+    report_write "maintenance/os/$short" "latest" \
+      "$short OS status @ $TIMESTAMP"$'\n'"$line" \
+      "[\"maintenance\",\"os\",\"$short\",\"automated\"]"
+
+    # Action-needed conditions
+    [[ "$rr" == "yes" ]] && { alerts+=$'\n'"🔁 $short needs a REBOOT ($rrpkgs pkg(s)): $(ssh_pkglist "$host" "$short")"; any_action=true; }
+    [[ "${sec:-0}" -gt 0 ]] 2>/dev/null && { alerts+=$'\n'"🔒 $short has $sec security update(s) still pending"; any_action=true; }
+    [[ "${uu:-0}" -eq 0 ]] 2>/dev/null && { alerts+=$'\n'"❗ $short: unattended-upgrades NOT installed"; any_action=true; }
+    [[ "${disk:-0}" -ge "$DISK_WARN_PCT" ]] 2>/dev/null && { alerts+=$'\n'"💾 $short disk at ${disk}%"; any_action=true; }
+  done
+
+  echo
+  echo "$summary"
+
+  report_write "maintenance/os/$RUN_DATE" "summary" "$summary" \
+    "[\"maintenance\",\"os\",\"automated\"]"
+  report_log "maintenance/" "OS maintenance report run @ $TIMESTAMP — action_needed=$any_action" \
+    "[\"maintenance\",\"os-event\",\"automated\"]"
+
+  if $any_action && [[ -n "$alerts" ]]; then
+    alert "🛠️ Grimnir OS maintenance ($RUN_DATE)${alerts}"
+  fi
+  echo
+  $any_action && echo "Action needed (alert sent)." || echo "All hosts patched & healthy."
+}
+
+# Best-effort fetch of the reboot-required package list (short) for the alert.
+ssh_pkglist() {  # host short
+  local host="$1" short="$2" cmd='head -3 /var/run/reboot-required.pkgs 2>/dev/null | tr "\n" "," | sed "s/,$//"'
+  if [[ "$short" == "$LOCAL_HOST" ]]; then bash -c "$cmd" 2>/dev/null || true
+  else ssh -o ConnectTimeout=6 -o BatchMode=yes "$DEPLOY_USER@$host" "$cmd" 2>/dev/null || true; fi
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# DEPS MODE
+# ═════════════════════════════════════════════════════════════════════════════
+run_deps() {
+  echo "Grimnir npm dependency report — $TIMESTAMP (v$REPORT_VERSION)"
+  echo
+
+  local repos; repos="$(REGISTRY_PATH="$REGISTRY" QUERY=scan node --input-type=commonjs "$REGISTRY_JS")"
+  local summary="npm outdated ($RUN_DATE):" grand_total=0 grand_major=0 checked=0
+
+  for repo in $repos; do
+    local dir="$REPOS_DIR/$repo"
+    if [[ ! -f "$dir/package.json" ]]; then
+      log_verbose "skip $repo (no package.json under $dir)"; continue
+    fi
+    checked=$((checked + 1))
+    local out counts total major
+    out="$(cd "$dir" && npm_config_cache="${npm_config_cache:-/tmp/npm-cache}" npm outdated --json 2>/dev/null || true)"
+    counts="$(OUT="$out" node --input-type=commonjs -e '
+      let o={}; try{o=JSON.parse(process.env.OUT||"{}")}catch(e){}
+      let total=0, major=0;
+      for (const k of Object.keys(o)) {
+        total++;
+        const cur=(o[k].current||o[k].wanted||"0").split(".")[0];
+        const lat=(o[k].latest||"0").split(".")[0];
+        if (Number(lat) > Number(cur)) major++;
+      }
+      process.stdout.write(total+" "+major);
+    ')"
+    total="${counts%% *}"; major="${counts##* }"
+    grand_total=$((grand_total + total)); grand_major=$((grand_major + major))
+
+    printf "  %-16s outdated=%s (major=%s)\n" "$repo" "$total" "$major"
+    summary+=$'\n'"  $repo: outdated=$total, major=$major"
+    report_write "maintenance/deps/$repo" "latest" \
+      "$repo outdated deps @ $TIMESTAMP: total=$total, major=$major" \
+      "[\"maintenance\",\"deps\",\"$repo\",\"automated\"]"
+  done
+
+  summary+=$'\n'"TOTAL: $grand_total outdated across $checked repos ($grand_major major)"
+  echo
+  echo "$summary"
+
+  report_write "maintenance/deps/$RUN_DATE" "summary" "$summary" \
+    "[\"maintenance\",\"deps\",\"automated\"]"
+  report_log "maintenance/" "npm dependency report run @ $TIMESTAMP — $grand_total outdated ($grand_major major) across $checked repos" \
+    "[\"maintenance\",\"deps-event\",\"automated\"]"
+
+  if [[ "$grand_total" -gt 0 ]]; then
+    alert "📦 Grimnir deps ($RUN_DATE): $grand_total outdated across $checked repos ($grand_major major bump(s)). Review & bump deliberately.${summary#npm outdated ($RUN_DATE):}"
+  fi
+  echo
+  echo "Done — detect+report only, nothing auto-applied."
+}
+
+case "$MODE" in
+  os) run_os ;;
+  deps) run_deps ;;
+esac

--- a/scripts/maintenance-report.sh
+++ b/scripts/maintenance-report.sh
@@ -141,6 +141,11 @@ run_os() {
       summary+=$'\n'"  $short: UNREACHABLE"
       alerts+=$'\n'"⚠️ $short unreachable for OS maintenance check"
       any_action=true
+      # Overwrite the per-host latest so consumers don't keep seeing a stale
+      # "healthy" value while the host is actually unreachable.
+      report_write "maintenance/os/$short" "latest" \
+        "$short OS status @ $TIMESTAMP"$'\n'"  $short: UNREACHABLE" \
+        "[\"maintenance\",\"os\",\"$short\",\"automated\",\"error\"]"
       continue
     fi
     local rr rrpkgs uu sec all disk kern
@@ -208,7 +213,7 @@ run_deps() {
   echo
 
   local repos; repos="$(REGISTRY_PATH="$REGISTRY" QUERY=scan node --input-type=commonjs "$REGISTRY_JS")"
-  local summary="npm outdated ($RUN_DATE):" grand_total=0 grand_major=0 checked=0
+  local summary="npm outdated ($RUN_DATE):" grand_total=0 grand_major=0 checked=0 errors=0
 
   for repo in $repos; do
     local dir="$REPOS_DIR/$repo"
@@ -216,10 +221,20 @@ run_deps() {
       log_verbose "skip $repo (no package.json under $dir)"; continue
     fi
     checked=$((checked + 1))
-    local out counts total major
-    out="$(cd "$dir" && npm_config_cache="${npm_config_cache:-/tmp/npm-cache}" npm outdated --json 2>/dev/null || true)"
-    counts="$(OUT="$out" node --input-type=commonjs -e '
-      let o={}; try{o=JSON.parse(process.env.OUT||"{}")}catch(e){}
+    local out rc counts total major
+    # npm outdated exits 0 when up to date, 1 when packages ARE outdated, and
+    # nonzero with empty/invalid stdout on a real error (network/registry).
+    # Capture both stdout and exit code so a failed check isn't read as "0".
+    set +e
+    out="$(cd "$dir" && npm_config_cache="${npm_config_cache:-/tmp/npm-cache}" npm outdated --json 2>/dev/null)"
+    rc=$?
+    set -e
+    counts="$(OUT="$out" RC="$rc" node --input-type=commonjs -e '
+      const out=(process.env.OUT||"").trim(), rc=process.env.RC||"0";
+      let o;
+      try { o = out === "" ? {} : JSON.parse(out); }
+      catch (e) { process.stdout.write("ERR"); process.exit(0); }
+      if (out === "" && rc !== "0") { process.stdout.write("ERR"); process.exit(0); }
       let total=0, major=0;
       for (const k of Object.keys(o)) {
         total++;
@@ -229,6 +244,15 @@ run_deps() {
       }
       process.stdout.write(total+" "+major);
     ')"
+    if [[ "$counts" == "ERR" ]]; then
+      errors=$((errors + 1))
+      printf "  %-16s CHECK FAILED (npm rc=%s)\n" "$repo" "$rc"
+      summary+=$'\n'"  $repo: CHECK FAILED"
+      report_write "maintenance/deps/$repo" "latest" \
+        "$repo dependency check FAILED @ $TIMESTAMP (npm outdated rc=$rc)" \
+        "[\"maintenance\",\"deps\",\"$repo\",\"automated\",\"error\"]"
+      continue
+    fi
     total="${counts%% *}"; major="${counts##* }"
     grand_total=$((grand_total + total)); grand_major=$((grand_major + major))
 
@@ -239,17 +263,17 @@ run_deps() {
       "[\"maintenance\",\"deps\",\"$repo\",\"automated\"]"
   done
 
-  summary+=$'\n'"TOTAL: $grand_total outdated across $checked repos ($grand_major major)"
+  summary+=$'\n'"TOTAL: $grand_total outdated across $checked repos ($grand_major major); $errors check error(s)"
   echo
   echo "$summary"
 
   report_write "maintenance/deps/$RUN_DATE" "summary" "$summary" \
     "[\"maintenance\",\"deps\",\"automated\"]"
-  report_log "maintenance/" "npm dependency report run @ $TIMESTAMP — $grand_total outdated ($grand_major major) across $checked repos" \
+  report_log "maintenance/" "npm dependency report run @ $TIMESTAMP — $grand_total outdated ($grand_major major) across $checked repos, $errors error(s)" \
     "[\"maintenance\",\"deps-event\",\"automated\"]"
 
-  if [[ "$grand_total" -gt 0 ]]; then
-    alert "📦 Grimnir deps ($RUN_DATE): $grand_total outdated across $checked repos ($grand_major major bump(s)). Review & bump deliberately.${summary#npm outdated ($RUN_DATE):}"
+  if [[ "$grand_total" -gt 0 || "$errors" -gt 0 ]]; then
+    alert "📦 Grimnir deps ($RUN_DATE): $grand_total outdated across $checked repos ($grand_major major bump(s)), $errors check error(s). Review & bump deliberately.${summary#npm outdated ($RUN_DATE):}"
   fi
   echo
   echo "Done — detect+report only, nothing auto-applied."
@@ -260,21 +284,23 @@ run_deps() {
 # Data arrives via env (heredoc-free single ssh command, robust under launchd):
 #   BREW_SUMMARY_B64  base64 of the one-line summary
 #   BREW_NCASKS       count of casks needing manual upgrade (>0 ⇒ Telegram)
+#   BREW_ALERT        "1" if the laptop run had update/upgrade failures (⇒ Telegram)
 # ═════════════════════════════════════════════════════════════════════════════
 run_brew() {
-  local summary ncasks
+  local summary ncasks balert
   summary="$(printf '%s' "${BREW_SUMMARY_B64:-}" | base64 -d 2>/dev/null || true)"
   [[ -n "$summary" ]] || summary="brew (laptop) @ $TIMESTAMP: (no summary provided)"
   ncasks="${BREW_NCASKS:-0}"
   case "$ncasks" in *[!0-9]*|'') ncasks=0 ;; esac
+  balert="${BREW_ALERT:-0}"
   echo "$summary"
 
   report_write "maintenance/brew/laptop" "latest" "$summary" \
     "[\"maintenance\",\"brew\",\"laptop\",\"automated\"]"
-  report_log "maintenance/" "brew laptop report @ $TIMESTAMP — $ncasks cask(s) need manual upgrade" \
+  report_log "maintenance/" "brew laptop report @ $TIMESTAMP — $ncasks cask(s) need manual upgrade, alert=$balert" \
     "[\"maintenance\",\"brew-event\",\"automated\"]"
 
-  [[ "$ncasks" -gt 0 ]] && alert "🍺 $summary"
+  { [[ "$ncasks" -gt 0 ]] || [[ "$balert" == "1" ]]; } && alert "🍺 $summary"
   echo "Done."
 }
 

--- a/scripts/maintenance-report.sh
+++ b/scripts/maintenance-report.sh
@@ -94,6 +94,12 @@ alert() { $DRY_RUN && { echo "  [dry-run] telegram: $1"; return 0; }; notify_tel
 os_probe_cmd() {
 cat <<'PROBE'
 RR=no; [ -e /var/run/reboot-required ] && RR=yes
+# Backup signal (Debian 13): needrestart kernel status >=2 means the running
+# kernel is older than the installed one — a reboot is recommended.
+if [ "$RR" = no ] && command -v needrestart >/dev/null 2>&1; then
+  KSTA=$(needrestart -b 2>/dev/null | awk -F: '/NEEDRESTART-KSTA/{print $2+0}')
+  [ "${KSTA:-0}" -ge 2 ] 2>/dev/null && RR=yes
+fi
 RRPKGS=0; [ -f /var/run/reboot-required.pkgs ] && RRPKGS=$(wc -l < /var/run/reboot-required.pkgs)
 UU=$(dpkg -l unattended-upgrades 2>/dev/null | grep -c '^ii' || true)
 if [ -x /usr/lib/update-notifier/apt-check ]; then

--- a/scripts/maintenance-report.sh
+++ b/scripts/maintenance-report.sh
@@ -100,7 +100,7 @@ if [ "$RR" = no ] && command -v needrestart >/dev/null 2>&1; then
   KSTA=$(needrestart -b 2>/dev/null | awk -F: '/NEEDRESTART-KSTA/{print $2+0}')
   [ "${KSTA:-0}" -ge 2 ] 2>/dev/null && RR=yes
 fi
-RRPKGS=0; [ -f /var/run/reboot-required.pkgs ] && RRPKGS=$(wc -l < /var/run/reboot-required.pkgs)
+RRPKGS=0; [ -f /var/run/reboot-required.pkgs ] && RRPKGS=$(wc -l < /var/run/reboot-required.pkgs | tr -d ' ')
 UU=$(dpkg -l unattended-upgrades 2>/dev/null | grep -c '^ii' || true)
 if [ -x /usr/lib/update-notifier/apt-check ]; then
   AC=$(/usr/lib/update-notifier/apt-check 2>&1); ALLUP=${AC%;*}; SEC=${AC#*;}

--- a/scripts/maintenance-report.sh
+++ b/scripts/maintenance-report.sh
@@ -56,8 +56,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 case "$MODE" in
-  os|deps) ;;
-  *) echo "Usage: $0 {os|deps} [--dry-run] [--verbose] [--munin-token T]" >&2; exit 1 ;;
+  os|deps|brew) ;;
+  *) echo "Usage: $0 {os|deps|brew} [--dry-run] [--verbose] [--munin-token T]" >&2; exit 1 ;;
 esac
 
 log_verbose() { $VERBOSE && echo "  $*" >&2 || true; }
@@ -255,7 +255,31 @@ run_deps() {
   echo "Done — detect+report only, nothing auto-applied."
 }
 
+# ═════════════════════════════════════════════════════════════════════════════
+# BREW MODE — reports a laptop Homebrew run forwarded over SSH from the laptop.
+# Data arrives via env (heredoc-free single ssh command, robust under launchd):
+#   BREW_SUMMARY_B64  base64 of the one-line summary
+#   BREW_NCASKS       count of casks needing manual upgrade (>0 ⇒ Telegram)
+# ═════════════════════════════════════════════════════════════════════════════
+run_brew() {
+  local summary ncasks
+  summary="$(printf '%s' "${BREW_SUMMARY_B64:-}" | base64 -d 2>/dev/null || true)"
+  [[ -n "$summary" ]] || summary="brew (laptop) @ $TIMESTAMP: (no summary provided)"
+  ncasks="${BREW_NCASKS:-0}"
+  case "$ncasks" in *[!0-9]*|'') ncasks=0 ;; esac
+  echo "$summary"
+
+  report_write "maintenance/brew/laptop" "latest" "$summary" \
+    "[\"maintenance\",\"brew\",\"laptop\",\"automated\"]"
+  report_log "maintenance/" "brew laptop report @ $TIMESTAMP — $ncasks cask(s) need manual upgrade" \
+    "[\"maintenance\",\"brew-event\",\"automated\"]"
+
+  [[ "$ncasks" -gt 0 ]] && alert "🍺 $summary"
+  echo "Done."
+}
+
 case "$MODE" in
   os) run_os ;;
   deps) run_deps ;;
+  brew) run_brew ;;
 esac

--- a/scripts/setup-host-patching.sh
+++ b/scripts/setup-host-patching.sh
@@ -139,8 +139,9 @@ echo
 echo "── Summary ──"
 for r in "${results[@]}"; do echo -e "  $r"; done
 
-# Non-zero exit if any host hard-failed (validate warnings don't count), so
-# `make patching` surfaces failures to callers/CI rather than reporting success.
+# Non-zero exit if any host hard-failed — unreachable, apt install, config push,
+# timer enable, or dry-run validation all count — so `make patching` surfaces
+# failures to callers/CI rather than reporting success.
 if [[ $fail_count -gt 0 ]]; then
   echo -e "${RED}${fail_count} host(s) failed${NC}"
   exit 1

--- a/scripts/setup-host-patching.sh
+++ b/scripts/setup-host-patching.sh
@@ -113,17 +113,25 @@ for host in "${HOSTS[@]}"; do
     continue
   fi
 
-  # 3. Ensure the stock timers are enabled (idempotent).
-  ssh "$remote" "sudo systemctl enable --now apt-daily.timer apt-daily-upgrade.timer >/dev/null 2>&1 || true"
+  # 3. Ensure the stock timers are enabled (idempotent). These drive the
+  #    actual unattended-upgrade runs, so a failure here is a real failure.
+  if ! ssh "$remote" "sudo systemctl enable --now apt-daily.timer apt-daily-upgrade.timer >/dev/null 2>&1"; then
+    echo -e "  ${RED}failed to enable apt timers${NC}"
+    results+=("${RED}✗${NC} $host (timer enable)")
+    fail_count=$((fail_count + 1))
+    continue
+  fi
 
-  # 4. Validate the config parses and origins resolve.
+  # 4. Validate the config parses and origins resolve — the confirmation that
+  #    this host will actually apply security upgrades. A failure counts.
   echo "  validating…"
   if ssh "$remote" "sudo unattended-upgrade --dry-run >/dev/null 2>&1"; then
     echo -e "  ${GREEN}OK${NC}"
     results+=("${GREEN}✓${NC} $host")
   else
-    echo -e "  ${YELLOW}installed but --dry-run reported issues (check journalctl)${NC}"
-    results+=("${YELLOW}?${NC} $host (validate)")
+    echo -e "  ${RED}validation failed (unattended-upgrade --dry-run) — check journalctl${NC}"
+    results+=("${RED}✗${NC} $host (validate)")
+    fail_count=$((fail_count + 1))
   fi
 done
 

--- a/scripts/setup-host-patching.sh
+++ b/scripts/setup-host-patching.sh
@@ -55,16 +55,29 @@ echo "Hosts: ${HOSTS[*]}"
 $DRY_RUN && echo -e "${YELLOW}DRY RUN — no changes will be made${NC}"
 echo
 
+# Resolve a reachable user@host: try the .local name, then the bare name over
+# Tailscale (mirrors deploy.sh's resolve_host — mDNS can flake under automation).
+resolve_remote() {
+  local host="$1" bare="${1%.local}"
+  if ssh -o ConnectTimeout=6 -o BatchMode=yes "$DEPLOY_USER@$host" true 2>/dev/null; then
+    echo "$DEPLOY_USER@$host"; return 0
+  fi
+  if [[ "$bare" != "$host" ]] && ssh -o ConnectTimeout=6 -o BatchMode=yes "$DEPLOY_USER@$bare" true 2>/dev/null; then
+    echo "$DEPLOY_USER@$bare"; return 0
+  fi
+  return 1
+}
+
 results=()
 for host in "${HOSTS[@]}"; do
   echo -e "${YELLOW}▶ $host${NC}"
-  remote="$DEPLOY_USER@$host"
 
-  if ! ssh -o ConnectTimeout=8 -o BatchMode=yes "$remote" true 2>/dev/null; then
-    echo -e "  ${RED}unreachable (ssh BatchMode failed)${NC}"
+  if ! remote="$(resolve_remote "$host")"; then
+    echo -e "  ${RED}unreachable (.local and Tailscale bare name both failed)${NC}"
     results+=("${RED}✗${NC} $host (unreachable)")
     continue
   fi
+  [[ "$remote" != "$DEPLOY_USER@$host" ]] && echo "  resolved via $remote"
 
   if $DRY_RUN; then
     echo "  would: apt-get install -y unattended-upgrades"

--- a/scripts/setup-host-patching.sh
+++ b/scripts/setup-host-patching.sh
@@ -69,12 +69,14 @@ resolve_remote() {
 }
 
 results=()
+fail_count=0
 for host in "${HOSTS[@]}"; do
   echo -e "${YELLOW}▶ $host${NC}"
 
   if ! remote="$(resolve_remote "$host")"; then
     echo -e "  ${RED}unreachable (.local and Tailscale bare name both failed)${NC}"
     results+=("${RED}✗${NC} $host (unreachable)")
+    fail_count=$((fail_count + 1))
     continue
   fi
   [[ "$remote" != "$DEPLOY_USER@$host" ]] && echo "  resolved via $remote"
@@ -97,6 +99,7 @@ for host in "${HOSTS[@]}"; do
   if ! ssh "$remote" "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y unattended-upgrades needrestart >/dev/null 2>&1"; then
     echo -e "  ${RED}apt install failed${NC}"
     results+=("${RED}✗${NC} $host (apt install)")
+    fail_count=$((fail_count + 1))
     continue
   fi
 
@@ -106,6 +109,7 @@ for host in "${HOSTS[@]}"; do
      || ! ssh "$remote" "sudo tee /etc/apt/apt.conf.d/50unattended-upgrades >/dev/null" < "$APT_DIR/50unattended-upgrades"; then
     echo -e "  ${RED}failed to write apt config${NC}"
     results+=("${RED}✗${NC} $host (config push)")
+    fail_count=$((fail_count + 1))
     continue
   fi
 
@@ -126,3 +130,10 @@ done
 echo
 echo "── Summary ──"
 for r in "${results[@]}"; do echo -e "  $r"; done
+
+# Non-zero exit if any host hard-failed (validate warnings don't count), so
+# `make patching` surfaces failures to callers/CI rather than reporting success.
+if [[ $fail_count -gt 0 ]]; then
+  echo -e "${RED}${fail_count} host(s) failed${NC}"
+  exit 1
+fi

--- a/scripts/setup-host-patching.sh
+++ b/scripts/setup-host-patching.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# setup-host-patching.sh — install & configure unattended-upgrades on every Pi
+# host in services.json, so OS security patches apply automatically.
+#
+# Idempotent: safe to re-run. Installs the `unattended-upgrades` package, pushes
+# Grimnir's version-controlled apt config (host-config/apt/*), and ensures the
+# stock apt-daily timers are enabled. Does NOT enable automatic reboots — see
+# host-config/apt/50unattended-upgrades and docs/scheduled-tasks.md.
+#
+# Usage:
+#   scripts/setup-host-patching.sh                 # all deploy hosts
+#   scripts/setup-host-patching.sh huginmunin.local   # one host
+#   scripts/setup-host-patching.sh --dry-run       # show actions, change nothing
+#
+# Relies on the same non-interactive, NOPASSWD-sudo SSH model as deploy.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
+REGISTRY="$GRIMNIR_DIR/services.json"
+REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
+APT_DIR="$GRIMNIR_DIR/host-config/apt"
+DEPLOY_USER="${DEPLOY_USER:-magnus}"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+
+DRY_RUN=false
+HOST_FILTER=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) HOST_FILTER+=("$1"); shift ;;
+  esac
+done
+
+[[ -f "$APT_DIR/20auto-upgrades" && -f "$APT_DIR/50unattended-upgrades" ]] || {
+  echo -e "${RED}Missing apt config under $APT_DIR${NC}" >&2; exit 1; }
+
+# ─── Derive unique deploy hosts from services.json ───────────────────────────
+# (portable: no mapfile — this script runs on the macOS laptop / bash 3.2)
+HOSTS=()
+if [[ ${#HOST_FILTER[@]} -gt 0 ]]; then
+  HOSTS=("${HOST_FILTER[@]}")
+else
+  while IFS= read -r h; do
+    [[ -n "$h" ]] && HOSTS+=("$h")
+  done < <(REGISTRY_PATH="$REGISTRY" QUERY=deploy \
+    node --input-type=commonjs "$REGISTRY_JS" | cut -d'|' -f3 | grep -v '^$' | sort -u)
+fi
+
+[[ ${#HOSTS[@]} -gt 0 ]] || { echo "No hosts."; exit 1; }
+echo "Hosts: ${HOSTS[*]}"
+$DRY_RUN && echo -e "${YELLOW}DRY RUN — no changes will be made${NC}"
+echo
+
+results=()
+for host in "${HOSTS[@]}"; do
+  echo -e "${YELLOW}▶ $host${NC}"
+  remote="$DEPLOY_USER@$host"
+
+  if ! ssh -o ConnectTimeout=8 -o BatchMode=yes "$remote" true 2>/dev/null; then
+    echo -e "  ${RED}unreachable (ssh BatchMode failed)${NC}"
+    results+=("${RED}✗${NC} $host (unreachable)")
+    continue
+  fi
+
+  if $DRY_RUN; then
+    echo "  would: apt-get install -y unattended-upgrades"
+    echo "  would: push 20auto-upgrades + 50unattended-upgrades to /etc/apt/apt.conf.d/"
+    echo "  would: enable apt-daily.timer apt-daily-upgrade.timer; validate with --dry-run"
+    results+=("${YELLOW}?${NC} $host (dry-run)")
+    continue
+  fi
+
+  # 1. Install the package (idempotent).
+  echo "  installing unattended-upgrades…"
+  if ! ssh "$remote" "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y unattended-upgrades >/dev/null 2>&1"; then
+    echo -e "  ${RED}apt install failed${NC}"
+    results+=("${RED}✗${NC} $host (apt install)")
+    continue
+  fi
+
+  # 2. Push the version-controlled config (cat → sudo tee, NOPASSWD).
+  echo "  syncing apt config…"
+  if ! ssh "$remote" "sudo tee /etc/apt/apt.conf.d/20auto-upgrades >/dev/null" < "$APT_DIR/20auto-upgrades" \
+     || ! ssh "$remote" "sudo tee /etc/apt/apt.conf.d/50unattended-upgrades >/dev/null" < "$APT_DIR/50unattended-upgrades"; then
+    echo -e "  ${RED}failed to write apt config${NC}"
+    results+=("${RED}✗${NC} $host (config push)")
+    continue
+  fi
+
+  # 3. Ensure the stock timers are enabled (idempotent).
+  ssh "$remote" "sudo systemctl enable --now apt-daily.timer apt-daily-upgrade.timer >/dev/null 2>&1 || true"
+
+  # 4. Validate the config parses and origins resolve.
+  echo "  validating…"
+  if ssh "$remote" "sudo unattended-upgrade --dry-run >/dev/null 2>&1"; then
+    echo -e "  ${GREEN}OK${NC}"
+    results+=("${GREEN}✓${NC} $host")
+  else
+    echo -e "  ${YELLOW}installed but --dry-run reported issues (check journalctl)${NC}"
+    results+=("${YELLOW}?${NC} $host (validate)")
+  fi
+done
+
+echo
+echo "── Summary ──"
+for r in "${results[@]}"; do echo -e "  $r"; done

--- a/scripts/setup-host-patching.sh
+++ b/scripts/setup-host-patching.sh
@@ -74,9 +74,14 @@ for host in "${HOSTS[@]}"; do
     continue
   fi
 
-  # 1. Install the package (idempotent).
-  echo "  installing unattended-upgrades…"
-  if ! ssh "$remote" "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y unattended-upgrades >/dev/null 2>&1"; then
+  # 1. Refresh package lists (stale lists cause 404s on install), then install
+  #    the patcher + needrestart (on Debian 13/trixie needrestart is what
+  #    creates the /var/run/reboot-required flag the OS report relies on; the
+  #    old update-notifier-common is gone). Idempotent.
+  echo "  apt-get update…"
+  ssh "$remote" "sudo DEBIAN_FRONTEND=noninteractive apt-get update >/dev/null 2>&1 || true"
+  echo "  installing unattended-upgrades + needrestart…"
+  if ! ssh "$remote" "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y unattended-upgrades needrestart >/dev/null 2>&1"; then
     echo -e "  ${RED}apt install failed${NC}"
     results+=("${RED}✗${NC} $host (apt install)")
     continue

--- a/services.json
+++ b/services.json
@@ -101,7 +101,9 @@
       "needs_build": false,
       "systemd_units": [
         { "name": "grimnir-security-scan", "type": "timer" },
-        { "name": "grimnir-validate", "type": "timer" }
+        { "name": "grimnir-validate", "type": "timer" },
+        { "name": "grimnir-maintenance-os", "type": "timer" },
+        { "name": "grimnir-maintenance-deps", "type": "timer" }
       ]
     },
     {

--- a/systemd/grimnir-maintenance-deps.service
+++ b/systemd/grimnir-maintenance-deps.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Grimnir weekly npm dependency report — npm outdated across all service repos (detect+report only)
+After=network-online.target munin-memory.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=magnus
+WorkingDirectory=/home/magnus/repos/grimnir
+ExecStart=/usr/bin/bash scripts/maintenance-report.sh deps
+TimeoutStartSec=600
+
+# npm writes its cache into the private /tmp, repos are read-only.
+Environment=npm_config_cache=/tmp/npm-cache
+
+# Read-only hardening (mirrors grimnir-security-scan, which also runs npm).
+ProtectSystem=strict
+ReadOnlyPaths=/home/magnus/repos
+ProtectHome=read-only
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+PrivateDevices=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target

--- a/systemd/grimnir-maintenance-deps.timer
+++ b/systemd/grimnir-maintenance-deps.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Grimnir weekly npm dependency report
+
+[Timer]
+# Monday early morning, off-peak and clear of the Sunday 03:00 security scan.
+OnCalendar=Mon *-*-* 02:10:00
+Persistent=true
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/systemd/grimnir-maintenance-os.service
+++ b/systemd/grimnir-maintenance-os.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Grimnir daily OS maintenance report — pending security updates, reboot-required & disk across all Pis
+After=network-online.target munin-memory.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=magnus
+WorkingDirectory=/home/magnus/repos/grimnir
+ExecStart=/usr/bin/bash scripts/maintenance-report.sh os
+TimeoutStartSec=180
+
+# Lighter sandbox than the read-only jobs: this one reads apt state under /var
+# and SSHes to nas, so /var stays writable and home is read-only (not blocked).
+ProtectSystem=true
+ProtectHome=read-only
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target

--- a/systemd/grimnir-maintenance-os.timer
+++ b/systemd/grimnir-maintenance-os.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Grimnir daily OS maintenance report
+
+[Timer]
+# After the stock apt-daily-upgrade run (~06:02–06:41) and the Skuld briefing (06:00),
+# so it reflects the morning's unattended-upgrades outcome.
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What & why

Closes the gap where there was **no mechanism to keep software updated** on the two Pis or the laptop. Detection existed (weekly `npm audit`) but almost no remediation, and **zero OS-level patching**.

Built per the chosen policy (security-only OS patches, no auto-reboot; npm deps detect-only; brew formulae auto / casks notify; Munin+Heimdall + Telegram for action-needed) and the repo's sovereignty / deliberate-over-automatic principles (all on-Pi, no Dependabot/GitHub Actions).

## Components

| Mechanism | Where | Cadence |
|---|---|---|
| `unattended-upgrades` (security-only, **no auto-reboot**) | both Pis | daily (apt-daily-upgrade) |
| `grimnir-maintenance-os` — pending security / reboot-required / disk for **both** hosts → Munin + Telegram | huginmunin (SSHes nas) | daily 07:00 |
| `grimnir-maintenance-deps` — `npm outdated` across all service repos → Munin (detect+report only) | huginmunin | weekly Mon 02:10 |
| Homebrew — upgrade formulae, notify on casks | laptop LaunchAgent | weekly Sun 11:00 |

## Notable

- **Infra fix:** `deploy.sh` had no timer-install branch — timer-only components (grimnir, skuld) were installed entirely by hand. Added one so `make deploy` copies units, daemon-reloads, and `enable --now`s them.
- Shared `lib/munin.sh` + `lib/notify.sh` factor the Munin RPC + Telegram plumbing (avoids the 4th copy flagged in the auto-ops debate).
- Version-controlled apt config in `host-config/apt/`; laptop job in `host-config/laptop/`.
- New `make` targets: `patching`, `maintenance-os`, `maintenance-deps`.

## Verification (already deployed & exercised live)

- unattended-upgrades installed + configured on both Pis; **12 pending security updates applied**, 0 remaining, no reboot required.
- OS + deps reports writing to Munin (`maintenance/*`) and alerting via Ratatoskr Telegram (HTTP 200 confirmed); healthy state correctly produces **no** alert.
- Timers installed & enabled (next OS 07:02, deps Mon 02:14).
- Laptop brew job runs under launchd (upgraded 10 formulae; casks flagged), reporting via Tailscale fallback.
- Adversarial review pass fixed 2 critical + 1 high `set -e`/glob/empty-array bugs before deploy.

Companion PR: Magnus-Gille/heimdall#(monitor new timers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)