### PR TITLE
docs: threat-model.md v0.1 (blind-spot audit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ No service code lives here — each component has its own repo.
 - `docs/tenant-validation-2026-07-04.md` — Evidence note from the first real non-Claude tenant run (Codex CLI, grimnir#58): seams A/B/C passed on transport, D blocked, per-tenant identity missing everywhere; harness in `scripts/tenant-validation/`
 - `docs/failure-recovery.md` — The autonomous-mutation undo convention: every autonomous mutation leaves a reversal recipe (git_revert / snapshot / irreversible+mitigation) + an audit event (issue #46)
 - `docs/gap-analysis-2026-07-03.md` — Critic-corrected ecosystem gap analysis vs vision v0.2: ranked gaps, quick wins, cut list, corrections log (the source of the 23-ticket fleet program)
-- `docs/threat-model.md` — Consolidated threat model (v0.1): assets, trust boundaries, adversaries, and a T1–T10 key-threats table mapped to owning tickets (from the 2026-07-06 blind-spot audit)
+- `docs/threat-model.md` — Consolidated threat model (v0.1): assets, trust boundaries, adversaries, and a T1–T11 key-threats table mapped to owning tickets (from the 2026-07-06 blind-spot audit)
 - `services.json` — **Single source of truth** for component inventory (names, hosts, ports, systemd units). All scripts read from it via `scripts/lib/registry.js`
 
 ## Scripts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ No service code lives here — each component has its own repo.
 - `docs/tenant-validation-2026-07-04.md` — Evidence note from the first real non-Claude tenant run (Codex CLI, grimnir#58): seams A/B/C passed on transport, D blocked, per-tenant identity missing everywhere; harness in `scripts/tenant-validation/`
 - `docs/failure-recovery.md` — The autonomous-mutation undo convention: every autonomous mutation leaves a reversal recipe (git_revert / snapshot / irreversible+mitigation) + an audit event (issue #46)
 - `docs/gap-analysis-2026-07-03.md` — Critic-corrected ecosystem gap analysis vs vision v0.2: ranked gaps, quick wins, cut list, corrections log (the source of the 23-ticket fleet program)
+- `docs/threat-model.md` — Consolidated threat model (v0.1): assets, trust boundaries, adversaries, and a T1–T10 key-threats table mapped to owning tickets (from the 2026-07-06 blind-spot audit)
 - `services.json` — **Single source of truth** for component inventory (names, hosts, ports, systemd units). All scripts read from it via `scripts/lib/registry.js`
 
 ## Scripts

--- a/STATUS.md
+++ b/STATUS.md
@@ -65,7 +65,7 @@ system's own recoverability, trustworthiness, or ROI.
   trifecta is open on interactive sessions (gating exists only on the Hugin queue path).
 - **Ground truth:** Skuld is `deploy:true` in services.json but has no unit on the box and has never
   run (`systemctl is-enabled` → not-found; journal empty); `munin-offsite.timer` IS live and firing.
-- **Artifacts:** `docs/threat-model.md` v0.1 (**PR #68**) — first consolidated threat model, T1–T10
+- **Artifacts:** `docs/threat-model.md` v0.1 (**PR #68**) — first consolidated threat model, T1–T11
   mapped to owning tickets. **14 `from:grimnir` tickets filed + on the Roadmap board:**
   grimnir#65 (succession), #66 (GDPR), #67 (system-ROI), #69 (Skuld SSOT drift), #70 (interactive
   trifecta); brokkr#38 (off-box dead-man's switch), #39 (off-site+restore), #40 (encryption-at-rest);

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -56,16 +56,16 @@
 
 | # | Threat | Vector | Current control | Residual | Tracked |
 |---|---|---|---|---|---|
-| T1 | Exfiltration via the **lethal trifecta** | Injection in ingested content → agent with memory+files+exec → egress | Hugin queue-path injection/exfil scanners + egress policy | **H** — detective only; `bypassPermissions` unconditional | hugin (permissions) |
-| T2 | Same trifecta on **interactive sessions** | Claude Code / Desktop reading raw email/Telegram with full Munin+Mimir access | *none* — gating exists only on the Hugin queue path | **H** | grimnir |
-| T3 | Command injection → fleet code-exec | Ratatoskr `/repo` path-traversal; LLM output submitted verbatim | Telegram owner-allowlist | **H** | ratatoskr |
-| T4 | Autonomous action unattributable / unlogged | Hugin mutates (commits/deploys/writes) but emits nothing to Verdandi; shared static tokens = no per-tenant identity | append-only Verdandi exists but is unfed by Hugin | **H** | hugin, verdandi#15 |
-| T5 | Audit-chain forgery on a compromised box | Attacker owns Pi 1, rewrites the chain and re-hashes | append-only trigger + SHA-256 chain; `GET /api/verify` | **M** — verify is manual + same-box; no off-box anchor | verdandi |
+| T1 | Exfiltration via the **lethal trifecta** | Injection in ingested content → agent with memory+files+exec → egress | Hugin queue-path injection/exfil scanners + egress policy | **H** — detective only; `bypassPermissions` unconditional | hugin#149 |
+| T2 | Same trifecta on **interactive sessions** | Claude Code / Desktop reading raw email/Telegram with full Munin+Mimir access | *none* — gating exists only on the Hugin queue path | **H** | grimnir#70 |
+| T3 | Command injection → fleet code-exec | Ratatoskr `/repo` path-traversal; LLM output submitted verbatim | Telegram owner-allowlist | **H** | ratatoskr#36 |
+| T4 | Autonomous action unattributable / unlogged | Hugin mutates (commits/deploys/writes) but emits nothing to Verdandi; shared static tokens = no per-tenant identity | append-only Verdandi exists but is unfed by Hugin | **H** | hugin#148, verdandi#15 |
+| T5 | Audit-chain forgery on a compromised box | Attacker owns Pi 1, rewrites the chain and re-hashes | append-only trigger + SHA-256 chain; `GET /api/verify` | **M** — verify is manual + same-box; no off-box anchor | verdandi#16 |
 | T6 | Supply-chain compromise | Malicious transitive npm dep in a Node service | weekly `security-scan.sh` (`npm audit`) + systemd sandbox | **M** | (scan exists) |
-| T7 | Physical theft → plaintext data at rest | Stolen Pi / SD card / NAS disk | file perms `0600`; **SD cards likely NOT encrypted — verify** | **H** if unencrypted | brokkr (verify FDE) |
-| T8 | Silent total-host failure | Pi 1 dies; monitoring + alerting die with it | on-box watchdog only | **M/H** — no off-box dead-man's switch | brokkr |
-| T9 | Backup loss / unrecoverable restore | NAS disk failure; restore never tested | Munin encrypted off-site; other stores on-prem only | **H** | brokkr |
-| T10 | Poisoned memory drives bad action | A false stored "fact" retrieved and acted on repeatedly | secret-scan on write; no correction / expiry path | **M** | munin-memory |
+| T7 | Physical theft → plaintext data at rest | Stolen Pi / SD card / NAS disk | file perms `0600`; **SD cards likely NOT encrypted — verify** | **H** if unencrypted | brokkr#40 |
+| T8 | Silent total-host failure | Pi 1 dies; monitoring + alerting die with it | on-box watchdog only | **M/H** — no off-box dead-man's switch | brokkr#38 |
+| T9 | Backup loss / unrecoverable restore | NAS disk failure; restore never tested | Munin encrypted off-site; other stores on-prem only | **H** | brokkr#39 |
+| T10 | Poisoned memory drives bad action | A false stored "fact" retrieved and acted on repeatedly | secret-scan on write; no correction / expiry path | **M** | munin-memory#192 |
 
 ## 6. Explicitly accepted / out-of-scope (for now)
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,8 +1,8 @@
-# Grimnir — Threat Model (v0.1, draft)
+# Grimnir — Threat Model (v0.1)
 
-> **Status:** v0.1 skeleton — 2026-07-06. Seeded by a local M5 model, then verified and
-> edited against the 2026-07-06 blind-spot audit. **Needs owner review.** Every residual-**High**
-> row in §5 is tracked as a `from:grimnir` ticket (see the *Tracked* column).
+> **Status:** v0.1 — 2026-07-06, owner-reviewed 2026-07-07. Seeded by a local M5 model, then
+> verified and edited against the 2026-07-06 blind-spot audit. Every residual-**High** row in §5
+> is tracked as a `from:grimnir` ticket (see the *Tracked* column).
 >
 > Companion to [`architecture.md`](architecture.md) (the *how*) and [`vision.md`](vision.md) (the
 > *why*). This is the *what-we-defend-against* — the artifact that was deferred as "Phase B" and is
@@ -13,9 +13,9 @@
 ## 1. Scope & assumptions
 
 - **Single operator** (Magnus) — one fully-trusted human; no multi-user model today.
-- **Sovereignty:** data *at rest* lives on-prem (Pi 1, Pi 2 / NAS, M5). Two deliberate exceptions:
-  cloud AI models *process* prompts statelessly (the replaceable "tenant"), and Munin ships an
-  **encrypted** off-site backup leg (`rclone`-crypt). Cloudflare fronts public ingress.
+- **Sovereignty:** data *at rest* lives on-prem (Pi 1, Pi 2 / NAS, M5). Deliberate exceptions:
+  cloud AI models may process prompts but are not treated as storage authority; Munin ships an
+  **encrypted** off-site backup leg (`rclone`-crypt); Cloudflare fronts public ingress.
 - **In scope:** confidentiality / integrity / availability of the two pillars (Sovereign Memory,
   Self-Knowing Inference) and the accounting + client data they touch.
 - **Threat horizon:** opportunistic and injection-borne compromise, operator error, hardware loss —
@@ -34,10 +34,11 @@
 
 ## 3. Trust boundaries
 
-- **Fully trusted:** the operator; local process-scope on each box.
+- **Fully trusted:** the operator; admin-controlled host accounts and root contexts. Individual
+  service processes and dependencies are not automatically trusted once compromised.
 - **Semi-trusted (soft):** the Tailscale mesh — treated as an internal network, but any compromised
-  device on it can reach loopback-bound services. The per-service **bearer auth is the real control**,
-  not the tailnet perimeter.
+  device on it can reach services bound to the tailnet/LAN or exposed through tunnels. The
+  per-service **bearer auth is the real control**, not the tailnet perimeter.
 - **Untrusted:** all *ingested content* (email, web, documents, Telegram messages / forwards / voice
   transcripts), npm dependencies, the public internet.
 - **Key crossings:** untrusted content → agent (holding Munin + Mimir + execution) → outbound
@@ -66,6 +67,7 @@
 | T8 | Silent total-host failure | Pi 1 dies; monitoring + alerting die with it | on-box watchdog only | **M/H** — no off-box dead-man's switch | brokkr#38 |
 | T9 | Backup loss / unrecoverable restore | NAS disk failure; restore never tested | Munin encrypted off-site; other stores on-prem only | **H** | brokkr#39 |
 | T10 | Poisoned memory drives bad action | A false stored "fact" retrieved and acted on repeatedly | secret-scan on write; no correction / expiry path | **M** | munin-memory#192 |
+| T11 | Third-party data retained without a data map / erasure path | Client/accounting/person data accumulates across Mimir, Munin, Fortnox exports, backups | ad hoc namespace tags + file permissions; no formal data map / retention / erasure policy | **M/H** | grimnir#66 |
 
 ## 6. Explicitly accepted / out-of-scope (for now)
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,83 @@
+# Grimnir — Threat Model (v0.1, draft)
+
+> **Status:** v0.1 skeleton — 2026-07-06. Seeded by a local M5 model, then verified and
+> edited against the 2026-07-06 blind-spot audit. **Needs owner review.** Every residual-**High**
+> row in §5 is tracked as a `from:grimnir` ticket (see the *Tracked* column).
+>
+> Companion to [`architecture.md`](architecture.md) (the *how*) and [`vision.md`](vision.md) (the
+> *why*). This is the *what-we-defend-against* — the artifact that was deferred as "Phase B" and is
+> named here for the first time.
+
+---
+
+## 1. Scope & assumptions
+
+- **Single operator** (Magnus) — one fully-trusted human; no multi-user model today.
+- **Sovereignty:** data *at rest* lives on-prem (Pi 1, Pi 2 / NAS, M5). Two deliberate exceptions:
+  cloud AI models *process* prompts statelessly (the replaceable "tenant"), and Munin ships an
+  **encrypted** off-site backup leg (`rclone`-crypt). Cloudflare fronts public ingress.
+- **In scope:** confidentiality / integrity / availability of the two pillars (Sovereign Memory,
+  Self-Knowing Inference) and the accounting + client data they touch.
+- **Threat horizon:** opportunistic and injection-borne compromise, operator error, hardware loss —
+  **not** a targeted nation-state adversary.
+
+## 2. Assets (ranked)
+
+| Asset | Why it hurts if lost or leaked |
+|---|---|
+| Mimir files (client docs, Fortnox exports, personal) | Breach of *third-party* client / financial data — legal + reputational, not just personal |
+| Munin memory (SQLite, local embeddings) | Loss = erased context; leak = a searchable index of everything personal; a wrong "fact" silently poisons autonomous action |
+| Verdandi audit chain | The record of what was done; if forgeable or lost there is no accountability for autonomous action |
+| Secrets & tokens (per-service bearer, OAuth, keychain) | Compromise → substrate takeover / lateral movement |
+| noxctl / Fortnox credentials + data | Money movement + customer PII |
+| Capability ledger / `m5-routing` | Poisoning re-routes work to the wrong or unsafe model |
+
+## 3. Trust boundaries
+
+- **Fully trusted:** the operator; local process-scope on each box.
+- **Semi-trusted (soft):** the Tailscale mesh — treated as an internal network, but any compromised
+  device on it can reach loopback-bound services. The per-service **bearer auth is the real control**,
+  not the tailnet perimeter.
+- **Untrusted:** all *ingested content* (email, web, documents, Telegram messages / forwards / voice
+  transcripts), npm dependencies, the public internet.
+- **Key crossings:** untrusted content → agent (holding Munin + Mimir + execution) → outbound
+  network; Telegram → Ratatoskr → Hugin task; laptop / interactive session → Munin + Mimir.
+
+## 4. Adversaries
+
+- **Prompt-injection via ingested content** — the primary realistic threat: untrusted text steers an
+  agent that holds memory + files + execution.
+- **Compromised laptop or Telegram account** — inherits the operator's full trust.
+- **Malicious / compromised npm dependency** in a Node service.
+- **Tailnet-present attacker** (lost phone, compromised device on the mesh).
+- **Physical theft / loss** of a Pi or the NAS disk.
+
+## 5. Key threats
+
+| # | Threat | Vector | Current control | Residual | Tracked |
+|---|---|---|---|---|---|
+| T1 | Exfiltration via the **lethal trifecta** | Injection in ingested content → agent with memory+files+exec → egress | Hugin queue-path injection/exfil scanners + egress policy | **H** — detective only; `bypassPermissions` unconditional | hugin (permissions) |
+| T2 | Same trifecta on **interactive sessions** | Claude Code / Desktop reading raw email/Telegram with full Munin+Mimir access | *none* — gating exists only on the Hugin queue path | **H** | grimnir |
+| T3 | Command injection → fleet code-exec | Ratatoskr `/repo` path-traversal; LLM output submitted verbatim | Telegram owner-allowlist | **H** | ratatoskr |
+| T4 | Autonomous action unattributable / unlogged | Hugin mutates (commits/deploys/writes) but emits nothing to Verdandi; shared static tokens = no per-tenant identity | append-only Verdandi exists but is unfed by Hugin | **H** | hugin, verdandi#15 |
+| T5 | Audit-chain forgery on a compromised box | Attacker owns Pi 1, rewrites the chain and re-hashes | append-only trigger + SHA-256 chain; `GET /api/verify` | **M** — verify is manual + same-box; no off-box anchor | verdandi |
+| T6 | Supply-chain compromise | Malicious transitive npm dep in a Node service | weekly `security-scan.sh` (`npm audit`) + systemd sandbox | **M** | (scan exists) |
+| T7 | Physical theft → plaintext data at rest | Stolen Pi / SD card / NAS disk | file perms `0600`; **SD cards likely NOT encrypted — verify** | **H** if unencrypted | brokkr (verify FDE) |
+| T8 | Silent total-host failure | Pi 1 dies; monitoring + alerting die with it | on-box watchdog only | **M/H** — no off-box dead-man's switch | brokkr |
+| T9 | Backup loss / unrecoverable restore | NAS disk failure; restore never tested | Munin encrypted off-site; other stores on-prem only | **H** | brokkr |
+| T10 | Poisoned memory drives bad action | A false stored "fact" retrieved and acted on repeatedly | secret-scan on write; no correction / expiry path | **M** | munin-memory |
+
+## 6. Explicitly accepted / out-of-scope (for now)
+
+- **Nation-state / targeted APT** — out of scope.
+- **Multi-user isolation** — single operator; Munin's multi-principal (Sara) support is access-sharing,
+  not a security boundary.
+- **The operator as an insider threat** — trusted by definition.
+- *Everything in §5 is a **tracked gap**, not an accepted risk.*
+
+## 7. Review cadence
+
+- Re-review **quarterly**, and on any change to: Hugin execution/permissions, Ratatoskr input
+  handling, the auth model, or Tailscale / Cloudflare exposure.
+- Each residual-**H** row must have an owning ticket and a target; close the row when its control
+  moves the risk to **M** or lower.


### PR DESCRIPTION
## What
First consolidated **threat model** for Grimnir (`docs/threat-model.md`) — the artifact deferred as "Phase B" in STATUS. v0.1 skeleton, needs owner review.

## Why
The 2026-07-06 blind-spot audit found no threat model existed anywhere in the fleet, while security mitigations were scattered per-component with no statement of the adversary, trust boundaries, or residual risk. This names them.

## Contents
- Scope/assumptions, ranked assets, trust boundaries, adversaries
- A key-threats table (T1–T10): vector / current control / residual risk / owning ticket
- Explicitly accepted + out-of-scope risks; review cadence

## Provenance
Skeleton seeded by a local M5 model (`qwen3-30b-instruct`), then verified and corrected against the audit — fixed a false "no SaaS dependencies" claim, reframed audit-verification from "accepted" to "tracked", and added supply-chain, physical/FDE, unlogged-autonomous-action, and poisoned-memory rows.

Residual-**High** threats are tracked by the `from:grimnir` tickets filed 2026-07-06 (hugin, ratatoskr, brokkr, verdandi, munin-memory, grimnir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
