### PR TITLE
feat: add infrastructure/inference-node inventory to services.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ What's here:
 - **[docs/architecture.md](docs/architecture.md)** — Full system architecture (topology, components, security, data flow)
 - **[docs/conventions.md](docs/conventions.md)** — Naming, ports, service patterns, GitHub ownership
 - **[docs/vision.md](docs/vision.md)** — Where the project is heading
-- **[services.json](services.json)** — Single source of truth for component inventory
+- **[services.json](services.json)** — Single source of truth for the component inventory (`components`) and the infrastructure/inference-node inventory (`nodes` — hosts, hardware, role, LLM servers). Query via `scripts/lib/registry.js` (`QUERY=nodes`).
 - **[scripts/](scripts/)** — Deploy, security scan, and architecture generation scripts
 
 ## Design principles

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -12,6 +12,8 @@
 //   validate     — host-aware output for validation: name|host|port|units_json per line
 //   json:<field>=<value> — filter by field, output full JSON array
 //   all          — full JSON array of all components
+//   nodes        — infra/inference hosts (data.nodes): name|hostname|ssh_alias|role|status|llm|monitor per line
+//   nodes-json   — full JSON array of all nodes (data.nodes)
 
 var fs = require('fs');
 var path = require('path');
@@ -110,6 +112,27 @@ switch (query) {
     process.stdout.write(JSON.stringify(components) + '\n');
     break;
   }
+  case 'nodes': {
+    // Infra/inference hosts — a peer concept to components. Guarded so older
+    // services.json files without a "nodes" key still work (empty output).
+    var nodes = Array.isArray(data.nodes) ? data.nodes : [];
+    nodes.forEach(function (n) {
+      var llm = (n.llm_servers || [])
+        .map(function (s) { return s.type + ':' + s.port; })
+        .join(',') || '-';
+      var hostname = n.hostname || '';
+      var sshAlias = n.ssh_alias || '';
+      var monitor = n.monitor ? 'true' : 'false';
+      process.stdout.write(
+        n.name + '|' + hostname + '|' + sshAlias + '|' + n.role + '|' + n.status + '|' + llm + '|' + monitor + '\n'
+      );
+    });
+    break;
+  }
+  case 'nodes-json': {
+    process.stdout.write(JSON.stringify(Array.isArray(data.nodes) ? data.nodes : []) + '\n');
+    break;
+  }
   default: {
     // json:<field>=<value> — filter and return JSON
     var match = query.match(/^json:(\w+)=(.+)$/);
@@ -123,7 +146,7 @@ switch (query) {
       process.stdout.write(JSON.stringify(filtered) + '\n');
     } else {
       process.stderr.write('ERROR: Unknown query: ' + query + '\n');
-      process.stderr.write('Valid queries: deploy, scan, components, systemd, ports, all, json:<field>=<value>\n');
+      process.stderr.write('Valid queries: deploy, scan, components, systemd, ports, validate, all, nodes, nodes-json, json:<field>=<value>\n');
       process.exit(1);
     }
   }

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -117,14 +117,17 @@ switch (query) {
     // services.json files without a "nodes" key still work (empty output).
     var nodes = Array.isArray(data.nodes) ? data.nodes : [];
     nodes.forEach(function (n) {
-      var llm = (n.llm_servers || [])
-        .map(function (s) { return s.type + ':' + s.port; })
+      var llm = (Array.isArray(n.llm_servers) ? n.llm_servers : [])
+        .map(function (s) { return (s.type || '') + ':' + (s.port || ''); })
         .join(',') || '-';
+      var name = n.name || '';
       var hostname = n.hostname || '';
       var sshAlias = n.ssh_alias || '';
+      var role = n.role || '';
+      var status = n.status || '';
       var monitor = n.monitor ? 'true' : 'false';
       process.stdout.write(
-        n.name + '|' + hostname + '|' + sshAlias + '|' + n.role + '|' + n.status + '|' + llm + '|' + monitor + '\n'
+        name + '|' + hostname + '|' + sshAlias + '|' + role + '|' + status + '|' + llm + '|' + monitor + '\n'
       );
     });
     break;

--- a/services.json
+++ b/services.json
@@ -119,5 +119,82 @@
         { "name": "verdandi", "type": "service", "scope": "user" }
       ]
     }
+  ],
+  "nodes": [
+    {
+      "name": "huginmunin",
+      "hostname": "huginmunin.local",
+      "ssh_alias": null,
+      "hardware": "Raspberry Pi (aarch64), 8GB",
+      "role": "service-host",
+      "status": "active",
+      "llm_servers": [
+        { "type": "ollama", "port": 11434, "protocol": "ollama" }
+      ],
+      "monitor": true,
+      "notes": "Primary service host — runs munin-memory, hugin, heimdall, ratatoskr, skuld, grimnir, verdandi. Also Ollama :11434 for tiny models (qwen3.5:2b, gemma4:e2b)."
+    },
+    {
+      "name": "nas",
+      "hostname": "nas.local",
+      "ssh_alias": null,
+      "hardware": "NAS",
+      "role": "storage",
+      "status": "active",
+      "llm_servers": [],
+      "monitor": true,
+      "notes": "Runs mimir (authenticated file server). Not an inference node."
+    },
+    {
+      "name": "bosgame",
+      "hostname": null,
+      "ssh_alias": null,
+      "hardware": "BosGame M5 — AMD Strix Halo (Ryzen AI Max+ 395), 128GB unified memory",
+      "role": "inference",
+      "status": "planned",
+      "llm_servers": [
+        { "type": "homeserver-gateway", "port": 8080, "protocol": "openai" }
+      ],
+      "monitor": false,
+      "notes": "Flagship local inference — NOT YET ARRIVED. homeserver gateway :8080 fronts LM Studio :1234; Cloudflare Tunnel for external access. hostname/ssh alias TBD on arrival. See home-server-inference-evaluation docs/adr-004-m5-routing-ownership.md + docs/bosgame-m5-architecture.md."
+    },
+    {
+      "name": "orin",
+      "hostname": null,
+      "ssh_alias": "orin",
+      "hardware": "NVIDIA Jetson Orin Nano, 8GB",
+      "role": "inference",
+      "status": "active",
+      "llm_servers": [
+        { "type": "ollama", "port": 11434, "protocol": "ollama" }
+      ],
+      "monitor": false,
+      "notes": "Hugin GPU cell (orinUrl). Only ~3B fits (qwen2.5-coder:3b; 4B OOMs). Live state unverified 2026-06-16 (SSH needs FIDO2 key) — Ollama at :11434, ~192.168.0.230."
+    },
+    {
+      "name": "laptop",
+      "hostname": null,
+      "ssh_alias": null,
+      "hardware": "MacBook Air M4, 32GB unified memory",
+      "role": "inference",
+      "status": "active",
+      "llm_servers": [
+        { "type": "lmstudio", "port": 1234, "protocol": "openai" },
+        { "type": "ollama", "port": 11434, "protocol": "ollama" }
+      ],
+      "monitor": false,
+      "notes": "Not always-on (medium compute, intermittent). Hugin laptopUrl (disabled by default). Local LM Studio :1234 + Ollama :11434."
+    },
+    {
+      "name": "skald",
+      "hostname": "skald.local",
+      "ssh_alias": "skald",
+      "hardware": "Raspberry Pi + e-paper display",
+      "role": "display",
+      "status": "active",
+      "llm_servers": [],
+      "monitor": false,
+      "notes": "E-paper display / skald-display MCP node — NOT an inference node. Back online 2026-06-16."
+    }
   ]
 }


### PR DESCRIPTION
## What

`services.json` modelled only deployable Node **services** (`components`). The inference **hosts** — the imminent **BosGame M5** (AMD Strix Halo, 128GB), plus Orin, the laptop, skald, the Pi, and the NAS — had no representation, so the flagship node would get zero deploy/scan/patch/monitoring coverage and the fleet inventory lived in 3 disagreeing places (services.json vs hugin `ollama-hosts.ts` vs `heimdall.config.json`).

- Adds a **peer top-level `"nodes"` array** (deliberately *not* shoehorned into `components` — a Strix Halo box is not a deployable service). Each node: `hostname`, `ssh_alias`, `hardware`, `role` (`inference`/`display`/`storage`/`service-host`), `status`, `llm_servers[{type,port,protocol}]`, `monitor`, `notes`.
- Adds `QUERY=nodes` (pipe-delimited) + `QUERY=nodes-json` to `registry.js`, both guarded with `Array.isArray(data.nodes)` so older files still work.

## Why zero-impact
`registry.js` reads only `data.components` and ignores unknown top-level keys. Verified the existing queries are byte-identical after the change: **deploy=8, scan=8, components=9**; `nodes` emits the 6 hosts; `nodes-json` parses to 6 entries.

## Scope
Follow-up #3 of `home-server-inference-evaluation` ADR-004. The heimdall/hugin reconcile (have them derive/cross-check from this inventory) is a real coupling change, tracked separately — **not** in this PR. `skald` is correctly tagged `role: display` (e-paper MCP node, not inference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)