### PR TITLE
Register Brokkr (platform/substrate layer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ No service code lives here — each component has its own repo.
 | Ratatoskr | `ratatoskr` | Telegram router + concierge |
 | Skuld | `skuld` (grimnir-bot org) | Daily intelligence briefing |
 | Fortnox MCP | `fortnox-mcp` | Accounting CLI + MCP |
+| Brokkr | `brokkr` | Platform/substrate layer — hardware, OS, storage, backups (peer, not a service) |
 
 ## Key documents
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Runs on two Raspberry Pis and a MacBook. All data stays on your hardware.
 | **Skuld** | Daily intelligence briefing | [skuld](https://github.com/grimnir-bot/skuld) |
 | **Verdandi** | Tamper-evident audit log | [verdandi](https://github.com/Magnus-Gille/verdandi) |
 | **noxctl** | Fortnox accounting CLI + MCP | [fortnox-mcp](https://github.com/Magnus-Gille/fortnox-mcp) |
+| **Brokkr** | Platform / substrate — hardware park, OS, storage, network, backups | [brokkr](https://github.com/Magnus-Gille/brokkr) |
+
+Brokkr is the **substrate layer** the others run on (peer to this repo, not a service): it owns the boxes, their OS, the NAS backup disk + Time Machine, and hardware-level health. The hardware inventory itself stays canonical in [`services.json`](services.json) (`nodes`).
 
 All components are named after figures from Norse mythology. See [docs/conventions.md](docs/conventions.md) for the naming guide.
 

--- a/services.json
+++ b/services.json
@@ -128,7 +128,9 @@
       "scan": true,
       "deploy_path": "/home/magnus/repos/brokkr",
       "needs_build": false,
-      "systemd_units": []
+      "systemd_units": [
+        { "name": "brokkr-health", "type": "timer" }
+      ]
     }
   ],
   "nodes": [

--- a/services.json
+++ b/services.json
@@ -118,6 +118,17 @@
       "systemd_units": [
         { "name": "verdandi", "type": "service", "scope": "user" }
       ]
+    },
+    {
+      "name": "brokkr",
+      "repo": "brokkr",
+      "host": "nas.local",
+      "port": null,
+      "deploy": false,
+      "scan": true,
+      "deploy_path": "/home/magnus/repos/brokkr",
+      "needs_build": false,
+      "systemd_units": []
     }
   ],
   "nodes": [


### PR DESCRIPTION
Adds **Brokkr** — the new platform/substrate repo — to Grimnir's system map.

- README + CLAUDE.md component tables get a Brokkr row, noting it's the substrate layer (peer to grimnir, not a service).
- `services.json` `components` gets a `brokkr` entry (`deploy:false` until its health checks are wired to a timer; `scan:true`).
- Hardware inventory is **not** duplicated — `services.json` `nodes` stays canonical; Brokkr references it.

Part of splitting the platform/substrate layer out into its own repo. See Munin `meta/brokkr` / `decisions/home-infra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)