### PR TITLE
fix(registry): hugin-daily-analysis in SSOT + self-heal grimnir deploy marker (#43, #33)

### DIFF
--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -214,6 +214,20 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   else
     RESULTS+="✅ registry-checkout: ${checkout_detail} ($REGISTRY_CHECKOUT)\n"
     PASS=$((PASS + 1))
+    # Self-heal the git-pull deploy marker (#33). grimnir deploys via git pull,
+    # so the on-Pi HEAD is the authoritative "what's live" — but .deployed-commit
+    # (what Heimdall's drift detector reads) is only re-stamped by deploy.sh.
+    # Sessions pull this canonical checkout forward outside a deploy, leaving the
+    # marker stale, so Heimdall false-flags every grimnir unit as behind origin.
+    # We only reach this branch when the checkout is verified clean AND on the
+    # default branch, so HEAD is safe to trust — re-stamp it. Guarded on an
+    # existing marker so this never fabricates one on a non-deploy checkout (a
+    # laptop run), and it never runs on a dirty/branch-stranded tree (those stay
+    # alert-worthy above).
+    _grimnir_marker="$REGISTRY_CHECKOUT/.deployed-commit"
+    if [[ -f "$_grimnir_marker" ]] && _grimnir_head="$(git -C "$REGISTRY_CHECKOUT" rev-parse HEAD 2>/dev/null)"; then
+      printf '%s\n' "$_grimnir_head" > "$_grimnir_marker" 2>/dev/null || true
+    fi
   fi
 
   # Print results

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -214,19 +214,18 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   else
     RESULTS+="✅ registry-checkout: ${checkout_detail} ($REGISTRY_CHECKOUT)\n"
     PASS=$((PASS + 1))
-    # Self-heal the git-pull deploy marker (#33). grimnir deploys via git pull,
-    # so the on-Pi HEAD is the authoritative "what's live" — but .deployed-commit
-    # (what Heimdall's drift detector reads) is only re-stamped by deploy.sh.
-    # Sessions pull this canonical checkout forward outside a deploy, leaving the
-    # marker stale, so Heimdall false-flags every grimnir unit as behind origin.
-    # We only reach this branch when the checkout is verified clean AND on the
-    # default branch, so HEAD is safe to trust — re-stamp it. Guarded on an
-    # existing marker so this never fabricates one on a non-deploy checkout (a
-    # laptop run), and it never runs on a dirty/branch-stranded tree (those stay
-    # alert-worthy above).
-    _grimnir_marker="$REGISTRY_CHECKOUT/.deployed-commit"
-    if [[ -f "$_grimnir_marker" ]] && _grimnir_head="$(git -C "$REGISTRY_CHECKOUT" rev-parse HEAD 2>/dev/null)"; then
-      printf '%s\n' "$_grimnir_head" > "$_grimnir_marker" 2>/dev/null || true
+    # Self-heal the git-pull deploy marker (#33). Sessions pull this canonical
+    # checkout forward OUTSIDE a deploy, leaving .deployed-commit — what Heimdall's
+    # drift detector reads — stale, so Heimdall false-flags every grimnir unit as
+    # behind origin. restamp_deploy_marker only writes because we reached this
+    # branch (checkout verified clean AND on the default branch) and a marker
+    # already exists. A non-zero return means the marker is stale but the write was
+    # refused (e.g. this service's read-only sandbox — see ReadWritePaths in
+    # grimnir-validate.service); surface it instead of letting the drift silently
+    # persist.
+    if ! restamp_deploy_marker "$REGISTRY_CHECKOUT" "$checkout_verdict"; then
+      RESULTS+="⚠️  deploy-marker: .deployed-commit stale but not writable (read-only mount?) — Heimdall drift may false-flag\n"
+      WARN=$((WARN + 1))
     fi
   fi
 

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -224,7 +224,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     # grimnir-validate.service); surface it instead of letting the drift silently
     # persist.
     if ! restamp_deploy_marker "$REGISTRY_CHECKOUT" "$checkout_verdict"; then
-      RESULTS+="⚠️  deploy-marker: .deployed-commit stale but not writable (read-only mount?) — Heimdall drift may false-flag\n"
+      RESULTS+="⚠️  deploy-marker: .deployed-commit not safely writable (read-only mount or symlink) — Heimdall drift may false-flag\n"
       WARN=$((WARN + 1))
     fi
   fi

--- a/scripts/lib/registry-checkout.sh
+++ b/scripts/lib/registry-checkout.sh
@@ -104,3 +104,31 @@ check_registry_checkout() {
 
   classify_registry_checkout "$git_ok" "$branch" "$default_branch" "$dirty"
 }
+
+# Re-stamp the git-pull deploy marker (#33). Heimdall's drift detector reads
+# <checkout>/.deployed-commit to decide whether a git-pull component is behind
+# origin. deploy.sh stamps that marker, but the canonical grimnir checkout also
+# gets pulled forward by ad-hoc sessions OUTSIDE a deploy, which leaves the marker
+# stale and makes Heimdall false-flag every grimnir unit as behind. Re-stamp HEAD
+# into the marker — but ONLY when the caller has already verified the checkout is
+# clean AND on its default branch (verdict "ok"); never bless a dirty or
+# branch-stranded tree. Guarded on an existing marker so it never fabricates one
+# on a non-deploy checkout (e.g. a laptop run).
+#
+# Returns:
+#   0 — stamped, or intentionally skipped (verdict != ok, or no marker present)
+#   1 — marker present + verdict ok, but the write FAILED (e.g. a read-only mount,
+#       as under grimnir-validate.service's sandbox). The caller MUST surface this
+#       rather than swallow it, or the marker silently stays stale.
+restamp_deploy_marker() {
+  local checkout="${1:-}" verdict="${2:-}"
+  [[ "$verdict" == "ok" ]] || return 0
+  local marker="${checkout}/.deployed-commit"
+  [[ -f "$marker" ]] || return 0
+  local head
+  head="$(git -C "$checkout" rev-parse HEAD 2>/dev/null)" || return 0
+  # Group the redirection so a failed open (read-only mount) is suppressed too —
+  # a bare `> "$marker" 2>/dev/null` can still leak the open error to stderr.
+  { printf '%s\n' "$head" > "$marker"; } 2>/dev/null || return 1
+  return 0
+}

--- a/scripts/lib/registry-checkout.sh
+++ b/scripts/lib/registry-checkout.sh
@@ -124,6 +124,11 @@ restamp_deploy_marker() {
   local checkout="${1:-}" verdict="${2:-}"
   [[ "$verdict" == "ok" ]] || return 0
   local marker="${checkout}/.deployed-commit"
+  # Refuse a symlinked marker. The marker is gitignored (outside git's dirty
+  # check), and both this write and the validate service's ReadWritePaths
+  # exception resolve symlinks — so following one could clobber an arbitrary
+  # target. Surface it (return 1) rather than write through it.
+  [[ -L "$marker" ]] && return 1
   [[ -f "$marker" ]] || return 0
   local head
   head="$(git -C "$checkout" rev-parse HEAD 2>/dev/null)" || return 0

--- a/scripts/tests/registry-checkout.test.sh
+++ b/scripts/tests/registry-checkout.test.sh
@@ -207,6 +207,18 @@ if [[ "$(id -u)" != "0" ]]; then
   assert_eq "ok + unwritable marker -> content unchanged" "deadbeef" "$(cat "$MARKER_FILE")"
 fi
 
+# A symlinked marker must be REFUSED, never followed — otherwise this write (and
+# the validate service's ReadWritePaths exception, which also resolves symlinks)
+# could clobber an arbitrary target. Return 1, leave the target untouched.
+rm -f "$MARKER_FILE"
+echo "target-untouched" > "$TMP_DIR/marker/real-target"
+ln -s "$TMP_DIR/marker/real-target" "$MARKER_FILE"
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+assert_eq "ok + symlink marker -> returns 1 (refused)" "1" "$rc"
+assert_eq "ok + symlink marker -> target left untouched" \
+  "target-untouched" "$(cat "$TMP_DIR/marker/real-target")"
+rm -f "$MARKER_FILE"
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/scripts/tests/registry-checkout.test.sh
+++ b/scripts/tests/registry-checkout.test.sh
@@ -164,6 +164,50 @@ assert_eq "fixture: empty path arg -> alert-no-git" \
   "alert-no-git" "$(check_registry_checkout "" main)"
 
 echo ""
+echo "restamp_deploy_marker tests (#33 deploy-marker self-heal)"
+echo "========================================================"
+
+mk_repo "$TMP_DIR/marker" main
+MARKER_HEAD="$(git -C "$TMP_DIR/marker" rev-parse HEAD)"
+MARKER_FILE="$TMP_DIR/marker/.deployed-commit"
+
+# ok verdict + existing (stale) marker -> rewritten to HEAD, returns 0.
+printf 'deadbeef\n' > "$MARKER_FILE"
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+assert_eq "ok + stale marker -> returns 0" "0" "$rc"
+assert_eq "ok + stale marker -> healed to HEAD" "$MARKER_HEAD" "$(cat "$MARKER_FILE")"
+
+# ok verdict + NO marker -> must not fabricate one (non-deploy checkout), returns 0.
+rm -f "$MARKER_FILE"
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+assert_eq "ok + no marker -> returns 0" "0" "$rc"
+assert_eq "ok + no marker -> no marker created" "no" \
+  "$([[ -f "$MARKER_FILE" ]] && echo yes || echo no)"
+
+# non-ok verdict must NEVER stamp, even with a marker present (don't bless a
+# dirty/branch-stranded tree).
+printf 'deadbeef\n' > "$MARKER_FILE"
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" alert-dirty || rc=$?
+assert_eq "alert-dirty + marker -> returns 0 (skip)" "0" "$rc"
+assert_eq "alert-dirty + marker -> left untouched" "deadbeef" "$(cat "$MARKER_FILE")"
+
+# no-arg call must not crash under set -euo pipefail (strict-mode contract).
+rc=0; restamp_deploy_marker || rc=$?
+assert_eq "no-arg restamp -> returns 0 (skip, no crash)" "0" "$rc"
+
+# ok verdict + marker present but UNWRITABLE -> returns 1 so the caller can warn
+# (this is the grimnir-validate.service read-only-sandbox case). Skipped as root,
+# where file permission bits don't block writes.
+if [[ "$(id -u)" != "0" ]]; then
+  printf 'deadbeef\n' > "$MARKER_FILE"
+  chmod 000 "$MARKER_FILE"
+  rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+  chmod 644 "$MARKER_FILE"
+  assert_eq "ok + unwritable marker -> returns 1 (surfaced)" "1" "$rc"
+  assert_eq "ok + unwritable marker -> content unchanged" "deadbeef" "$(cat "$MARKER_FILE")"
+fi
+
+echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 if [[ "$FAIL" -gt 0 ]]; then
   exit 1

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -230,6 +230,33 @@ assert_clean_failure "null entry in systemd_units" "$TMP_DIR/null-unit.json"
 echo '{ "components": [], "nodes": [null] }' > "$TMP_DIR/null-node.json"
 assert_clean_failure "null entry in nodes" "$TMP_DIR/null-node.json"
 
+# ── registry.js deploy-query invariant (#43 / #33) ──────────────────────────
+# The `deploy` projection derives each component's primary unit_type/scope from
+# systemd_units[0]. hugin must stay a user-scoped rsync service even after a
+# system-scoped `hugin-daily-analysis` timer was appended to its systemd_units —
+# appending units must never change the deploy row. Pin the real services.json
+# plus the ordering contract on a synthetic fixture.
+REGISTRY_JS="$SCRIPT_DIR/../lib/registry.js"
+deploy_row() {  # $1 = registry path, $2 = component name
+  REGISTRY_PATH="$1" QUERY=deploy node --input-type=commonjs "$REGISTRY_JS" 2>/dev/null \
+    | grep "^$2|" || true
+}
+assert_eq "real services.json: hugin deploy row unchanged by appended timer" \
+  "hugin|hugin|huginmunin.local|/home/magnus/repos/hugin|service|true|user|rsync" \
+  "$(deploy_row "$REPO_REGISTRY" hugin)"
+
+cat > "$TMP_DIR/order.json" << 'EOF'
+{
+  "components": [
+    { "name": "svc", "repo": "svc", "host": "h1.local", "port": 3030, "deploy": true, "scan": false, "deploy_path": "/x", "needs_build": true,
+      "systemd_units": [ { "name": "svc", "type": "service", "scope": "user" }, { "name": "svc-daily", "type": "timer" } ] }
+  ]
+}
+EOF
+assert_eq "deploy row derives type/scope from systemd_units[0] (service+user first)" \
+  "svc|svc|h1.local|/x|service|true|user|rsync" \
+  "$(deploy_row "$TMP_DIR/order.json" svc)"
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/services.json
+++ b/services.json
@@ -23,7 +23,8 @@
       "deploy_path": "/home/magnus/repos/hugin",
       "needs_build": true,
       "systemd_units": [
-        { "name": "hugin", "type": "service", "scope": "user" }
+        { "name": "hugin", "type": "service", "scope": "user" },
+        { "name": "hugin-daily-analysis", "type": "timer" }
       ]
     },
     {

--- a/systemd/grimnir-validate.service
+++ b/systemd/grimnir-validate.service
@@ -15,6 +15,12 @@ TimeoutStartSec=120
 # Sandboxing — read-only, needs network for SSH and Munin HTTP
 ProtectSystem=strict
 ReadOnlyPaths=/home/magnus/repos
+# Exception (#33): let the validate run self-heal ONLY the deploy marker so
+# Heimdall's drift detector doesn't false-flag grimnir after a session pulls the
+# tree forward outside a deploy. The '-' prefix makes it optional, so a checkout
+# without a marker yet still starts cleanly. Overrides ReadOnlyPaths/ProtectHome
+# for this single file only.
+ReadWritePaths=-/home/magnus/repos/grimnir/.deployed-commit
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHome=read-only


### PR DESCRIPTION
Two small grimnir-hygiene fixes, both grimnir-owned, both closing open issues.

## #43 — add `hugin-daily-analysis` timer to the SSOT
`services.json` listed only `hugin.service` for the `hugin` component, so Heimdall carried the `hugin-daily-analysis` timer as a manual `additive` overlay in `heimdall.config.json`. Added it to `systemd_units` — **appended second**, so `registry.js` still derives the component's primary `unit_type`/`scope` from `systemd_units[0]` (verified: `deploy` query still emits `hugin|…|service|true|user|rsync`). Heimdall can now drop the overlay.

**Discovery (filed to hugin):** the timer is installed on huginmunin but was **never `enable --now`'d** — deploy handles `hugin` as a user *service*, so `deploy.sh`'s timer-enable branch never fired for it. `hugin-daily-analysis.timer` is `inactive`/`disabled`, journal empty → **hugin's daily journal analysis has never run** since the feature commit. Adding it to the SSOT is what makes that gap visible; enabling it is hugin's to do.

## #33 — self-heal the git-pull deploy marker
Ground truth on huginmunin: grimnir `HEAD == origin/main` (clean) — the tree **is** current, kept so by session `git pull --ff-only`. But `.deployed-commit` (what Heimdall's drift detector reads) is only re-stamped by `deploy.sh`, so a tree pulled forward outside a deploy leaves the marker stale (`28ff65e` vs `cfb441e`) → Heimdall false-flagged all 4 grimnir units as behind for ~4 days.

Fix: in the `--validate` flow, when the canonical checkout is verified clean **and** on the default branch (the existing #47 integrity gate), re-stamp `HEAD` into `.deployed-commit`. Guarded on an existing marker (never fabricates one on a laptop run); never runs on a dirty/branch-stranded tree (those stay alert-worthy). `make deploy ARGS="grimnir"` also clears it immediately (git-pull mode stamps HEAD every deploy).

## Verification
- `bash -n` clean; `services.json` valid JSON.
- `deploy` query: hugin unchanged (`service|true|user|rsync`); `validate` query now carries both units.
- Self-heal unit-tested both ways: no-marker → doesn't create one; stale marker → heals to HEAD.

## Not in this PR (filed separately)
- grimnir-validate ignores `scope: user` — always uses system `systemctl is-active`, so user-scoped units (`hugin.service`) chronically false-report `inactive`. Pre-existing; grimnir-owned.

Closes #43
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)