### PR TITLE
docs: record auto-update system (scripts table + STATUS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,5 @@ No service code lives here — each component has its own repo.
 | `scripts/deploy.sh` | Deploy services to Pi hosts (all or selective) | `make deploy` or `make deploy ARGS="munin-memory"` |
 | `scripts/generate-architecture.sh` | Generate deployment snapshot + full-architecture.md | `make docs` (Pi only) |
 | `scripts/security-scan.sh` | Scan all repos for vulnerabilities and secrets | `make security` |
+| `scripts/setup-host-patching.sh` | Install/refresh `unattended-upgrades` (security-only, no auto-reboot) on all Pi hosts | `make patching` (`ARGS="--dry-run"`) |
+| `scripts/maintenance-report.sh` | OS patch-status + npm-outdated reports → Munin + Telegram (timers `grimnir-maintenance-os` daily, `grimnir-maintenance-deps` weekly) | `make maintenance-os` / `make maintenance-deps` |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,39 +1,44 @@
 # Grimnir System — Status
 
-**Last session:** 2026-04-11
+**Last session:** 2026-06-16
 **Branch:** main
 
-## Completed This Session
+## Completed This Session (2026-06-15 → 16)
 
-### Pi grimnir repo drift — fixed
-- Pi's `/home/magnus/repos/grimnir` was 29 commits behind `origin/main` with a pile of uncommitted modifications and untracked files
-- Verified every local change was stale echo of origin before touching anything:
-  - Tracked modifications were either byte-identical to origin (Makefile, scripts/security-scan.sh) or older versions of files origin had since rewritten
-  - Untracked files (services.json, scripts/deploy.sh, scripts/lib/registry.js, docs/scheduled-tasks.md, systemd/grimnir-validate.*) were byte-identical to origin — leftover from a pre-commit manual copy
-  - services.json was the only outlier — older, missing the verdandi block
-  - `git log origin/main..HEAD` empty; reflog's only local commit (`4d30000`, SCION plan) reachable from origin
-- Cleaned the conflicting files, discarded stale tracked modifications via `git checkout -- .`, fast-forwarded from `a3818b9` to `c6d54b0`
-- `.claude/` preserved (not touched)
-- Root cause not diagnosed — grimnir-validate.timer is supposed to catch drift like this, but didn't surface it; possibly the timer isn't installed on the Pi yet (it was listed as an open next-step from the 2026-04-01 session)
+### Automated software-update system — built, Codex-reviewed, merged, live
+- Closed the gap where nothing kept software updated on the two Pis or the laptop.
+- **grimnir PR #26** (squash `fa66789`) + **heimdall PR #21** (squash `46cb6f9`) merged;
+  both re-deployed from `main` so `.deployed-commit` matches HEAD (no Heimdall drift).
+- Survived a **4-round Codex (gpt-5.5 xhigh) cross-model review** (7 → 4 → 1 → 2 findings, all fixed).
+- Mechanisms now running:
+  - `unattended-upgrades` (security-archive only, **no auto-reboot**) on **both** Pis; `needrestart`
+    provides the reboot-required flag (Debian 13 dropped update-notifier-common). 12 pending
+    security updates were applied during deploy; 0 remaining.
+  - `grimnir-maintenance-os.timer` (daily 07:00) — pending security / reboot-required / disk for
+    both hosts (SSHes to nas) → Munin `maintenance/os/*` + Telegram on action-needed.
+    **First autonomous run fired 2026-06-16 07:04, confirmed in Munin.**
+  - `grimnir-maintenance-deps.timer` (weekly Mon 02:10) — `npm outdated` across all service repos →
+    Munin `maintenance/deps/*`. **Detect+report only** (per auto-ops debate — never blind auto-bump).
+  - Laptop `com.magnusgille.brew-update` LaunchAgent (weekly Sun 11:00) — formulae auto-upgrade,
+    casks notify, reports via a Tailscale-fallback SSH-hop (mDNS flaky under launchd).
+- **Infra fix:** `deploy.sh` gained a timer-install branch — timer-only components (grimnir, skuld)
+  now auto-install + `enable --now` their units (previously installed entirely by hand). This also
+  addresses the long-standing "verify grimnir-validate.timer installed" concern.
+- Shared `scripts/lib/munin.sh` + `lib/notify.sh`; new make targets `patching` / `maintenance-os` /
+  `maintenance-deps`; apt config in `host-config/apt/`, laptop job in `host-config/laptop/`.
+- Munin: `decisions/auto-updates`, `projects/grimnir` logs updated.
 
-### Prior session context (2026-04-09)
-- Ecosystem review plan committed at `docs/ecosystem-review-plan.md`, tracking issue grimnir#7, plan stress-tested via Codex debate
-- Debate corpus now tracked in git via upgraded gitignore
-- Debate-codex skill updated with new default git-handling pattern
-
-## Next Steps
-
-0. **Verify grimnir-validate.timer is installed on the Pi** — if it's missing, drift can reach 29+ commits unseen. Check `systemctl list-timers | grep grimnir-validate` on huginmunin. If absent, `systemctl enable --now grimnir-validate.timer` via deploy.
-1. **Step 0 — Write cross-service contracts section in `docs/architecture.md`** (grimnir#7). This blocks everything else in the ecosystem review program. Named contracts, named owners per contract, regression matrix, evolution rules.
-2. **Phase A — Integration fixes** (2-3 sessions). MuninClient copy for Ratatoskr, CommonJS adapter for Heimdall, Skuld interface wrap, three contract tests, per-file contract ownership comments.
-3. **Phase B — Targeted `/security-review`** (3 sessions, concurrent with A). munin-memory first (sharded), ratatoskr next, hugin after Phase A #1 stabilizes. Draft `docs/threat-model.md` afterward.
-4. **Phase C — Minimum CI floor** (1 session, conditional). Only if Phase A tests aren't already catching drift.
-5. Review OpenClaw research spike results (`tasks/20260407-203751-openclaw-vs-grimnir`)
-6. **heimdall#7** — Boot health check
-7. **hugin#26** — Plan autonomous dependency bump workflow
-8. **grimnir#5** — Plan doc drift detection
-9. **Hugin security hardening** — issues #7–#13
-10. **UPS for both Pis** — grimnir#4
+## Next Steps (carried over — ecosystem review program)
+1. **grimnir#7** — cross-service contracts section in `docs/architecture.md` (blocks integration work)
+2. **Phase A — Integration fixes** — MuninClient copy for Ratatoskr, CommonJS adapter for Heimdall,
+   Skuld interface wrap, three contract tests, per-file contract ownership comments
+3. **Phase B — Targeted `/security-review`** — munin-memory → ratatoskr → hugin; draft `docs/threat-model.md`
+4. **hugin#26** — autonomous dependency bump (note: the **detect+report** half now exists via
+   `grimnir-maintenance-deps`; the auto-bump half is still deliberately deferred)
+5. **grimnir#5** — doc drift detection
+6. **review-pr-codex skill** — fix the prereq check: it bails on missing `OPENAI_API_KEY` even when
+   Codex is authenticated via ChatGPT sign-in (caused both review subagents to abort on first try)
+7. **UPS for both Pis** — grimnir#4
 
 ## Blockers
 - None


### PR DESCRIPTION
Post-merge bookkeeping for #26: adds `setup-host-patching.sh` + `maintenance-report.sh` to the CLAUDE.md scripts table and refreshes STATUS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)