### PR TITLE
feat(deploy): Option A — grimnir deploys via git pull --ff-only (#47 follow-up)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -158,8 +158,19 @@ deploy_service() {
     # so checkout == HEAD == origin/main by construction. A dirty tree or
     # diverged branch fails loudly here and trips the registry-checkout alarm.
     echo "==> Updating ${remote}:${deploy_path} via git pull --ff-only..."
+    # Post-conditions are checked explicitly because `pull --ff-only` exits 0
+    # in two bad states (codex review, PR #54): a local main AHEAD of origin
+    # (stray commit — the #44 incident class) and unrelated dirty tracked
+    # files. Either would let the stamp certify a non-canonical tree, so both
+    # fail the deploy loudly instead.
+    local pull_cmd
+    pull_cmd="git -C '$deploy_path' fetch --quiet origin && "
+    pull_cmd+="git -C '$deploy_path' checkout --quiet main && "
+    pull_cmd+="git -C '$deploy_path' pull --ff-only --quiet origin main && "
+    pull_cmd+="if [ -n \"\$(git -C '$deploy_path' status --porcelain)\" ]; then echo 'ERROR: checkout dirty after pull' >&2; exit 1; fi && "
+    pull_cmd+="if [ \"\$(git -C '$deploy_path' rev-parse HEAD)\" != \"\$(git -C '$deploy_path' rev-parse origin/main)\" ]; then echo 'ERROR: HEAD != origin/main after pull (stray local commits?)' >&2; exit 1; fi"
     # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
-    if ! ssh -o ConnectTimeout=10 "$remote" "git -C '$deploy_path' fetch --quiet origin && git -C '$deploy_path' checkout --quiet main && git -C '$deploy_path' pull --ff-only --quiet origin main"; then
+    if ! ssh -o ConnectTimeout=10 "$remote" "$pull_cmd"; then
       echo -e "${RED}FAILED${NC}"
       results+=("${RED}✗${NC} ${name}")
       fail=$((fail + 1))

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,7 @@ GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
 REGISTRY="$GRIMNIR_DIR/services.json"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 
-# Read deployable services from registry: name|repo|host|deploy_path|unit_type|needs_build|unit_scope
+# Read deployable services from registry: name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode
 SERVICES=()
 while IFS= read -r line; do
   [[ -n "$line" ]] && SERVICES+=("$line")
@@ -95,7 +95,7 @@ resolve_local_path() {
 }
 
 deploy_service() {
-  local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system}
+  local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync}
   local local_path
   local remote_host
   local remote
@@ -118,13 +118,19 @@ deploy_service() {
   branch=$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   commit=$(git -C "$local_path" rev-parse --short HEAD 2>/dev/null || echo "unknown")
   commit_full=$(git -C "$local_path" rev-parse HEAD 2>/dev/null || echo "$commit")
-  if [[ -n "$(git -C "$local_path" status --porcelain 2>/dev/null)" ]]; then
-    dirty_state="dirty"
-    echo -e "${YELLOW}WARN${NC} Deploying local working tree with uncommitted changes"
+  if [[ "$deploy_mode" == "git-pull" ]]; then
+    # git-pull mode ships origin/main on the remote — the local tree is not
+    # the source, so its branch/dirtiness is informational only.
+    echo "Source: origin/main (deploy_mode=git-pull — local tree not shipped; local: ${branch} @ ${commit})"
   else
-    dirty_state="clean"
+    if [[ -n "$(git -C "$local_path" status --porcelain 2>/dev/null)" ]]; then
+      dirty_state="dirty"
+      echo -e "${YELLOW}WARN${NC} Deploying local working tree with uncommitted changes"
+    else
+      dirty_state="clean"
+    fi
+    echo "Source: ${local_path} (${branch} @ ${commit}, ${dirty_state})"
   fi
-  echo "Source: ${local_path} (${branch} @ ${commit}, ${dirty_state})"
 
   if ! remote_host=$(resolve_host "$host"); then
     echo -e "${RED}FAILED${NC}"
@@ -135,7 +141,8 @@ deploy_service() {
   remote="${DEPLOY_USER}@${remote_host}"
 
   # Build locally before syncing if runtime expects generated artifacts like dist/
-  if [[ "$needs_build" == "true" ]]; then
+  # (irrelevant in git-pull mode — nothing local is shipped)
+  if [[ "$needs_build" == "true" && "$deploy_mode" != "git-pull" ]]; then
     echo "==> Building locally..."
     if ! build_locally "$local_path"; then
       echo -e "${RED}FAILED${NC}"
@@ -144,6 +151,21 @@ deploy_service() {
       return
     fi
   fi
+
+  if [[ "$deploy_mode" == "git-pull" ]]; then
+    # git-pull mode (Option A, docs/role-separation.md): the checkout IS the
+    # deployment. Fast-forward it to origin/main — never force, never rsync —
+    # so checkout == HEAD == origin/main by construction. A dirty tree or
+    # diverged branch fails loudly here and trips the registry-checkout alarm.
+    echo "==> Updating ${remote}:${deploy_path} via git pull --ff-only..."
+    # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
+    if ! ssh -o ConnectTimeout=10 "$remote" "git -C '$deploy_path' fetch --quiet origin && git -C '$deploy_path' checkout --quiet main && git -C '$deploy_path' pull --ff-only --quiet origin main"; then
+      echo -e "${RED}FAILED${NC}"
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+      return
+    fi
+  else
 
   echo "==> Syncing to ${remote}:${deploy_path}..."
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
@@ -175,6 +197,8 @@ deploy_service() {
     fail=$((fail + 1))
     return
   fi
+
+  fi # end rsync-mode block (deploy_mode != git-pull)
 
   local cmd="cd '$deploy_path' && "
   if [[ "$unit_type" == "service" && "$unit_scope" == "user" ]]; then
@@ -214,7 +238,13 @@ deploy_service() {
   # source (excluded from rsync above so --delete won't clobber it). Heimdall
   # reads <deploy_path>/.deployed-commit instead of trusting /health (often no
   # commit) or the on-Pi .git (stale — rsync excludes it).
-  cmd+="printf '%s\\n' '${commit_full}' > .deployed-commit && "
+  if [[ "$deploy_mode" == "git-pull" ]]; then
+    # In git-pull mode the remote HEAD is the ground truth (origin/main was
+    # just pulled) — stamp that, not the local checkout's commit.
+    cmd+="git rev-parse HEAD > .deployed-commit && "
+  else
+    cmd+="printf '%s\\n' '${commit_full}' > .deployed-commit && "
+  fi
   cmd+="echo 'DEPLOY_OK'"
 
   local output
@@ -241,7 +271,7 @@ deploy_service() {
 requested=("$@")
 
 for entry in "${SERVICES[@]}"; do
-  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope <<< "$entry"
+  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope deploy_mode <<< "$entry"
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false
@@ -251,7 +281,7 @@ for entry in "${SERVICES[@]}"; do
     $match || continue
   fi
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}"
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}"
 done
 
 # Summary

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -49,7 +49,7 @@ var components = data.components;
 switch (query) {
   case 'deploy': {
     // Output format matches what deploy.sh needs:
-    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope
+    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope|deploy_mode
     var deployable = components.filter(function (c) { return c.deploy; });
     deployable.forEach(function (c) {
       // Determine primary unit type/scope from first systemd unit.
@@ -64,8 +64,9 @@ switch (query) {
       }
       var deployPath = c.deploy_path || ('/home/magnus/repos/' + c.repo);
       var needsBuild = c.needs_build ? 'true' : 'false';
+      var deployMode = c.deploy_mode || 'rsync';
       process.stdout.write(
-        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '\n'
+        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '|' + deployMode + '\n'
       );
     });
     break;

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -80,6 +80,10 @@ data.components.forEach(function (c, i) {
     }
   });
 
+  if (c.deploy_mode !== undefined && c.deploy_mode !== 'rsync' && c.deploy_mode !== 'git-pull') {
+    fail(label + ': "deploy_mode" must be "rsync" or "git-pull" when present, got "' + c.deploy_mode + '"');
+  }
+
   if (c.host !== null && typeof c.host !== 'string') {
     fail(label + ': field "host" must be a string or null');
   }

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -184,6 +184,28 @@ cat > "$TMP_DIR/dup-node.json" << 'EOF'
 EOF
 assert_eq "duplicate node name -> exit 1" "1" "$(run_validator "$TMP_DIR/dup-node.json")"
 
+# ── deploy_mode: valid git-pull passes ──────────────────────────────────────
+cat > "$TMP_DIR/deploy-mode-git-pull.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/x", "needs_build": false, "deploy_mode": "git-pull", "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "deploy_mode git-pull -> exit 0" "0" "$(run_validator "$TMP_DIR/deploy-mode-git-pull.json")"
+
+# ── deploy_mode: bogus value fails ──────────────────────────────────────────
+cat > "$TMP_DIR/deploy-mode-bogus.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/x", "needs_build": false, "deploy_mode": "ftp", "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "deploy_mode bogus value -> exit 1" "1" "$(run_validator "$TMP_DIR/deploy-mode-bogus.json")"
+
 # ── Missing file entirely ───────────────────────────────────────────────────
 assert_eq "missing file -> exit 1" "1" "$(run_validator "$TMP_DIR/does-not-exist.json")"
 

--- a/services.json
+++ b/services.json
@@ -99,6 +99,7 @@
       "scan": false,
       "deploy_path": "/home/magnus/repos/grimnir",
       "needs_build": false,
+      "deploy_mode": "git-pull",
       "systemd_units": [
         { "name": "grimnir-security-scan", "type": "timer" },
         { "name": "grimnir-validate", "type": "timer" }


### PR DESCRIPTION
The go-ahead follow-up to #53's `docs/role-separation.md` recommendation.

- `services.json`: grimnir gets `deploy_mode: "git-pull"` (new optional field, default `rsync`)
- `deploy.sh`: git-pull mode fetches + `checkout main` + `pull --ff-only` on the Pi — never force, never rsync; a dirty/diverged checkout **fails loudly** and trips the #53 registry-checkout alarm. Timer-unit install + `.deployed-commit` stamp (from pulled remote HEAD) preserved. Build/npm skipped (nothing local is shipped).
- `validate-registry.js` + smoke tests: `deploy_mode` enum-validated (2 new cases, red→green)

Verification: `bash -n` + shellcheck clean; all 5 `make test` suites green (96 assertions); registry pipe emits the new field correctly for all components.

Provenance: scaffolding from m5 code_loop `cl-20260704-c1b9ffc6` (local compute per directive; arm-errored at turn 7), completed by hand.

Closes the Option-A action from #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)