### PR TITLE
docs: re-center vision on sovereign substrate + sync architecture to reality

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # The Grimnir System — Architecture Guide
 
 > Internal reference document for the Grimnir personal AI infrastructure.
-> Last updated: 2026-04-07.
+> Last updated: 2026-06-29.
 
 ---
 
@@ -39,7 +39,7 @@ Three principles guide every decision:
 | **Verdandi** | Tamper-evident audit log | 3036 | Pi 1 | `verdandi` |
 | **Mimir** | Authenticated file server | 3031 | Pi 2 (NAS) | `mimir` |
 | **noxctl** | Accounting CLI + MCP | — | Laptop (global) | `fortnox-mcp` |
-| **Home-server gateway** | Local-inference gateway + micro-orchestrator | 8080 | BosGame M5 *(awaiting hw)* | `home-server-inference-evaluation` |
+| **Home-server gateway** | Local-inference gateway + micro-orchestrator | 8080 | BosGame M5 (`inference.gille.ai`, live) | `home-server-inference-evaluation` |
 
 ---
 
@@ -329,6 +329,10 @@ Hugin is the system's hands. It polls Munin for pending tasks, spawns AI runtime
 - **Framework:** Express (health endpoint only)
 - **Deployment:** systemd on Pi 1, co-located with Munin
 - **Integration:** Munin HTTP API via JSON-RPC 2.0
+- **Agent loop:** the in-process Claude runtime is the **Claude Agent SDK** (`@anthropic-ai/claude-agent-sdk`, `sdk-executor.ts`) — Hugin no longer shells out to `claude -p`. Codex still runs as a subprocess (`codex exec`).
+- **Multi-runtime:** a `runtime-registry.ts` + `router.ts` select per task between the Agent SDK, local **Ollama** (`ollama-executor.ts`), **OpenRouter** (`openrouter-client.ts`), and the **M5 home-server** (`homeserver-executor.ts`), with fallback to Claude on local-infra failure.
+
+> **Repo note:** `hugin` is the deployed service. `hugin-orchestrator` is a feature line (broker + workflow expansion) that should either land back into `hugin` or formally supersede it — two repos for one service is drift risk. `hugin-munin` is an archived bootstrap/reference scaffold, not a running service.
 
 ### The poll-claim-execute-report lifecycle
 
@@ -361,12 +365,24 @@ sequenceDiagram
 
 ### Execution model
 
-- **One task at a time** — no parallelism. Simplicity over throughput.
+- **One task at a time** — the poll loop claims and runs a single task at a time. Simplicity over throughput. (Multi-step *pipelines* fan out within a single claimed task; see below.)
 - **Compare-and-swap claiming** — uses Munin's `expected_updated_at` to prevent double-claiming.
 - **Output capture** — ring buffer keeps the last 50,000 characters of combined stdout/stderr. Full output also streamed to per-task log files in `~/.hugin/logs/`.
 - **Timeout handling** — SIGTERM after configured timeout, SIGKILL after an additional 10 seconds.
 - **Stale task recovery** — on startup, scans for `running` tasks; marks as `failed` if elapsed time exceeds 2x timeout.
 - **Graceful shutdown** — SIGTERM forwarded to child process with 30-second grace period.
+
+### Pipelines (multi-step task graphs)
+
+Beyond single prompts, Hugin compiles declarative multi-step work into a DAG and executes it: `pipeline-compiler.ts` → `pipeline-ir.ts` / `task-graph.ts` → `pipeline-dispatch.ts`, with `pipeline-gates.ts` enforcing inter-step conditions and `pipeline-summary-manager.ts` rolling up results. This is the structured successor to the older `Group`/`Sequence` FIFO sub-task fields — it lets one submitted task expand into a routed, gated, multi-runtime chain.
+
+### Delegation broker (cloud-side)
+
+`src/broker/` exposes an HTTP delegation API (`server.ts`, `handlers.ts`) so a cloud Claude session can hand Hugin a bounded sub-task without writing a Munin task by hand. It carries idempotency keys (`idempotency.ts`), a durable journal (`journal.ts`), reconciliation (`reconciliation.ts`), and its own OpenRouter executor — this is the `orchestrator-v1` broker behind the `/delegate` skill.
+
+### Safety gating
+
+Because Hugin runs untrusted prompts against real credentials and the tailnet, every task passes a gating layer: `prompt-injection-scanner.ts`, `exfiltration-scanner.ts`, `egress-policy.ts`, a `privacy-filter/`, content `sensitivity.ts` classification, plus `task-signing.ts` / `provenance.ts` for attribution. This is the harness-level analogue of Verdandi's redact-before-persist and Munin's secret-scan.
 
 ### Task schema
 
@@ -413,7 +429,7 @@ Tags: ["pending", "runtime:claude", "type:code"]
 
 ## Home-server (M5) — Local Inference
 
-The BosGame M5 is a dedicated local-inference node (awaiting delivery). It runs the **home-server gateway** (`home-server-inference-evaluation` repo, port 8080) — an authenticated, OpenAI-compatible front door to locally-served models, plus a deterministic micro-orchestrator and a capability ledger.
+The BosGame M5 is a dedicated local-inference node, **live** at `inference.gille.ai` (public, Cloudflare) and on the tailnet (`m5`, port 8080). It runs the **home-server gateway** (`home-server-inference-evaluation` repo) — an authenticated, OpenAI-compatible front door to locally-served models (llama-swap on `:8091` loopback), plus a deterministic micro-orchestrator and a capability ledger. It is registered as the `m5` MCP server (`ask` / `list_models`) and is the target of Hugin's local-runtime offload.
 
 ### Routing ownership (ADR-004)
 
@@ -427,7 +443,7 @@ The BosGame M5 is a dedicated local-inference node (awaiting delivery). It runs 
 
 ### Why a dedicated node
 
-Offload the bulk of agentic sub-task tokens (classification, extraction, summarize, rewrite, short reasoning) to local models, keeping a frontier orchestrator for planning and escalation. Economics, model roster, and per-task viability are tracked in the home-server evaluation project. Until the M5 arrives, the gateway, ledger, improve-loop, and routing contract are validated against LM Studio on the MacBook Air (a "hosted-proxy / local upper bound").
+Offload the bulk of agentic sub-task tokens (classification, extraction, summarize, rewrite, short reasoning) to local models, keeping a frontier orchestrator for planning and escalation. Economics, model roster, and per-task viability are tracked in the home-server evaluation project, whose **offloadability trend** (which task types local models can be trusted with) now publishes nightly to a Heimdall panel — the data-grounded feedback loop that drives routing decisions.
 
 ---
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,70 +1,129 @@
 # Grimnir — Vision
 
-> **DRAFT v0.1** — 2026-03-28. This document is a working draft.
-> It captures direction, not commitments.
+> **DRAFT v0.2** — 2026-06-29 (supersedes v0.1, 2026-03-28).
+> Captures direction, not commitments. Companion to `architecture.md` (the *how*);
+> this is the *why* and the *what-not-to-build*.
 
 ---
 
-## North Star
+## The thesis
 
-Grimnir is an autonomous collaborator that improves itself and does useful work — both when prompted and on its own.
+**Grimnir is a sovereign, self-knowing personal-AI substrate that any agent can safely act through.**
 
-It starts by maintaining its own infrastructure. It graduates to doing real work: client deliverables, consulting output, business operations. The end state is a system that Magnus trusts to act independently on things that matter.
+The substrate is the identity. The agent — the loop, the channels, the model — is a replaceable tenant. The market is pouring foundation-scale effort into that tenant layer (OpenClaw, nanoclaw, Hermes, the Claude Agent SDK) and commoditizing it toward zero. Racing there is a losing game and an unnecessary one.
 
-## Founding Principles
+As frontier models and agent harnesses both commoditize, the only scarce, personal, non-replicable assets left are *your* memory, *your* files, *your* accountability record, and *your* learned model of what to route where. **Grimnir owns that substrate and lets any agent plug into it.**
+
+The older "autonomous collaborator" framing (v0.1) isn't wrong — it's the *roadmap of what Grimnir does* (see The Arc). But it isn't the *identity*. The identity is the substrate; autonomy is a capability that rides on top of it.
+
+---
+
+## The two protected pillars
+
+These are the things Grimnir builds and never outsources. Everything else is a tenant.
+
+### Pillar 1 — Sovereign Memory
+*Munin (memory) · Mimir (files) · Verdandi (audit).*
+
+Your data, your documents, and a tamper-evident record of what was done with them — on your hardware, auth at every layer, secrets scanned before persistence. The asset that cannot be bought back, shared by every environment (CLI, desktop, web, mobile, Telegram).
+
+### Pillar 2 — Self-Knowing Inference
+*M5 home-server gateway · capability ledger · offloadability eval.*
+
+A system that *learns what it can trust cheaper compute with* and routes accordingly — data-grounded, not assumed. No external harness has this; it is Grimnir's most original idea, and a first-class pillar — not a side-experiment.
+
+---
+
+## The decision rule
+
+> **Build only what touches Memory or Inference-routing. Reuse everything in the harness layer — provided it is open-source and plugs into Munin + the gateway.**
+
+This replaces case-by-case "build vs buy" judgement. Ask one question: *does this touch a pillar?*
+
+- **No** → reuse the best open-source option (the Claude Agent SDK today; a nanoclaw-style ingress tomorrow). Keep our own code small.
+- **Yes** → build it, because it compounds personally and cannot be reacquired.
+
+### Applied to the harness (Hugin)
+
+Hugin is capped as an agent *platform* and deepened as the **policy-and-routing gateway to the sovereign core**:
+
+| Concern | Pillar? | Stance |
+|---|---|---|
+| Agent loop | tenant | Reuse the Claude Agent SDK — never hand-roll |
+| Channels | tenant | Cap (Telegram is enough); reuse ingress for more |
+| Sub-agent fan-out | tenant | Borrow proven patterns; don't invent |
+| Capability routing | **Inference** | **Deepen** — make it ledger-driven |
+| Safety gating | **Memory** | **Own** — it makes tenants safe against our data |
+| Munin task semantics | **Memory** | Keep — substrate glue |
+
+---
+
+## Founding principles
 
 ### Sovereignty
-All data lives on Magnus's hardware. Cloud AI services are stateless tools — they process but don't store. The Pis hold the database, the files, and the backups. This is non-negotiable.
+All data lives on Magnus's hardware. Cloud AI services are stateless tools — they process but don't store. The Pis and the M5 hold the database, the files, the ledger, and the backups. Non-negotiable.
 
 ### Privacy
-Auth is required at every layer. Secrets are scanned before storage. Sensitive documents get summaries in memory but full text stays on the Pi.
+Auth at every layer. Secrets scanned before storage. Sensitive documents get summaries in memory; full text stays on the box.
 
-### Simplicity
-Each service is single-purpose. No heavy frameworks. SQLite for storage. systemd for process management. If it can't run on a Raspberry Pi, it's too complex.
+### Minimal surface, deep where it must be
+*(Revised from v0.1's "Simplicity.")* Most components stay single-purpose and small — SQLite, systemd, no heavy frameworks. But the harness/routing core (Hugin, the gateway) is allowed real depth, because that is where safety and capability-routing live. The discipline is not "always simple"; it is "small everywhere we can, complex only at the two pillars, and never complex by accident."
 
-### Autonomous improvement by design
-Every component should have a measurable signal it can optimize toward. Autonomous improvement is not a feature bolted on later — it is a structural property of every service we build. When designing a new capability, the question is always: *"What signal tells us this is working well, and how could the system use that signal to get better on its own?"*
+### Self-knowing by design *(Pillar 1, as a build principle)*
+> **Every component should emit evidence of its own competence, and decisions should be made from that evidence rather than from assumption.**
+
+The ledger does this for model routing. The same shape applies to runtime selection, to which tasks are safe to auto-run, and to which of our own services are earning their keep. Instrument first; let the data say what to keep, cut, or route. `docs/observability-and-improvement.md` is the operational home of this principle.
+
+### Cut bloat continuously
+Capability that isn't earning its place — empty repos, duplicate services, stale experiments — is removed, not preserved out of sentiment. A smaller, sharper system is the goal, not a larger one. (Standing cut list: merge `hugin-orchestrator` into `hugin`; archive `hugin-munin`; delete `meta-agent` and `agentic-eval`; converge or retire `agent-council`.)
+
+---
 
 ## The Arc
 
-### Phase 1: Reactive (largely complete)
-*"Tell Grimnir to do X and go to sleep."*
+The substrate is what Grimnir *is*. The Arc is what it progressively *does* on top — the autonomy roadmap. Each phase rides on the two pillars; none of it replaces them.
 
-Memory, files, task dispatch, monitoring, briefings, mobile access. The system does what it's told and reports back. Human initiates everything.
+### Phase 1: Reactive (largely complete)
+*"Tell Grimnir to do X and go to sleep."* Memory, files, task dispatch, monitoring, briefings, mobile access. Human initiates everything.
 
 ### Phase 2: Self-maintaining
-*"Grimnir keeps itself healthy without being asked."*
-
-The system notices when dependencies are outdated and upgrades them. It detects failing health checks and investigates. It spots patterns in its own data and proposes optimizations. It identifies documentation drift and fixes it.
-
-Human still sets direction. Grimnir handles upkeep.
+*"Grimnir keeps itself healthy without being asked."* Notices outdated dependencies and upgrades them; investigates failing health checks; spots patterns in its own data; fixes documentation drift. Human sets direction; Grimnir handles upkeep.
 
 ### Phase 3: Proactive collaborator
-*"Grimnir does useful work on its own."*
-
-The system identifies work worth doing — from project context, client commitments, calendar, financial data — and either does it or proposes it. It drafts, it researches, it prepares. Magnus reviews output, not input.
+*"Grimnir does useful work on its own."* Identifies work worth doing — from project context, client commitments, calendar, financials — and does or proposes it. Magnus reviews output, not input.
 
 ### Phase 4: Trusted autonomous agent
-*"Grimnir acts independently on things that matter."*
-
-Client deliverables. Business operations. Consulting output. The system has earned enough trust through phases 1-3 that it can take meaningful action without prior approval on a growing set of domains.
-
-## Open Questions
-
-These are not gaps to fill before starting — they are questions that can only be answered through experience with the system.
-
-### Trust model
-At what point should Grimnir act without asking? What guardrails prevent it from doing something irreversible and wrong? The current model requires explicit human initiation (submit a task) or human-in-the-loop (Ratatoskr clarifies intent). The right trust model will emerge from accumulated evidence of reliability across phases 1-3 — not from upfront design.
-
-### Signal design
-What are the right optimization signals for each component? Some are obvious (task success rate, query latency). Others are harder (did the briefing change Magnus's behavior? was the autonomous fix correct?). Getting signals wrong could optimize for the wrong thing.
-
-### Scope boundaries
-Where does Grimnir stop? Should it touch client-facing communication directly, or always draft for review? Should it have access to financial systems beyond read-only? These boundaries will shift as trust accumulates.
-
-### Failure recovery
-When Grimnir acts autonomously and gets it wrong, what happens? The system needs to be able to undo its own mistakes, or at minimum make them visible before they propagate. This is prerequisite for phases 3-4.
+*"Grimnir acts independently on things that matter."* Client deliverables, business operations, consulting output — meaningful action without prior approval on a growing set of domains, earned through phases 1-3.
 
 ---
 
-*Built by Magnus Gille, with Claude and Codex. Running on two Raspberry Pis in Mariefred, Sweden.*
+## What this is *not*
+
+- Not an agent framework competing with OpenClaw/Hermes/nanoclaw — we are a tenant of that ecosystem, not a rival.
+- Not a cloud-token product — the opposite thesis (everything on our hardware).
+- Not a maximalist constellation of services — each component earns its place or is consolidated away.
+
+---
+
+## Open questions
+
+Answerable only through experience with the system, not upfront design.
+
+### Trust model
+At what point should Grimnir act without asking? What guardrails prevent an irreversible, wrong action? The right model emerges from accumulated evidence of reliability across phases 1-3.
+
+### Signal design
+What are the right optimization signals per component? Some are obvious (task success rate, latency); others are hard (did the briefing change behavior? was the autonomous fix correct?). Getting signals wrong optimizes for the wrong thing.
+
+### Reuse boundaries
+Which open-source harness do we actually adopt for ingress/loop when we outgrow Telegram-only (nanoclaw fork vs. OpenClaw-as-ingress vs. status quo)? The decision rule says *reuse* — but which, and how does it plug into Munin + the gateway without leaking sovereignty?
+
+### Scope boundaries
+Where does Grimnir stop? Draft-for-review vs. direct client communication? Read-only vs. write access to financial systems? Boundaries shift as trust accumulates.
+
+### Failure recovery
+When Grimnir acts autonomously and gets it wrong, what happens? It must undo its own mistakes, or at least make them visible before they propagate — prerequisite for phases 3-4.
+
+---
+
+*Built by Magnus Gille, with Claude and Codex. Running on two Raspberry Pis and a BosGame M5 in Mariefred, Sweden.*


### PR DESCRIPTION
## What

Re-centers `docs/vision.md` (v0.1 → v0.2) and corrects `docs/architecture.md` to match the deployed reality.

### Vision (v0.2)
- Leads with the thesis: **Grimnir is a sovereign, self-knowing personal-AI substrate that any agent can safely act through** — the substrate is the identity, the agent is a replaceable tenant.
- **Two protected pillars:** Sovereign Memory (Munin/Mimir/Verdandi) and Self-Knowing Inference (M5 gateway + capability ledger + offloadability eval).
- **Decision rule:** build only what touches a pillar; reuse the harness layer when it's open-source and plugs into Munin + the gateway.
- Hugin cap/deepen table; "Simplicity" → "minimal surface, deep where it must be"; self-knowing elevated as a build principle; standing cut-bloat list.
- **Preserved** the 4-phase Arc and Open Questions, reframed as what Grimnir *does* on top of the substrate.

### Architecture (sync to reality)
- Hugin: Claude Agent SDK + multi-runtime router + pipeline DAGs + delegation broker + safety scanners — no longer "spawns `claude -p`".
- M5 marked **live** at `inference.gille.ai` (was "awaiting hardware"); offloadability trend → Heimdall noted.
- Flags `hugin` / `hugin-orchestrator` repo drift.

## Why
Audit against external agent harnesses (nanoclaw / OpenClaw / Hermes-agent) showed the harness layer is commoditizing fast and not worth racing — Grimnir's moat is the substrate those products treat as plumbing.

## Provenance
Decision recorded in Munin `decisions/grimnir-vision`. Cross-repo cleanup (the cut-bloat list) is filed separately as a hugin issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)