### PR TITLE
feat(security-scan): delta-aware Telegram alert on escalated findings (#21)

### DIFF
--- a/scripts/lib/escalation.sh
+++ b/scripts/lib/escalation.sh
@@ -1,26 +1,77 @@
 # shellcheck shell=bash
-# escalation.sh — pure escalation check for the security scanner.
+# escalation.sh — pure, testable helpers for the security scanner's delta path.
 #
 # scan_escalated prev_crit prev_high prev_secrets cur_crit cur_high cur_secrets
 #   echoes "yes" if any current finding-count exceeds the previous snapshot,
 #   else "no".
 #
+# parse_prev_counts  (reads a Munin memory_read response on stdin)
+#   echoes "<crit>\t<high>\t<secrets>\t<status>" where status is:
+#     ok          — a valid JSON-RPC result envelope was present and the counts
+#                   are trusted integers (genuine first run with no prior scan
+#                   also yields "0 0 0 ok")
+#     unavailable — RPC failure / sentinel "{}" / malformed or poisoned shape;
+#                   the caller MUST NOT treat the zeros as a real baseline.
+#
 # Sourced by both security-scan.sh and the delta unit test so the logic has a
-# single definition. bash 3.2+.
+# single definition. bash 3.2+ (parsing delegated to node).
+
+# Coerce a value to a safe base-10 integer string, or "0" if not a plain 1–9
+# digit number. Rejects non-numeric, leading-zero/octal (08, 09), and overlong
+# values before they can reach bash arithmetic ([[ -gt ]] evaluates operands
+# arithmetically; a poisoned multi-writer Munin record must never get there).
+_escal_int() {
+  if [[ "$1" =~ ^[0-9]{1,9}$ ]]; then
+    printf '%s' "$((10#$1))"
+  else
+    printf '%s' 0
+  fi
+}
 
 scan_escalated() {
-  local prev_c="$1" prev_h="$2" prev_s="$3" cur_c="$4" cur_h="$5" cur_s="$6" v
-  # Coerce every argument to an integer BEFORE the `[[ -gt ]]` comparison.
-  # `[[ a -gt b ]]` evaluates its operands as arithmetic, so a non-numeric value
-  # from a poisoned multi-writer Munin record (e.g. `a[$(cmd)]`) would otherwise
-  # trip `set -u` ("unbound variable") and abort the scan — or, on a shell
-  # without nounset, reach arithmetic evaluation. Never let untrusted data in.
-  for v in prev_c prev_h prev_s cur_c cur_h cur_s; do
-    [[ "${!v}" =~ ^[0-9]+$ ]] || printf -v "$v" '%s' 0
-  done
+  local prev_c prev_h prev_s cur_c cur_h cur_s
+  prev_c="$(_escal_int "$1")"; prev_h="$(_escal_int "$2")"; prev_s="$(_escal_int "$3")"
+  cur_c="$(_escal_int "$4")";  cur_h="$(_escal_int "$5")";  cur_s="$(_escal_int "$6")"
   if [[ "$cur_c" -gt "$prev_c" ]] || [[ "$cur_h" -gt "$prev_h" ]] || [[ "$cur_s" -gt "$prev_s" ]]; then
     echo "yes"
   else
     echo "no"
   fi
+}
+
+parse_prev_counts() {
+  # shellcheck disable=SC2016  # single-quoted node program — no bash expansion
+  node --input-type=commonjs -e '
+    var d;
+    try { d = JSON.parse(require("fs").readFileSync("/dev/stdin", "utf8")); }
+    catch (e) { process.stdout.write("0\t0\t0\tunavailable"); process.exit(0); }
+    // No JSON-RPC result envelope => RPC failed / sentinel "{}" => unavailable.
+    if (!d || !d.result || !Array.isArray(d.result.content)) {
+      process.stdout.write("0\t0\t0\tunavailable"); process.exit(0);
+    }
+    var first = d.result.content[0];
+    var text = (first && typeof first.text === "string") ? first.text : "";
+    var m = text.match(/```json\s*([\s\S]*?)```/);
+    // Envelope present but no prior-scan content => genuine first run.
+    if (!m) { process.stdout.write("0\t0\t0\tok"); process.exit(0); }
+    var obj;
+    try { obj = JSON.parse(m[1]); }
+    catch (e) { process.stdout.write("0\t0\t0\tunavailable"); process.exit(0); }
+    // Strict integer: JSON number or all-digit string, bounded. parseInt-style
+    // leniency ("999junk" -> 999) and a fake {length:N} secrets object must NOT
+    // produce a trusted baseline that could suppress a real escalation.
+    function intOrNull(x) {
+      if (typeof x === "number" && Number.isInteger(x) && x >= 0 && x <= 1e9) return x;
+      if (typeof x === "string" && /^[0-9]{1,9}$/.test(x)) return parseInt(x, 10);
+      return null;
+    }
+    var audit = (obj && typeof obj.audit === "object" && obj.audit) ? obj.audit : {};
+    var c = intOrNull(audit.critical);
+    var h = intOrNull(audit.high);
+    var s = Array.isArray(obj.secrets) ? obj.secrets.length : null;
+    if (c === null || h === null || s === null) {
+      process.stdout.write("0\t0\t0\tunavailable"); process.exit(0);
+    }
+    process.stdout.write(c + "\t" + h + "\t" + s + "\tok");
+  ' 2>/dev/null || printf '%s' "0	0	0	unavailable"
 }

--- a/scripts/lib/escalation.sh
+++ b/scripts/lib/escalation.sh
@@ -1,0 +1,26 @@
+# shellcheck shell=bash
+# escalation.sh — pure escalation check for the security scanner.
+#
+# scan_escalated prev_crit prev_high prev_secrets cur_crit cur_high cur_secrets
+#   echoes "yes" if any current finding-count exceeds the previous snapshot,
+#   else "no".
+#
+# Sourced by both security-scan.sh and the delta unit test so the logic has a
+# single definition. bash 3.2+.
+
+scan_escalated() {
+  local prev_c="$1" prev_h="$2" prev_s="$3" cur_c="$4" cur_h="$5" cur_s="$6" v
+  # Coerce every argument to an integer BEFORE the `[[ -gt ]]` comparison.
+  # `[[ a -gt b ]]` evaluates its operands as arithmetic, so a non-numeric value
+  # from a poisoned multi-writer Munin record (e.g. `a[$(cmd)]`) would otherwise
+  # trip `set -u` ("unbound variable") and abort the scan — or, on a shell
+  # without nounset, reach arithmetic evaluation. Never let untrusted data in.
+  for v in prev_c prev_h prev_s cur_c cur_h cur_s; do
+    [[ "${!v}" =~ ^[0-9]+$ ]] || printf -v "$v" '%s' 0
+  done
+  if [[ "$cur_c" -gt "$prev_c" ]] || [[ "$cur_h" -gt "$prev_h" ]] || [[ "$cur_s" -gt "$prev_s" ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -61,17 +61,10 @@ log_verbose() {
   fi
 }
 
-# scan_escalated — pure escalation check; echoes "yes" or "no".
-# A repo escalated if any tracked severity count increased vs the previous scan.
-# Usage: scan_escalated prev_crit prev_high prev_secrets cur_crit cur_high cur_secrets
-scan_escalated() {
-  local prev_c="$1" prev_h="$2" prev_s="$3" cur_c="$4" cur_h="$5" cur_s="$6"
-  if [[ "$cur_c" -gt "$prev_c" ]] || [[ "$cur_h" -gt "$prev_h" ]] || [[ "$cur_s" -gt "$prev_s" ]]; then
-    echo "yes"
-  else
-    echo "no"
-  fi
-}
+# scan_escalated lives in lib/escalation.sh (shared with the delta unit test).
+# shellcheck source=scripts/lib/escalation.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/escalation.sh"
 
 # Node.js 25+ strips TypeScript by default, misparses object literals
 # in -e scripts. --input-type=commonjs fixes it. Also, complex node
@@ -530,9 +523,12 @@ for repo in $SCAN_COMPONENTS; do
   prev_c=0; prev_h=0; prev_s=0
 
   if [[ "$DRY_RUN" != "true" ]] && [[ -n "$MUNIN_TOKEN" ]]; then
+    # `|| printf '{}'` keeps a node failure from aborting the whole scan under
+    # set -e (this runs before the alert + Munin writes). A '{}' read_args makes
+    # memory_read a no-op, prev counts fall back to 0 → silent, correct.
     read_args="$(REPO_NS="security/repos/${repo}" node --input-type=commonjs -e '
       console.log(JSON.stringify({namespace: process.env.REPO_NS, key: "latest"}))
-    ')"
+    ' 2>/dev/null || printf '%s' '{}')"
     prev_raw="$(munin_tool_call "memory_read" "$read_args" 2>/dev/null || echo "{}")"
     # Parse the embedded ```json block from the Munin response's text content.
     # Response is a JSON-RPC result: {result:{content:[{type:"text",text:"..."}]}}
@@ -548,17 +544,24 @@ for repo in $SCAN_COMPONENTS; do
       var obj = {};
       if (m) { try { obj = JSON.parse(m[1]); } catch(e) {} }
       var audit = obj.audit || {};
+      // Coerce to integers — a non-numeric value here must not flow into bash
+      // arithmetic downstream. parseInt(NaN-ish) -> 0.
+      var n = function (x) { var i = parseInt(x, 10); return Number.isFinite(i) ? i : 0; };
       process.stdout.write(
-        (audit.critical || 0) + "\t" +
-        (audit.high || 0) + "\t" +
+        n(audit.critical) + "\t" +
+        n(audit.high) + "\t" +
         ((obj.secrets || []).length)
       );
     ' 2>/dev/null || printf '%s' "0	0	0")"
     prev_c="$(printf '%s' "$prev_counts" | cut -f1)"
     prev_h="$(printf '%s' "$prev_counts" | cut -f2)"
     prev_s="$(printf '%s' "$prev_counts" | cut -f3)"
-    # Guard against empty/unparseable output
-    prev_c="${prev_c:-0}"; prev_h="${prev_h:-0}"; prev_s="${prev_s:-0}"
+    # Guard against empty/unparseable/non-numeric output. The numeric regex
+    # protects the `delta_desc` block below (which compares the caller's prev_*
+    # directly) the same way scan_escalated guards its own copies.
+    [[ "$prev_c" =~ ^[0-9]+$ ]] || prev_c=0
+    [[ "$prev_h" =~ ^[0-9]+$ ]] || prev_h=0
+    [[ "$prev_s" =~ ^[0-9]+$ ]] || prev_s=0
   fi
 
   if [[ "$(scan_escalated "$prev_c" "$prev_h" "$prev_s" "$cur_c" "$cur_h" "$cur_s")" == "yes" ]]; then

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -21,6 +21,11 @@ SCANNER_VERSION="1.2.0"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
 REPOS_DIR="$HOME/repos"
+
+# ─── Source shared helpers ─────────────────────────────────────
+# shellcheck source=scripts/lib/notify.sh
+# shellcheck disable=SC1091  # dynamic path; use shellcheck -x to follow
+source "$SCRIPT_DIR/lib/notify.sh"
 TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 SCAN_DATE="$(date -u '+%Y-%m-%d')"
 HOSTNAME_VAL="$(hostname)"
@@ -53,6 +58,18 @@ done
 log_verbose() {
   if [[ "$VERBOSE" == "true" ]]; then
     echo "$*" >&2
+  fi
+}
+
+# scan_escalated — pure escalation check; echoes "yes" or "no".
+# A repo escalated if any tracked severity count increased vs the previous scan.
+# Usage: scan_escalated prev_crit prev_high prev_secrets cur_crit cur_high cur_secrets
+scan_escalated() {
+  local prev_c="$1" prev_h="$2" prev_s="$3" cur_c="$4" cur_h="$5" cur_s="$6"
+  if [[ "$cur_c" -gt "$prev_c" ]] || [[ "$cur_h" -gt "$prev_h" ]] || [[ "$cur_s" -gt "$prev_s" ]]; then
+    echo "yes"
+  else
+    echo "no"
   fi
 }
 
@@ -496,6 +513,86 @@ fi
 
 echo "Overall status: $OVERALL_STATUS"
 echo ""
+
+# ─── Delta computation (escalation detection) ─────────────────
+# For each repo: read the previous scan from Munin (if available and not dry-run),
+# compare critical/high/secret counts, and track any repo that escalated.
+# In dry-run mode, prev counts are treated as 0 (simulates first run).
+
+ESCALATED_REPOS=""
+ESCALATION_MSG_LINES=""
+
+for repo in $SCAN_COMPONENTS; do
+  cur_c="$(repo_get "$repo" audit_critical)"; [[ -z "$cur_c" ]] && cur_c=0
+  cur_h="$(repo_get "$repo" audit_high)";    [[ -z "$cur_h" ]] && cur_h=0
+  cur_s="$(repo_get "$repo" secret_count)";  [[ -z "$cur_s" ]] && cur_s=0
+
+  prev_c=0; prev_h=0; prev_s=0
+
+  if [[ "$DRY_RUN" != "true" ]] && [[ -n "$MUNIN_TOKEN" ]]; then
+    read_args="$(REPO_NS="security/repos/${repo}" node --input-type=commonjs -e '
+      console.log(JSON.stringify({namespace: process.env.REPO_NS, key: "latest"}))
+    ')"
+    prev_raw="$(munin_tool_call "memory_read" "$read_args" 2>/dev/null || echo "{}")"
+    # Parse the embedded ```json block from the Munin response's text content.
+    # Response is a JSON-RPC result: {result:{content:[{type:"text",text:"..."}]}}
+    # shellcheck disable=SC2016  # single quotes intentional — node JS, not bash expansion
+    prev_counts="$(printf '%s' "$prev_raw" | node --input-type=commonjs -e '
+      var d;
+      try { d = JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); }
+      catch(e) { d = {}; }
+      var text = (d.result && d.result.content &&
+                  Array.isArray(d.result.content) &&
+                  d.result.content[0] && d.result.content[0].text) || "";
+      var m = text.match(/```json\s*([\s\S]*?)```/);
+      var obj = {};
+      if (m) { try { obj = JSON.parse(m[1]); } catch(e) {} }
+      var audit = obj.audit || {};
+      process.stdout.write(
+        (audit.critical || 0) + "\t" +
+        (audit.high || 0) + "\t" +
+        ((obj.secrets || []).length)
+      );
+    ' 2>/dev/null || printf '%s' "0	0	0")"
+    prev_c="$(printf '%s' "$prev_counts" | cut -f1)"
+    prev_h="$(printf '%s' "$prev_counts" | cut -f2)"
+    prev_s="$(printf '%s' "$prev_counts" | cut -f3)"
+    # Guard against empty/unparseable output
+    prev_c="${prev_c:-0}"; prev_h="${prev_h:-0}"; prev_s="${prev_s:-0}"
+  fi
+
+  if [[ "$(scan_escalated "$prev_c" "$prev_h" "$prev_s" "$cur_c" "$cur_h" "$cur_s")" == "yes" ]]; then
+    delta_desc=""
+    [[ "$cur_c" -gt "$prev_c" ]] && delta_desc="${delta_desc} critical:${prev_c}->${cur_c}"
+    [[ "$cur_h" -gt "$prev_h" ]] && delta_desc="${delta_desc} high:${prev_h}->${cur_h}"
+    [[ "$cur_s" -gt "$prev_s" ]] && delta_desc="${delta_desc} secrets:${prev_s}->${cur_s}"
+    delta_desc="${delta_desc# }"  # trim leading space
+    if [[ -z "$ESCALATED_REPOS" ]]; then
+      ESCALATED_REPOS="$repo"
+      ESCALATION_MSG_LINES="  - ${repo}: ${delta_desc}"
+    else
+      ESCALATED_REPOS="${ESCALATED_REPOS} ${repo}"
+      ESCALATION_MSG_LINES="${ESCALATION_MSG_LINES}
+  - ${repo}: ${delta_desc}"
+    fi
+  fi
+done
+
+# ─── Telegram alert — high/critical status + at least one escalation ──────
+# Stays silent when overall is clean/low/moderate, or when nothing escalated.
+
+if [[ "$OVERALL_STATUS" == "high" ]] || [[ "$OVERALL_STATUS" == "critical" ]]; then
+  if [[ -n "$ESCALATED_REPOS" ]]; then
+    OVERALL_UPPER="$(echo "$OVERALL_STATUS" | tr '[:lower:]' '[:upper:]')"
+    ALERT_MSG="[Grimnir security] ${OVERALL_UPPER} — escalated findings (${SCAN_DATE}):
+${ESCALATION_MSG_LINES}"
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "[dry-run] telegram: ${ALERT_MSG}"
+    else
+      notify_telegram "$ALERT_MSG"
+    fi
+  fi
+fi
 
 # ─── Munin writes ─────────────────────────────────────────────
 

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -521,50 +521,41 @@ for repo in $SCAN_COMPONENTS; do
   cur_s="$(repo_get "$repo" secret_count)";  [[ -z "$cur_s" ]] && cur_s=0
 
   prev_c=0; prev_h=0; prev_s=0
+  # baseline_ok = we have a trustworthy previous snapshot to diff against. A
+  # read failure / missing token / poisoned record must NOT look like a "0 0 0"
+  # baseline — otherwise every existing finding reads as newly-escalated and the
+  # alert fires (falsely) on every run. Only an "ok" parse enables alerting.
+  baseline_ok=false
 
-  if [[ "$DRY_RUN" != "true" ]] && [[ -n "$MUNIN_TOKEN" ]]; then
+  if [[ "$DRY_RUN" == "true" ]]; then
+    # Dry-run has no Munin read; simulate a first-run baseline so the smoke test
+    # can demonstrate what an alert would look like.
+    baseline_ok=true
+  elif [[ -n "$MUNIN_TOKEN" ]]; then
     # `|| printf '{}'` keeps a node failure from aborting the whole scan under
-    # set -e (this runs before the alert + Munin writes). A '{}' read_args makes
-    # memory_read a no-op, prev counts fall back to 0 → silent, correct.
-    read_args="$(REPO_NS="security/repos/${repo}" node --input-type=commonjs -e '
-      console.log(JSON.stringify({namespace: process.env.REPO_NS, key: "latest"}))
-    ' 2>/dev/null || printf '%s' '{}')"
-    prev_raw="$(munin_tool_call "memory_read" "$read_args" 2>/dev/null || echo "{}")"
-    # Parse the embedded ```json block from the Munin response's text content.
-    # Response is a JSON-RPC result: {result:{content:[{type:"text",text:"..."}]}}
-    # shellcheck disable=SC2016  # single quotes intentional — node JS, not bash expansion
-    prev_counts="$(printf '%s' "$prev_raw" | node --input-type=commonjs -e '
-      var d;
-      try { d = JSON.parse(require("fs").readFileSync("/dev/stdin","utf8")); }
-      catch(e) { d = {}; }
-      var text = (d.result && d.result.content &&
-                  Array.isArray(d.result.content) &&
-                  d.result.content[0] && d.result.content[0].text) || "";
-      var m = text.match(/```json\s*([\s\S]*?)```/);
-      var obj = {};
-      if (m) { try { obj = JSON.parse(m[1]); } catch(e) {} }
-      var audit = obj.audit || {};
-      // Coerce to integers — a non-numeric value here must not flow into bash
-      // arithmetic downstream. parseInt(NaN-ish) -> 0.
-      var n = function (x) { var i = parseInt(x, 10); return Number.isFinite(i) ? i : 0; };
-      process.stdout.write(
-        n(audit.critical) + "\t" +
-        n(audit.high) + "\t" +
-        ((obj.secrets || []).length)
-      );
-    ' 2>/dev/null || printf '%s' "0	0	0")"
-    prev_c="$(printf '%s' "$prev_counts" | cut -f1)"
-    prev_h="$(printf '%s' "$prev_counts" | cut -f2)"
-    prev_s="$(printf '%s' "$prev_counts" | cut -f3)"
-    # Guard against empty/unparseable/non-numeric output. The numeric regex
-    # protects the `delta_desc` block below (which compares the caller's prev_*
-    # directly) the same way scan_escalated guards its own copies.
-    [[ "$prev_c" =~ ^[0-9]+$ ]] || prev_c=0
-    [[ "$prev_h" =~ ^[0-9]+$ ]] || prev_h=0
-    [[ "$prev_s" =~ ^[0-9]+$ ]] || prev_s=0
+    # set -e (this runs before the alert + Munin writes). The '{}' sentinel
+    # parses to status=unavailable → no false escalation.
+    read_args="$(REPO_NS="security/repos/${repo}" node --input-type=commonjs -e \
+      'console.log(JSON.stringify({namespace: process.env.REPO_NS, key: "latest"}))' \
+      2>/dev/null || printf '%s' '{}')"
+    prev_raw="$(munin_tool_call "memory_read" "$read_args" 2>/dev/null || printf '%s' '{}')"
+    # parse_prev_counts (lib/escalation.sh) emits "crit<TAB>high<TAB>secrets<TAB>status"
+    # with strict integer/array validation. Tab-separated; read via IFS.
+    prev_parsed="$(printf '%s' "$prev_raw" | parse_prev_counts)"
+    IFS=$'\t' read -r prev_c prev_h prev_s baseline_status <<< "$prev_parsed"
+    prev_c="${prev_c:-0}"; prev_h="${prev_h:-0}"; prev_s="${prev_s:-0}"
+    [[ "${baseline_status:-unavailable}" == "ok" ]] && baseline_ok=true
   fi
 
-  if [[ "$(scan_escalated "$prev_c" "$prev_h" "$prev_s" "$cur_c" "$cur_h" "$cur_s")" == "yes" ]]; then
+  # Defense-in-depth for the delta_desc comparisons below (which use prev_*
+  # directly): canonicalize to base-10 ints, mirroring scan_escalated.
+  [[ "$prev_c" =~ ^[0-9]{1,9}$ ]] && prev_c=$((10#$prev_c)) || prev_c=0
+  [[ "$prev_h" =~ ^[0-9]{1,9}$ ]] && prev_h=$((10#$prev_h)) || prev_h=0
+  [[ "$prev_s" =~ ^[0-9]{1,9}$ ]] && prev_s=$((10#$prev_s)) || prev_s=0
+
+  if [[ "$baseline_ok" != "true" ]]; then
+    log_verbose "  $repo: previous baseline unavailable — skipping delta alert"
+  elif [[ "$(scan_escalated "$prev_c" "$prev_h" "$prev_s" "$cur_c" "$cur_h" "$cur_s")" == "yes" ]]; then
     delta_desc=""
     [[ "$cur_c" -gt "$prev_c" ]] && delta_desc="${delta_desc} critical:${prev_c}->${cur_c}"
     [[ "$cur_h" -gt "$prev_h" ]] && delta_desc="${delta_desc} high:${prev_h}->${cur_h}"

--- a/scripts/tests/security-scan-delta.test.sh
+++ b/scripts/tests/security-scan-delta.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# security-scan-delta.test.sh — unit tests for the scan_escalated helper.
+# Tests the pure escalation logic in isolation (no Munin, no network, no node).
+#
+# The function definition below MUST match scan_escalated() in security-scan.sh.
+# Compatible with bash 3.2+ (macOS default).
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+# ── Pure escalation function (must match security-scan.sh) ──────────────────
+# Returns "yes" if current findings exceed the previous snapshot on any
+# tracked dimension (critical vulns, high vulns, secret count); "no" otherwise.
+scan_escalated() {
+  local prev_c="$1" prev_h="$2" prev_s="$3" cur_c="$4" cur_h="$5" cur_s="$6"
+  if [[ "$cur_c" -gt "$prev_c" ]] || [[ "$cur_h" -gt "$prev_h" ]] || [[ "$cur_s" -gt "$prev_s" ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+# ── Test harness ─────────────────────────────────────────────────────────────
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — expected '$expected', got '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "security-scan delta escalation tests"
+echo "======================================"
+
+# no-change scenarios -> no
+assert_eq "no-change (all zeros)"           "no"  "$(scan_escalated 0 0 0 0 0 0)"
+assert_eq "no-change (non-zero same)"       "no"  "$(scan_escalated 1 2 3 1 2 3)"
+
+# counts decreased -> no
+assert_eq "counts decreased (all)"         "no"  "$(scan_escalated 5 5 5 3 3 3)"
+assert_eq "critical decreased"             "no"  "$(scan_escalated 2 0 0 1 0 0)"
+assert_eq "high decreased"                 "no"  "$(scan_escalated 0 3 0 0 2 0)"
+assert_eq "secrets decreased"              "no"  "$(scan_escalated 0 0 4 0 0 2)"
+
+# escalation scenarios -> yes
+assert_eq "high increased"                 "yes" "$(scan_escalated 0 1 0 0 2 0)"
+assert_eq "new critical (from zero)"       "yes" "$(scan_escalated 0 0 0 1 0 0)"
+assert_eq "new secret (from zero)"         "yes" "$(scan_escalated 0 0 0 0 0 1)"
+assert_eq "critical increased (non-zero)"  "yes" "$(scan_escalated 1 0 0 2 0 0)"
+assert_eq "secrets increased (non-zero)"   "yes" "$(scan_escalated 0 0 2 0 0 4)"
+
+# first-run: prev all zero, cur > 0 -> yes
+assert_eq "first-run critical"             "yes" "$(scan_escalated 0 0 0 3 0 0)"
+assert_eq "first-run high"                 "yes" "$(scan_escalated 0 0 0 0 5 0)"
+assert_eq "first-run secrets"              "yes" "$(scan_escalated 0 0 0 0 0 2)"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/tests/security-scan-delta.test.sh
+++ b/scripts/tests/security-scan-delta.test.sh
@@ -2,7 +2,8 @@
 # security-scan-delta.test.sh — unit tests for the scan_escalated helper.
 # Tests the pure escalation logic in isolation (no Munin, no network, no node).
 #
-# The function definition below MUST match scan_escalated() in security-scan.sh.
+# Sources the REAL scan_escalated from lib/escalation.sh (no duplicated copy)
+# so the test can never silently drift from the production logic.
 # Compatible with bash 3.2+ (macOS default).
 
 set -euo pipefail
@@ -10,17 +11,10 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
-# ── Pure escalation function (must match security-scan.sh) ──────────────────
-# Returns "yes" if current findings exceed the previous snapshot on any
-# tracked dimension (critical vulns, high vulns, secret count); "no" otherwise.
-scan_escalated() {
-  local prev_c="$1" prev_h="$2" prev_s="$3" cur_c="$4" cur_h="$5" cur_s="$6"
-  if [[ "$cur_c" -gt "$prev_c" ]] || [[ "$cur_h" -gt "$prev_h" ]] || [[ "$cur_s" -gt "$prev_s" ]]; then
-    echo "yes"
-  else
-    echo "no"
-  fi
-}
+# Source the production function under test.
+# shellcheck source=scripts/lib/escalation.sh
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../lib/escalation.sh"
 
 # ── Test harness ─────────────────────────────────────────────────────────────
 assert_eq() {
@@ -58,6 +52,24 @@ assert_eq "secrets increased (non-zero)"   "yes" "$(scan_escalated 0 0 2 0 0 4)"
 assert_eq "first-run critical"             "yes" "$(scan_escalated 0 0 0 3 0 0)"
 assert_eq "first-run high"                 "yes" "$(scan_escalated 0 0 0 0 5 0)"
 assert_eq "first-run secrets"              "yes" "$(scan_escalated 0 0 0 0 0 2)"
+
+# ── Robustness: non-numeric inputs (e.g. a poisoned multi-writer Munin record)
+# must be treated as 0, never reach the `[[ -gt ]]` arithmetic context, and must
+# not abort the function under `set -euo pipefail`. A bare name like `a[...]`
+# would otherwise trip nounset ("a: unbound variable") and kill the whole scan.
+rm -f /tmp/sce_inject_marker
+assert_eq "non-numeric prev -> treated as 0" "no" "$(scan_escalated abc 0 0 0 0 0)"
+assert_eq "non-numeric cur  -> treated as 0" "no" "$(scan_escalated 0 0 0 xyz 0 0)"
+# Single quotes are intentional: pass the literal payload so coercion (not the
+# test harness) decides its fate. Coerced to 0, cur also 0 -> "no".
+# shellcheck disable=SC2016
+assert_eq "arith-injection prev is inert"    "no" "$(scan_escalated 'a[$(touch /tmp/sce_inject_marker)]' 0 0 0 0 0)"
+if [[ -e /tmp/sce_inject_marker ]]; then
+  echo "  FAIL: arithmetic injection executed (marker created)"; FAIL=$((FAIL + 1))
+  rm -f /tmp/sce_inject_marker
+else
+  echo "  PASS: arithmetic injection inert (no marker)"; PASS=$((PASS + 1))
+fi
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/scripts/tests/security-scan-delta.test.sh
+++ b/scripts/tests/security-scan-delta.test.sh
@@ -71,6 +71,43 @@ else
   echo "  PASS: arithmetic injection inert (no marker)"; PASS=$((PASS + 1))
 fi
 
+# ── Leading-zero / octal inputs: `[[ -gt ]]` would treat 08/09 as invalid octal
+# and error → silent miss. Must be canonicalized base-10, not rejected to 0.
+assert_eq "octal-looking escalation (08->09)"  "yes" "$(scan_escalated 08 0 0 09 0 0)"
+assert_eq "octal-looking no-change (09 vs 08)" "no"  "$(scan_escalated 09 0 0 08 0 0)"
+assert_eq "octal high 08->09"                  "yes" "$(scan_escalated 0 08 0 0 09 0)"
+assert_eq "overlong digit string -> 0"         "no"  "$(scan_escalated 0 0 0 99999999999 0 0)"
+
+echo ""
+echo "parse_prev_counts tests"
+echo "======================================="
+
+# Build a realistic Munin memory_read response wrapping the scanner's stored
+# per-repo content (a markdown body with an embedded ```json block).
+mk_munin() {  # $1 = inner json block content
+  local block="$1"
+  REPO_TEXT="## repo — Security State
+\`\`\`json
+${block}
+\`\`\`" node --input-type=commonjs -e \
+    'console.log(JSON.stringify({result:{content:[{type:"text",text:process.env.REPO_TEXT}]}}))'
+}
+
+assert_eq "valid baseline -> counts + ok" "2	3	1	ok" \
+  "$(mk_munin '{"audit":{"critical":2,"high":3},"secrets":[{"file":"a"}]}' | parse_prev_counts)"
+assert_eq "first run (envelope, no block) -> 0 0 0 ok" "0	0	0	ok" \
+  "$(node --input-type=commonjs -e 'console.log(JSON.stringify({result:{content:[{type:"text",text:"no scans yet"}]}}))' | parse_prev_counts)"
+assert_eq "rpc failure sentinel {} -> unavailable" "0	0	0	unavailable" \
+  "$(printf '%s' '{}' | parse_prev_counts)"
+assert_eq "malformed json block -> unavailable" "0	0	0	unavailable" \
+  "$(mk_munin '{not valid json' | parse_prev_counts)"
+assert_eq "poisoned partial-numeric (999junk) -> unavailable" "0	0	0	unavailable" \
+  "$(mk_munin '{"audit":{"critical":"999junk","high":0},"secrets":[]}' | parse_prev_counts)"
+assert_eq "poisoned fake-array secrets {length:999} -> unavailable" "0	0	0	unavailable" \
+  "$(mk_munin '{"audit":{"critical":0,"high":0},"secrets":{"length":999}}' | parse_prev_counts)"
+assert_eq "garbage (not json at all) -> unavailable" "0	0	0	unavailable" \
+  "$(printf '%s' 'totally not json' | parse_prev_counts)"
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## What

Closes #21. The security scanner computed `overall_status` and wrote per-repo state to Munin, but **nothing surfaced high/critical findings to a human** — the 2026-05-17 `critical` hugin result sat unread for ~11h. This adds a delta-aware Telegram alert.

## How

After status assessment, a new pass:
1. Reads each repo's previous `security/repos/<repo>/latest` from Munin (before the scan overwrites it).
2. Compares `critical` / `high` / `secret` counts via a pure `scan_escalated()`.
3. Fires **one** `notify_telegram` (via `lib/notify.sh`) only when `overall_status` is `high`/`critical` **and** at least one repo escalated vs the previous scan.

Silent when unchanged or clean/low/moderate — **no weekly nag**. Dry-run treats prev counts as 0 and echoes the alert instead of sending.

## Tests
- `scripts/tests/security-scan-delta.test.sh` — 14-case red/green unit test for the escalation logic (no-change→silent, increases→alert, decreases→silent, first-run→alert). All pass.
- `bash -n` clean, `shellcheck -x` clean, `--dry-run` smoke completes silent-when-clean.

## Cluster note
This PR is the one item of the #8/#21/#31/#33 "deploy cluster" that needed new code:
- **#8** closed — scope mechanism already shipped in #20; live scopes verified to match `services.json`.
- **#31** → re-scoped to a per-service version-drift self-check (decision); not a grimnir change.
- **#33** → root cause confirmed (grimnir doesn't self-update its own repo); redeploy + follow-up issue tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)