### PR TITLE
Fix registry-driven unit deploy and validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ No service code lives here — each component has its own repo.
 ## Key documents
 
 - `docs/architecture.md` — Full system architecture guide (topology, components, security, data flow)
-- `docs/full-architecture.md` — Auto-generated comprehensive doc (run `make docs` or `scripts/generate-architecture.sh` to regenerate)
+- `docs/full-architecture.md` — Ignored, auto-generated comprehensive doc (run `make docs` or `scripts/generate-architecture.sh` on the Pi to regenerate a local snapshot)
 - `docs/conventions.md` — Naming, GitHub ownership, service patterns
 - `docs/role-separation.md` — Why the canonical grimnir checkout must not double as a deploy target or hugin workspace, and the validate check that alarms on drift (issue #47)
 - `docs/observability-and-improvement.md` — How components capture traces, score outputs, and feed the self-improving loop

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal AI infrastructure that gives Claude persistent memory, file access, and autonomous task execution across every environment — from a phone on the bus to a terminal at the desk.
 
-Runs on two Raspberry Pis and a MacBook. All data stays on your hardware.
+Runs on two Raspberry Pis, a MacBook, and a local M5 inference box. All data stays on your hardware.
 
 ## Components
 
@@ -46,4 +46,4 @@ This is a personal infrastructure project. The documentation is public for refer
 
 ---
 
-*Built by Magnus Gille, with Claude and Codex. Running on two Raspberry Pis in Mariefred, Sweden.*
+*Built by Magnus Gille, with Claude and Codex. Running on local hardware in Mariefred, Sweden.*

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,39 @@
 # Grimnir System — Status
 
-**Last session:** 2026-07-06 (Opus) — blind-spot audit → threat model + 14 tickets
-**Branch:** main (PR #68 open on `docs/threat-model`)
+**Last session:** 2026-07-07 (Codex) — registry unit/deploy validation cleanup
+**Branch:** `codex/registry-unit-validation` worktree at `/Users/magnus/repos/grimnir-worktrees/registry-unit-validation` (draft PR #71)
+
+## Completed This Session (2026-07-07) — registry units are deploy/validation truth, Skuld port drift removed
+
+Followed up the adversarial repo review with a focused branch for the operationally risky findings.
+
+- **Registry projection:** `QUERY=deploy` now carries full `systemd_units` JSON, and `QUERY=validate`
+  carries `deploy_path` so consumers do not collapse multi-unit components to `systemd_units[0]` or
+  assume `~/repos/<repo>`.
+- **Deploy flow:** `scripts/deploy.sh` now installs every declared unit from either `systemd/` or
+  root-level unit files, restarts services by scope, enables timers by scope, and installs matching
+  oneshot service companions for timers when present. This directly addresses the hugin daily-analysis
+  and Skuld timer classes.
+- **Validation/snapshot flow:** `scripts/generate-architecture.sh --validate` now honors user vs system
+  scope, checks timers as timers, and reports missing remote checkouts instead of treating them as
+  current. Snapshot generation now includes unit scope and type-aware rows.
+- **Registry truth:** Skuld no longer declares port `3040`; it is a timer-only briefing producer whose
+  web view is rendered by Heimdall from Munin. A follow-up M5-assisted review caught that the
+  root-level `skuld.service` has no `User=`, so `skuld.timer` is now explicitly user-scoped in the
+  registry and pinned by the smoke test.
+- **Docs:** Updated `README.md`, `docs/architecture.md`, `docs/scheduled-tasks.md`, and `CLAUDE.md`
+  to remove the stale Skuld web/API surface and M5 “awaiting delivery” wording, and to describe
+  deploy modes more honestly.
+- **Verification:** `make test` passed; CI-equivalent `shellcheck scripts/*.sh scripts/lib/*.sh
+  scripts/tests/*.sh` passed; `bash -n` passed for shell scripts; registry projections and
+  `validate-registry.js` passed after the M5 review follow-up.
+
+### Pending / next
+- Review draft PR #71.
+- After merge, deploy `grimnir`, then deploy affected component repos (`hugin`, `heimdall`, `skuld`) so
+  declared secondary timers are installed/enabled from the corrected deploy path.
+- Re-run `grimnir-validate.service` on huginmunin and check that hugin/verdandi user units and Skuld
+  no-port behavior report correctly.
 
 ## Completed This Session (2026-07-06) — blind-spot audit: vision alignment + threat-model v0.1 + 14 from:grimnir tickets
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 
 ## The Grimnir System
 
-Grimnir is a personal AI infrastructure that gives Claude persistent memory, file access, and autonomous task execution across every environment — from a phone on the bus to a terminal at the desk. It runs on two Raspberry Pis and a MacBook, under the principle that **data sovereignty and simplicity beat sophistication**.
+Grimnir is a personal AI infrastructure that gives Claude persistent memory, file access, local inference, and autonomous task execution across every environment — from a phone on the bus to a terminal at the desk. It runs on two Raspberry Pis, a MacBook, and a BosGame M5 inference node, under the principle that **data sovereignty and simplicity beat sophistication**.
 
 ### Why it exists
 
@@ -35,7 +35,7 @@ Three principles guide every decision:
 | **Hugin** | Task dispatcher | 3032 | Pi 1 | `hugin` |
 | **Heimdall** | Monitoring dashboard | 3033 | Pi 1 | `heimdall` |
 | **Ratatoskr** | Telegram router + concierge | 3034 | Pi 1 | `ratatoskr` |
-| **Skuld** | Daily intelligence briefing | 3040 | Pi 1 | `skuld` (grimnir-bot) |
+| **Skuld** | Daily intelligence briefing | — | Pi 1 | `skuld` (grimnir-bot) |
 | **Verdandi** | Tamper-evident audit log | 3036 | Pi 1 | `verdandi` |
 | **Mimir** | Authenticated file server | 3031 | Pi 2 (NAS) | `mimir` |
 | **noxctl** | Accounting CLI + MCP | — | Laptop (global) | `fortnox-mcp` |
@@ -45,7 +45,7 @@ Three principles guide every decision:
 
 ## System Topology
 
-The system spans two Raspberry Pis and a MacBook Air, connected via Tailscale (private mesh VPN) and exposed to cloud services through Cloudflare Tunnels.
+The system spans two Raspberry Pis, a MacBook Air, and a BosGame M5 inference node, connected via Tailscale (private mesh VPN) and exposed to cloud services through Cloudflare Tunnels where needed.
 
 ```mermaid
 graph TB
@@ -69,7 +69,7 @@ graph TB
         Hugin["Hugin Dispatcher<br/>:3032 (health only)"]
         Heimdall_Svc["Heimdall Dashboard<br/>:3033 (Fastify + HTMX)"]
         Ratatoskr_Svc["Ratatoskr Router<br/>:3034 (Telegram bot)"]
-        Skuld_Svc["Skuld Briefing<br/>:3040 (web UI)"]
+        Skuld_Svc["Skuld Briefing<br/>(systemd timer)"]
         Verdandi_Svc["Verdandi Audit<br/>:3036 (Fastify)"]
         Claude_Pi[Claude Code / Codex<br/>spawned by Hugin]
         Tunnel_Pi1["cloudflared tunnel"]
@@ -102,7 +102,7 @@ graph TB
     Codex -->|HTTP Bearer| Munin
     Hugin -->|HTTP JSON-RPC| Munin
     Claude_Pi -->|MCP stdio or HTTP| Munin
-    Skuld_Svc -->|SQLite direct read| Munin
+    Skuld_Svc -->|SQLite read + API write| Munin
     Skuld_Svc -->|Claude API| Internet
     Heimdall_Svc -->|SQLite read + SSH| Pi2
 
@@ -135,7 +135,7 @@ graph TB
 | Pi 2 | NAS | Storage & backup | Mimir, Samba, Time Machine |
 | M5 | `m5` (tailnet `100.76.72.59`) | Local LLM inference (1–5 users) | Home-server gateway, llama-swap |
 
-Both Pis are Raspberry Pi 5 units (8 GB RAM) in Flirc passive-cooling aluminum cases. They run on the same local network and are also connected via Tailscale for reliable cross-Pi communication. The BosGame M5 (awaiting delivery) joins as a dedicated local-inference node — see *Home-server (M5) — Local Inference* below and the gateway API contract in the `home-server-inference-evaluation` repo.
+Both Pis are Raspberry Pi 5 units (8 GB RAM) in Flirc passive-cooling aluminum cases. They run on the same local network and are also connected via Tailscale for reliable cross-Pi communication. The BosGame M5 is the dedicated local-inference node — see *Home-server (M5) — Local Inference* below and the gateway API contract in the `home-server-inference-evaluation` repo.
 
 ### Network model
 
@@ -519,7 +519,7 @@ Heimdall is the watchman. It provides at-a-glance health visibility for the enti
 
 ### Design principle
 
-**Heimdall answers one question: "Is the system healthy?"** Green/yellow/red for every service, backup, and resource. It does not try to be the UI for any service — no Munin browser, no task submission, no briefing rendering. For service-specific UIs, use the service directly (e.g., Skuld's web UI at :3040).
+**Heimdall answers one question: "Is the system healthy?"** Green/yellow/red for every service, backup, and resource. It does not try to be the UI for every service — no Munin browser and no task submission. Skuld is the exception by design: Heimdall renders the latest briefing from Munin because Skuld has no standalone web surface.
 
 ### Data collection
 
@@ -529,9 +529,8 @@ Pull model with systemd timers:
 
 ### Planned additions
 
-- Skuld briefing status (last run, success/failure) — pending Skuld systemd timer
+- Skuld briefing status (last run, success/failure)
 - Deploy drift UI — collector exists, needs dashboard wiring
-- Link to Skuld web UI
 
 ---
 
@@ -542,7 +541,7 @@ Skuld is the oracle. Named after the Norn of the future, it generates a daily in
 ### Architecture
 
 - **Runtime:** Node.js 22+, TypeScript (strict mode)
-- **Framework:** Express (web UI + API)
+- **Interface:** CLI / oneshot systemd service; no standalone web server
 - **AI:** @anthropic-ai/sdk (Claude API direct)
 - **Data sources:** Google Calendar (ICS), Munin (SQLite direct read), Fortnox (future via noxctl)
 - **Deployment:** Pi 1, co-located with Munin for low-latency SQLite reads
@@ -553,7 +552,7 @@ Skuld is the oracle. Named after the Norn of the future, it generates a daily in
 1. **Collect** — Fetches calendar events (ICS feed), queries Munin for active projects/client statuses/weekly plan/recent logs
 2. **Assemble** — Builds a `BriefingContext` with structured data from all sources
 3. **Synthesize** — Sends context to Claude API with a narrative system prompt ("trusted chief of staff" persona)
-4. **Deliver** — Outputs briefing to stdout (formatted), Munin (`briefings/daily/{date}`), and web UI
+4. **Deliver** — Outputs briefing to stdout (formatted) and Munin (`briefings/daily/{date}` / `briefings/latest`); Heimdall renders the web view from Munin
 
 ### Briefing sections
 
@@ -567,8 +566,7 @@ Skuld is the oracle. Named after the Norn of the future, it generates a daily in
 | Channel | Access |
 |---------|--------|
 | CLI (`skuld briefing`) | Direct on Pi |
-| Web UI (`GET /`) | Browser at :3040 |
-| JSON API (`GET /api/briefing`) | Programmatic |
+| Heimdall (`/briefing`) | Web view rendered from Munin |
 | Munin (`briefings/daily/{date}`) | Any Claude environment |
 
 ### Roadmap
@@ -727,10 +725,10 @@ This isn't just convenience; it's necessity. Claude.ai and Claude Mobile can acc
 All services follow the same deployment model:
 
 1. **Build locally** — `npm run build` compiles TypeScript to `dist/`
-2. **Deploy via script** — `scripts/deploy-*.sh` rsyncs the repo tree to the target Pi, runs `npm install --omit=dev`, installs systemd unit, restarts service. `.env` files are preserved on the Pi and never overwritten.
-3. **systemd manages the process** — `Restart=always`, sandboxed
-4. **Health endpoints** — every service exposes `/health` for Heimdall monitoring
-5. **Auto-deploy** — Heimdall uses a systemd path watcher on `.git/refs/heads/main` to restart on new commits (deployed by Hugin tasks)
+2. **Deploy via script** — `scripts/deploy.sh` reads `services.json`, syncs or pulls the target tree, runs `npm install --omit=dev` where applicable, installs every declared systemd unit, restarts services, and enables timers. `.env` files are preserved on the Pi and never overwritten.
+3. **systemd manages the process or schedule** — services use `Restart=always` where appropriate; timer components run oneshot jobs on schedule.
+4. **Health endpoints** — long-running HTTP services expose `/health` for Heimdall monitoring; timer-only components are validated through systemd state and their Munin outputs.
+5. **Deploy modes differ by component** — most services deploy by rsync; `grimnir` uses `git pull --ff-only` because its canonical checkout is also the registry source.
 
 There is no CI/CD pipeline. Deploys are manual and intentional — appropriate for a single-operator system.
 

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -1,13 +1,13 @@
 # Scheduled Tasks Registry
 
 > All automated tasks running on Grimnir infrastructure.
-> Last updated: 2026-06-15.
+> Last updated: 2026-07-07.
 
 ---
 
 ## Overview
 
-All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where noted. Timer units live in each service's repo under `systemd/`. Heimdall monitors all timers via its Deploy Status card.
+All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where noted. Timer units usually live under `systemd/`, but root-level `{name}.service` / `{name}.timer` files are also supported by `scripts/deploy.sh`. Declared timer inventory lives in `services.json`.
 
 ---
 
@@ -43,7 +43,7 @@ All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where no
 | **Unit** | `skuld.timer` / `skuld.service` |
 | **Repo** | `skuld` (grimnir-bot org) |
 | **Purpose** | Synthesize calendar, project state, and Munin context into a morning briefing via Claude API |
-| **Output** | Munin: `briefings/daily/{date}`, web UI at :3040 |
+| **Output** | Munin: `briefings/daily/{date}` and `briefings/latest`; Heimdall renders `/briefing` |
 | **Why it exists** | Morning orientation — what's on today, what changed overnight, what needs attention |
 
 ### Hugin Daily Journal Analysis
@@ -91,7 +91,7 @@ All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where no
 ## Adding a new scheduled task
 
 1. Create the script in the relevant repo's `scripts/` directory.
-2. Create `systemd/{name}.service` (Type=oneshot) and `systemd/{name}.timer` in the same repo.
-3. Add the timer to Heimdall's `heimdall.config.json` as a `"type": "timer"` service entry.
+2. Create `systemd/{name}.service` (Type=oneshot) and `systemd/{name}.timer` in the same repo, or root-level `{name}.service` / `{name}.timer` if that repo already uses root-level units.
+3. Add the timer to the owning component's `systemd_units` in `services.json`.
 4. Update this document.
-5. Deploy: `make deploy ARGS="grimnir"` — `scripts/deploy.sh` now has a timer-install branch that copies units from `systemd/` to `/etc/systemd/system/`, runs `daemon-reload`, and `enable --now`s all timers automatically. No manual systemctl step needed for grimnir-repo timers.
+5. Deploy the owning component — `scripts/deploy.sh` installs every declared unit, runs `daemon-reload`, and enables timers automatically. No manual systemctl step should be needed.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,8 @@ GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
 REGISTRY="$GRIMNIR_DIR/services.json"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 
-# Read deployable services from registry: name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode
+# Read deployable services from registry:
+# name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json
 SERVICES=()
 while IFS= read -r line; do
   [[ -n "$line" ]] && SERVICES+=("$line")
@@ -96,8 +97,35 @@ resolve_local_path() {
   echo "${LOCAL_REPOS_ROOT}/${repo}"
 }
 
+unit_rows() {
+  local units_json=$1 fallback_name=$2 fallback_type=$3 fallback_scope=$4
+  UNITS_JSON="$units_json" FALLBACK_NAME="$fallback_name" FALLBACK_TYPE="$fallback_type" FALLBACK_SCOPE="$fallback_scope" \
+    node --input-type=commonjs -e '
+      var units = [];
+      try {
+        units = JSON.parse(process.env.UNITS_JSON || "[]");
+      } catch (_) {
+        units = [];
+      }
+      if (!Array.isArray(units) || units.length === 0) {
+        units = [{
+          name: process.env.FALLBACK_NAME,
+          type: process.env.FALLBACK_TYPE || "service",
+          scope: process.env.FALLBACK_SCOPE || "system"
+        }];
+      }
+      units.forEach(function (u) {
+        process.stdout.write([
+          u.name,
+          u.type || "service",
+          u.scope || "system"
+        ].join("|") + "\n");
+      });
+    '
+}
+
 deploy_service() {
-  local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync}
+  local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync} units_json=${9:-[]}
   local local_path
   local remote_host
   local remote
@@ -214,39 +242,65 @@ deploy_service() {
   fi # end rsync-mode block (deploy_mode != git-pull)
 
   local cmd="cd '$deploy_path' && "
-  if [[ "$unit_type" == "service" && "$unit_scope" == "user" ]]; then
-    # User unit (systemctl --user). Sync unit file from repo's systemd/
-    # subdir if present, then restart via the *user* manager. No sudo, and
-    # critically no stop/disable of the user instance — for a user-scoped
-    # service that instance IS the service, not a stray leftover.
-    cmd+="if [ -f systemd/${name}.service ]; then"
-    cmd+=" install -D -m644 systemd/${name}.service \"\$HOME/.config/systemd/user/${name}.service\""
-    cmd+=" && systemctl --user daemon-reload"
-    cmd+=" && echo '  user unit file synced'; fi && "
-    cmd+="systemctl --user restart ${name} && "
-  elif [[ "$unit_type" == "service" ]]; then
-    # System unit. Sync unit file from repo's systemd/ subdir if present
-    # (no placeholders expected there).
-    cmd+="if [ -f systemd/${name}.service ]; then"
-    cmd+=" sudo cp systemd/${name}.service /etc/systemd/system/${name}.service"
-    cmd+=" && sudo systemctl daemon-reload"
-    cmd+=" && echo '  unit file synced'; fi && "
-    # Kill any leftover user-unit instance holding the port before the system unit restarts
-    cmd+="systemctl --user stop ${name} 2>/dev/null || true && "
-    cmd+="systemctl --user disable ${name} 2>/dev/null || true && "
-    cmd+="sudo systemctl restart ${name} && "
-  elif [[ "$unit_type" == "timer" ]]; then
-    # Timer component (e.g. grimnir, skuld). These have no long-running service
-    # to restart; instead install ALL oneshot services + timers from systemd/,
-    # daemon-reload, and enable --now every timer. Idempotent — safe per deploy.
-    # (Previously timers were installed entirely by hand; this closes that gap.)
-    # `|| continue` keeps a non-matching glob (left literal when nullglob is
-    # unset) from leaking a failed `[ -f ]` status into the && chain.
-    cmd+="for u in systemd/*.service systemd/*.timer; do [ -f \"\$u\" ] || continue; sudo cp \"\$u\" /etc/systemd/system/ || exit 1; done && "
-    cmd+="sudo systemctl daemon-reload && "
-    cmd+="for t in systemd/*.timer; do [ -f \"\$t\" ] || continue; sudo systemctl enable --now \"\$(basename \"\$t\")\" || exit 1; done && "
-    cmd+="echo '  timers synced & enabled' && "
+  local rows unit_name unit_kind unit_actual_scope unit_file companion_file
+  local user_needs_reload=false system_needs_reload=false
+  local user_services=() system_services=() user_timers=() system_timers=()
+
+  rows="$(unit_rows "$units_json" "$name" "$unit_type" "$unit_scope")"
+  while IFS='|' read -r unit_name unit_kind unit_actual_scope; do
+    [[ -n "$unit_name" ]] || continue
+    unit_file="${unit_name}.${unit_kind}"
+
+    if [[ "$unit_actual_scope" == "user" ]]; then
+      cmd+="unit_src=''; for f in systemd/${unit_file} ${unit_file}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
+      cmd+="[ -n \"\$unit_src\" ] || { echo 'ERROR: unit file missing: ${unit_file}' >&2; exit 1; }; "
+      cmd+="install -D -m644 \"\$unit_src\" \"\$HOME/.config/systemd/user/${unit_file}\" && "
+      user_needs_reload=true
+      if [[ "$unit_kind" == "service" ]]; then
+        user_services+=("$unit_name")
+      elif [[ "$unit_kind" == "timer" ]]; then
+        companion_file="${unit_name}.service"
+        cmd+="companion_src=''; for f in systemd/${companion_file} ${companion_file}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
+        cmd+="if [ -n \"\$companion_src\" ]; then install -D -m644 \"\$companion_src\" \"\$HOME/.config/systemd/user/${companion_file}\"; fi && "
+        user_timers+=("$unit_name")
+      fi
+    else
+      cmd+="unit_src=''; for f in systemd/${unit_file} ${unit_file}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
+      cmd+="[ -n \"\$unit_src\" ] || { echo 'ERROR: unit file missing: ${unit_file}' >&2; exit 1; }; "
+      cmd+="sudo install -D -m644 \"\$unit_src\" \"/etc/systemd/system/${unit_file}\" && "
+      system_needs_reload=true
+      if [[ "$unit_kind" == "service" ]]; then
+        system_services+=("$unit_name")
+      elif [[ "$unit_kind" == "timer" ]]; then
+        companion_file="${unit_name}.service"
+        cmd+="companion_src=''; for f in systemd/${companion_file} ${companion_file}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
+        cmd+="if [ -n \"\$companion_src\" ]; then sudo install -D -m644 \"\$companion_src\" \"/etc/systemd/system/${companion_file}\"; fi && "
+        system_timers+=("$unit_name")
+      fi
+    fi
+  done <<< "$rows"
+
+  if [[ "$user_needs_reload" == "true" ]]; then
+    cmd+="systemctl --user daemon-reload && "
   fi
+  if [[ "$system_needs_reload" == "true" ]]; then
+    cmd+="sudo systemctl daemon-reload && "
+  fi
+  for unit_name in ${user_services[@]+"${user_services[@]}"}; do
+    cmd+="systemctl --user restart ${unit_name}.service && "
+  done
+  for unit_name in ${system_services[@]+"${system_services[@]}"}; do
+    # Kill any leftover user-unit instance holding the port before the system unit restarts.
+    cmd+="{ systemctl --user stop ${unit_name}.service 2>/dev/null || true; } && "
+    cmd+="{ systemctl --user disable ${unit_name}.service 2>/dev/null || true; } && "
+    cmd+="sudo systemctl restart ${unit_name}.service && "
+  done
+  for unit_name in ${user_timers[@]+"${user_timers[@]}"}; do
+    cmd+="systemctl --user enable --now ${unit_name}.timer && "
+  done
+  for unit_name in ${system_timers[@]+"${system_timers[@]}"}; do
+    cmd+="sudo systemctl enable --now ${unit_name}.timer && "
+  done
   # Stamp the deployed commit so Heimdall's drift detector has an authoritative
   # source (excluded from rsync above so --delete won't clobber it). Heimdall
   # reads <deploy_path>/.deployed-commit instead of trusting /health (often no
@@ -284,7 +338,7 @@ deploy_service() {
 requested=("$@")
 
 for entry in "${SERVICES[@]}"; do
-  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope deploy_mode <<< "$entry"
+  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope deploy_mode units_json <<< "$entry"
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false
@@ -294,7 +348,7 @@ for entry in "${SERVICES[@]}"; do
     $match || continue
   fi
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}"
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}"
 done
 
 # Summary

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -44,6 +44,26 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+unit_rows_from_json() {
+  local units_json=$1
+  UNITS_JSON="$units_json" node --input-type=commonjs -e '
+    var units = [];
+    try {
+      units = JSON.parse(process.env.UNITS_JSON || "[]");
+    } catch (_) {
+      units = [];
+    }
+    if (!Array.isArray(units)) units = [];
+    units.forEach(function (u) {
+      process.stdout.write([
+        u.name,
+        u.type || "service",
+        u.scope || "system"
+      ].join("|") + "\n");
+    });
+  '
+}
+
 # ─── Validate mode ────────────────────────────────────────
 # Read-only comparison of registry vs live state.
 # Uses SSH for cross-host checks. Writes results to Munin.
@@ -87,7 +107,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   RESULTS=""
 
   # Read host-aware registry data
-  while IFS='|' read -r v_name v_host v_port v_repo v_units_json; do
+  while IFS='|' read -r v_name v_host v_port v_repo v_deploy_path v_units_json; do
     [[ -z "$v_name" ]] && continue
 
     # Skip components with no host (laptop-only, e.g. fortnox-mcp)
@@ -108,27 +128,32 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
 
     # Check systemd units
     if [[ "$v_units_json" != "[]" ]] && [[ -n "$v_units_json" ]]; then
-      # Parse unit names from JSON
-      unit_names="$(echo "$v_units_json" | node --input-type=commonjs -e '
-        var d = JSON.parse(require("fs").readFileSync("/dev/stdin","utf8"));
-        d.forEach(function(u) { process.stdout.write(u.name + "." + u.type + "\n"); });
-      ' 2>/dev/null)"
+      unit_rows="$(unit_rows_from_json "$v_units_json")"
 
-      while IFS= read -r unit; do
-        [[ -z "$unit" ]] && continue
+      while IFS='|' read -r unit_name unit_kind unit_scope; do
+        [[ -z "$unit_name" ]] && continue
+        unit="${unit_name}.${unit_kind}"
         if [[ "$IS_LOCAL" == "true" ]]; then
-          active="$(systemctl is-active "$unit" 2>/dev/null || echo 'unknown')"
+          if [[ "$unit_scope" == "user" ]]; then
+            active="$(systemctl --user is-active "$unit" 2>/dev/null || echo 'unknown')"
+          else
+            active="$(systemctl is-active "$unit" 2>/dev/null || echo 'unknown')"
+          fi
         else
-          active="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "systemctl is-active $unit" 2>/dev/null || echo 'unknown')"
+          if [[ "$unit_scope" == "user" ]]; then
+            active="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "systemctl --user is-active '$unit'" 2>/dev/null || echo 'unknown')"
+          else
+            active="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "systemctl is-active '$unit'" 2>/dev/null || echo 'unknown')"
+          fi
         fi
 
         if [[ "$active" == "active" ]]; then
-          STATUS_LINE+=" unit:$unit=active"
+          STATUS_LINE+=" unit:$unit($unit_scope)=active"
         else
-          STATUS_LINE+=" unit:$unit=$active"
+          STATUS_LINE+=" unit:$unit($unit_scope)=$active"
           COMPONENT_OK=false
         fi
-      done <<< "$unit_names"
+      done <<< "$unit_rows"
     fi
 
     # Check port / health endpoint
@@ -155,7 +180,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
 
     # Check repo staleness (git fetch --dry-run to see if behind)
     if [[ -n "$v_repo" ]]; then
-      repo_path="$HOME/repos/$v_repo"
+      repo_path="${v_deploy_path:-/home/magnus/repos/$v_repo}"
       if [[ "$IS_LOCAL" == "true" ]]; then
         if [[ -d "$repo_path/.git" ]]; then
           behind="$(cd "$repo_path" && git fetch --dry-run 2>&1 | grep -c '\.\.') " || behind="0"
@@ -171,10 +196,13 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
           COMPONENT_OK=false
         fi
       else
-        remote_check="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "cd ~/repos/$v_repo 2>/dev/null && git fetch --dry-run 2>&1 | grep -c '\.\.' || echo 0" 2>/dev/null || echo '-1')"
+        remote_check="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "if [ -d '$repo_path/.git' ]; then cd '$repo_path' && { git fetch --dry-run 2>&1 | grep -c '\.\.' || true; }; else echo missing; fi" 2>/dev/null || echo '-1')"
         remote_check="${remote_check// /}"
         if [[ "$remote_check" == "-1" ]]; then
           STATUS_LINE+=" repo:ssh-failed"
+          COMPONENT_OK=false
+        elif [[ "$remote_check" == "missing" ]]; then
+          STATUS_LINE+=" repo:not-found"
           COMPONENT_OK=false
         elif [[ "$remote_check" -gt 0 ]]; then
           STATUS_LINE+=" repo:behind-origin"
@@ -349,23 +377,31 @@ munin_tool_call() {
 }
 
 service_status_row() {
-  local svc="$1"
-  local unit="${svc}.service"
+  local unit_name="$1" unit_kind="$2" unit_scope="$3"
+  local unit="${unit_name}.${unit_kind}"
   local active enabled pid mem mem_mb started
-  active="$(systemctl is-active "$unit" 2>/dev/null || echo 'unknown')"
-  enabled="$(systemctl is-enabled "$unit" 2>/dev/null || echo 'unknown')"
-  if [[ "$active" == "active" ]]; then
-    pid="$(systemctl show "$unit" --property=MainPID 2>/dev/null | cut -d= -f2)"
-    mem="$(systemctl show "$unit" --property=MemoryCurrent 2>/dev/null | cut -d= -f2)"
-    started="$(systemctl show "$unit" --property=ExecMainStartTimestamp 2>/dev/null | cut -d= -f2-)"
+  local -a systemctl_prefix
+  if [[ "$unit_scope" == "user" ]]; then
+    systemctl_prefix=(systemctl --user)
+  else
+    systemctl_prefix=(systemctl)
+  fi
+  active="$("${systemctl_prefix[@]}" is-active "$unit" 2>/dev/null || echo 'unknown')"
+  enabled="$("${systemctl_prefix[@]}" is-enabled "$unit" 2>/dev/null || echo 'unknown')"
+  if [[ "$active" == "active" && "$unit_kind" == "service" ]]; then
+    pid="$("${systemctl_prefix[@]}" show "$unit" --property=MainPID 2>/dev/null | cut -d= -f2)"
+    mem="$("${systemctl_prefix[@]}" show "$unit" --property=MemoryCurrent 2>/dev/null | cut -d= -f2)"
+    started="$("${systemctl_prefix[@]}" show "$unit" --property=ExecMainStartTimestamp 2>/dev/null | cut -d= -f2-)"
     if [[ "$mem" =~ ^[0-9]+$ ]] && [[ "$mem" -gt 0 ]]; then
       mem_mb="$((mem / 1024 / 1024))MB"
     else
       mem_mb="n/a"
     fi
-    echo "| $unit | ✅ $active | $enabled | $pid | $mem_mb | $started |"
+    echo "| $unit | $unit_scope | ✅ $active | $enabled | $pid | $mem_mb | $started |"
+  elif [[ "$active" == "active" ]]; then
+    echo "| $unit | $unit_scope | ✅ $active | $enabled | — | — | — |"
   else
-    echo "| $unit | ❌ $active | $enabled | — | — | — |"
+    echo "| $unit | $unit_scope | ❌ $active | $enabled | — | — | — |"
   fi
 }
 
@@ -379,11 +415,15 @@ echo ""
 # ─── Service status ───────────────────────────────────────
 
 echo "🔍 Collecting service status..."
-read -ra SYSTEMD_SERVICES <<< "$(REGISTRY_PATH="$REGISTRY" QUERY=systemd node --input-type=commonjs "$REGISTRY_JS")"
 DEPLOYMENT_TABLE=""
-for svc in "${SYSTEMD_SERVICES[@]}"; do
-  DEPLOYMENT_TABLE+="$(service_status_row "$svc")\n"
-done
+while IFS='|' read -r _s_name _s_host _s_port _s_repo _s_deploy_path s_units_json; do
+  [[ -n "$s_units_json" && "$s_units_json" != "[]" ]] || continue
+  s_unit_rows="$(unit_rows_from_json "$s_units_json")"
+  while IFS='|' read -r s_unit_name s_unit_kind s_unit_scope; do
+    [[ -n "$s_unit_name" ]] || continue
+    DEPLOYMENT_TABLE+="$(service_status_row "$s_unit_name" "$s_unit_kind" "$s_unit_scope")\n"
+  done <<< "$s_unit_rows"
+done < <(REGISTRY_PATH="$REGISTRY" QUERY=validate node --input-type=commonjs "$REGISTRY_JS")
 
 # ─── Git versions ─────────────────────────────────────────
 
@@ -477,8 +517,8 @@ cat > "$SNAPSHOT" << EOF
 
 ### Service Status
 
-| Unit | State | Enabled | PID | Memory | Started |
-|------|-------|---------|-----|--------|---------|
+| Unit | Scope | State | Enabled | PID | Memory | Started |
+|------|-------|-------|---------|-----|--------|---------|
 $(echo -e "$DEPLOYMENT_TABLE")
 
 ### Repository Versions

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -4,7 +4,7 @@
 //   REGISTRY_PATH=/path/to/services.json QUERY=<query> node --input-type=commonjs scripts/lib/registry.js
 //
 // Queries:
-//   deploy       — components where deploy=true, output: name|repo|host|deploy_path|unit_type|needs_build (deploy.sh format)
+//   deploy       — components where deploy=true, output: name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json (deploy.sh format)
 //   scan         — components where scan=true, output: space-separated repo names
 //   components   — all component names, space-separated
 //   systemd      — all systemd unit names, space-separated
@@ -49,7 +49,7 @@ var components = data.components;
 switch (query) {
   case 'deploy': {
     // Output format matches what deploy.sh needs:
-    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope|deploy_mode
+    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope|deploy_mode|units_json
     var deployable = components.filter(function (c) { return c.deploy; });
     deployable.forEach(function (c) {
       // Determine primary unit type/scope from first systemd unit.
@@ -65,8 +65,9 @@ switch (query) {
       var deployPath = c.deploy_path || ('/home/magnus/repos/' + c.repo);
       var needsBuild = c.needs_build ? 'true' : 'false';
       var deployMode = c.deploy_mode || 'rsync';
+      var units = JSON.stringify(c.systemd_units || []);
       process.stdout.write(
-        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '|' + deployMode + '\n'
+        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '|' + deployMode + '|' + units + '\n'
       );
     });
     break;
@@ -99,13 +100,14 @@ switch (query) {
     break;
   }
   case 'validate': {
-    // Host-aware output for validation: name|host|port|repo|units_json
+    // Host-aware output for validation: name|host|port|repo|deploy_path|units_json
     // Includes all components so validator can check each on the correct host
     components.forEach(function (c) {
       var port = c.port || '';
       var host = c.host || '';
+      var deployPath = c.deploy_path || '';
       var units = JSON.stringify(c.systemd_units || []);
-      process.stdout.write(c.name + '|' + host + '|' + port + '|' + c.repo + '|' + units + '\n');
+      process.stdout.write(c.name + '|' + host + '|' + port + '|' + c.repo + '|' + deployPath + '|' + units + '\n');
     });
     break;
   }

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -52,6 +52,7 @@ if (!Array.isArray(data.components)) {
 
 var VALID_UNIT_TYPES = ['service', 'timer'];
 var VALID_UNIT_SCOPES = ['system', 'user'];
+var VALID_UNIT_NAME = /^[A-Za-z0-9_.@-]+$/;
 
 var seenNames = {};
 var seenPorts = {};
@@ -125,6 +126,8 @@ data.components.forEach(function (c, i) {
       }
       if (typeof u.name !== 'string' || !u.name) {
         fail(uLabel + ': missing/invalid "name"');
+      } else if (!VALID_UNIT_NAME.test(u.name)) {
+        fail(uLabel + ': "name" must be a valid systemd unit base name, got "' + u.name + '"');
       }
       if (VALID_UNIT_TYPES.indexOf(u.type) === -1) {
         fail(uLabel + ': "type" must be one of ' + VALID_UNIT_TYPES.join('/') + ', got "' + u.type + '"');

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -172,6 +172,17 @@ cat > "$TMP_DIR/bad-unit-type.json" << 'EOF'
 EOF
 assert_eq "invalid systemd unit type -> exit 1" "1" "$(run_validator "$TMP_DIR/bad-unit-type.json")"
 
+# ── Bad systemd unit name ───────────────────────────────────────────────────
+cat > "$TMP_DIR/bad-unit-name.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": null, "port": null, "deploy": false, "scan": true, "needs_build": false,
+      "systemd_units": [{ "name": "alpha;rm -rf /", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "invalid systemd unit name -> exit 1" "1" "$(run_validator "$TMP_DIR/bad-unit-name.json")"
+
 # ── Duplicate node name ──────────────────────────────────────────────────────
 cat > "$TMP_DIR/dup-node.json" << 'EOF'
 {
@@ -242,8 +253,12 @@ deploy_row() {  # $1 = registry path, $2 = component name
     | grep "^$2|" || true
 }
 assert_eq "real services.json: hugin deploy row unchanged by appended timer" \
-  "hugin|hugin|huginmunin.local|/home/magnus/repos/hugin|service|true|user|rsync" \
+  'hugin|hugin|huginmunin.local|/home/magnus/repos/hugin|service|true|user|rsync|[{"name":"hugin","type":"service","scope":"user"},{"name":"hugin-daily-analysis","type":"timer"}]' \
   "$(deploy_row "$REPO_REGISTRY" hugin)"
+
+assert_eq "real services.json: skuld timer deploys via user manager" \
+  'skuld|skuld|huginmunin.local|/home/magnus/repos/skuld|timer|true|user|rsync|[{"name":"skuld","type":"timer","scope":"user"}]' \
+  "$(deploy_row "$REPO_REGISTRY" skuld)"
 
 cat > "$TMP_DIR/order.json" << 'EOF'
 {
@@ -254,7 +269,7 @@ cat > "$TMP_DIR/order.json" << 'EOF'
 }
 EOF
 assert_eq "deploy row derives type/scope from systemd_units[0] (service+user first)" \
-  "svc|svc|h1.local|/x|service|true|user|rsync" \
+  'svc|svc|h1.local|/x|service|true|user|rsync|[{"name":"svc","type":"service","scope":"user"},{"name":"svc-daily","type":"timer"}]' \
   "$(deploy_row "$TMP_DIR/order.json" svc)"
 
 echo ""

--- a/services.json
+++ b/services.json
@@ -59,13 +59,13 @@
       "name": "skuld",
       "repo": "skuld",
       "host": "huginmunin.local",
-      "port": 3040,
+      "port": null,
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/repos/skuld",
       "needs_build": true,
       "systemd_units": [
-        { "name": "skuld", "type": "timer" }
+        { "name": "skuld", "type": "timer", "scope": "user" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- carry full `systemd_units` metadata through registry deploy/validate projections
- install every declared unit from `systemd/` or repo-root unit files, restart services by scope, and enable timers by scope
- make validation/snapshot generation honor user units, timers, deploy paths, and missing remote checkouts
- remove stale Skuld `:3040` registry/docs surface and refresh related architecture/scheduled-task docs

## Verification
- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `bash -n scripts/deploy.sh scripts/generate-architecture.sh scripts/lib/*.sh scripts/tests/*.sh tests/scripts/*.sh`
- `REGISTRY_PATH=services.json QUERY=deploy node --input-type=commonjs scripts/lib/registry.js`
- `REGISTRY_PATH=services.json QUERY=validate node --input-type=commonjs scripts/lib/registry.js`
- `node --input-type=commonjs scripts/lib/validate-registry.js`

## Deployment note
Draft until reviewed because this changes live deploy semantics. After merge, deploy `grimnir`, then affected components (`hugin`, `heimdall`, `skuld`) and re-run `grimnir-validate.service` on huginmunin.