### PR TITLE
fix(deploy): gitignore .deployed-commit + .claude/ (git-pull post-condition false-positive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ node_modules/
 docs/snapshot.md
 docs/full-architecture.md
 .playwright-mcp/
+
+# Deployment metadata (written by deploy.sh on the Pi; rsync-excluded, must not
+# dirty the git-pull post-condition or the #53 registry-checkout alarm)
+.deployed-commit
+# Claude Code session droppings (until hugin#139 workspace isolation is activated)
+.claude/


### PR DESCRIPTION
Surfaced by the first live git-pull deploy (#54 acceptance): `.deployed-commit` is untracked and unignored, so the NEXT git-pull deploy's clean-tree post-condition and tonight's #53 drift alarm would both false-fire on deploy metadata. `.claude/` added for the same reason (hugin-session droppings in the canonical checkout, until hugin#139's isolation is activated on the Pi).

One-time Pi step after merge: `rm .deployed-commit` there, then redeploy — the pull delivers this .gitignore, the stamp is rewritten and thereafter ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)