### PR TITLE
docs: add roadmap now decision brief

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ No service code lives here — each component has its own repo.
 - `docs/failure-recovery.md` — The autonomous-mutation undo convention: every autonomous mutation leaves a reversal recipe (git_revert / snapshot / irreversible+mitigation) + an audit event (issue #46)
 - `docs/gap-analysis-2026-07-03.md` — Critic-corrected ecosystem gap analysis vs vision v0.2: ranked gaps, quick wins, cut list, corrections log (the source of the 23-ticket fleet program)
 - `docs/threat-model.md` — Consolidated threat model (v0.1): assets, trust boundaries, adversaries, and a T1–T11 key-threats table mapped to owning tickets (from the 2026-07-06 blind-spot audit)
+- `docs/roadmap-now-decision-brief.md` — Working brief for the current "now" cluster: succession (#65), GDPR/data lifecycle (#66), system ROI/off-ramp (#67), Skuld revive-or-cut (#69), interactive-session trust posture (#70), and the #58 Verdandi blocker
 - `services.json` — **Single source of truth** for component inventory (names, hosts, ports, systemd units). All scripts read from it via `scripts/lib/registry.js`
 
 ## Scripts

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ What's here:
 - **[docs/architecture.md](docs/architecture.md)** — Full system architecture (topology, components, security, data flow)
 - **[docs/conventions.md](docs/conventions.md)** — Naming, ports, service patterns, GitHub ownership
 - **[docs/vision.md](docs/vision.md)** — Where the project is heading
+- **[docs/roadmap-now-decision-brief.md](docs/roadmap-now-decision-brief.md)** — Current owner decisions for succession, data lifecycle, ROI/off-ramp, Skuld, and interactive-session trust
 - **[services.json](services.json)** — Single source of truth for the component inventory (`components`) and the infrastructure/inference-node inventory (`nodes` — hosts, hardware, role, LLM servers). Query via `scripts/lib/registry.js` (`QUERY=nodes`).
 - **[scripts/](scripts/)** — Deploy, security scan, and architecture generation scripts
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,52 @@
 # Grimnir System — Status
 
-**Last session:** 2026-07-07 (Codex) — PR #68 threat model reviewed + merged
-**Branch:** main (pushed + deployed to huginmunin)
+**Last session:** 2026-07-07 (Codex) — roadmap "now" fanout reviewed, Grimnir decision brief PR #72
+**Branch:** codex/roadmap-now-decision-brief (PR #72 open; not deployed)
+
+## Completed This Session (2026-07-07) — roadmap "now" cluster decision brief
+
+Created `docs/roadmap-now-decision-brief.md` as the smallest safe Grimnir-side progress for the
+current Roadmap "now" cluster. The brief deliberately does **not** create a large policy framework;
+it captures owner decisions and lightweight next artifacts for:
+
+- **grimnir#65** succession / bus factor: decide emergency delegate(s) and whether the desired
+  outcome is recover, export-and-shutdown, or keep-running temporarily.
+- **grimnir#66** GDPR / data map / retention / erasure: choose default retention windows for
+  client/accounting data, personal memory, operational telemetry, and transient task artifacts.
+- **grimnir#67** system ROI ledger + exit/off-ramp: define the cut/keep threshold for services with
+  no measured use, no pillar-protection role, and no owner-reviewed reason to keep.
+- **grimnir#69** Skuld revive-or-cut: choose either a four-week measured briefing trial or cut now.
+- **grimnir#70** interactive-session trust posture: choose advisory-only, fresh-session-required
+  after untrusted input, or route consequential mutations through Hugin.
+- **grimnir#58** remains blocked by **verdandi#15**; Grimnir should not claim end-to-end tenant
+  conformance until off-Pi Verdandi intake/key provisioning exists and Seam D is rerun.
+
+Indexed the new brief from `README.md` and `CLAUDE.md`. Opened PR #72 after local and M5 review;
+not deployed yet.
+
+Ran a repo-local fanout for the rest of the "now" cluster. No non-Grimnir repo changes were accepted
+from the subagents; their outputs were patch plans only, reviewed against `docs/vision.md`,
+`docs/tenant-contract.md`, `docs/authority.md`, and the current threat model:
+
+- **Accept direction:** brokkr#38 belongs in Brokkr as off-box host liveness, but its alert path
+  must not depend only on huginmunin-hosted Heimdall/Munin.
+- **Accept direction:** verdandi#16 checkpoint/anchor work is safe before verdandi#15; verdandi#15
+  must add tenant-bound keys/events before exposing off-Pi intake.
+- **Accept direction:** hugin#149 is the highest-risk Hugin fix; keep an explicit compatibility
+  escape hatch while removing unconditional `bypassPermissions`.
+- **Accept direction:** ratatoskr#36 validation belongs in `task-writer`, not only the Telegram
+  command handler, because LLM-produced task context is untrusted too.
+- **Accept direction:** munin-memory#191 should precede #192; ownership-aware correction/forgetting
+  needs server-derived tenant identity first.
+- **Accept direction:** gille-inference#152 is the next safe inference-side step; keep #154 blocked
+  on verdandi#15 and keep #156 guarded by trusted-verifier evidence.
+
+### Pending / next
+- Owner decisions above are the blockers for splitting this brief into final docs.
+- After decisions: create `docs/succession-checklist.md`, `docs/data-lifecycle.md`, a short
+  `docs/vision.md` ROI/off-ramp section, a Skuld decision record, and the interactive-session
+  posture note.
+- Keep grimnir#58 parked until verdandi#15 lands.
 
 ## Completed This Session (2026-07-07) — threat model v0.1 reviewed and merged
 

--- a/docs/roadmap-now-decision-brief.md
+++ b/docs/roadmap-now-decision-brief.md
@@ -1,0 +1,168 @@
+# Grimnir Roadmap Now - Decision Brief
+
+> Status: 2026-07-07 working brief for grimnir#65, #66, #67, #69, #70.
+> This is intentionally not a full policy pack. It captures the smallest owner decisions needed to
+> move the "now" cluster without bloating the architecture.
+
+---
+
+## Why these items belong in Grimnir
+
+The current threat model made three system-level gaps visible: continuity, data lifecycle, and
+trust posture. They are not new feature ideas; they protect the two pillars named in
+[`vision.md`](vision.md):
+
+- **Sovereign Memory:** succession, data mapping, erasure, and interactive-session handling decide
+  who can recover, delete, or accidentally leak Munin, Mimir, Verdandi, and related stores.
+- **Self-Knowing Inference:** an ROI ledger and Skuld decision make Grimnir measure whether its own
+  services earn their place instead of preserving stale automation by habit.
+
+The safe shape is therefore a set of decision records and small checklists, not a large compliance
+framework.
+
+## grimnir#65 - Succession / bus factor
+
+**Problem:** Grimnir has one fully trusted operator. If Magnus is unavailable, the sovereign memory
+and audit substrate may be inaccessible or unrecoverable, even though it is deliberately not hosted
+by a third party.
+
+**Smallest useful artifact:** a private succession envelope, referenced but not stored in this repo,
+plus a non-secret public checklist in this repo.
+
+The non-secret checklist should contain:
+
+- where the private envelope lives;
+- how to identify the active hardware and repos (`services.json` remains the inventory authority);
+- how to stop public ingress, scheduled jobs, and autonomous execution;
+- how to recover or export Munin/Mimir/Verdandi without exposing secrets in docs;
+- who is allowed to receive help from an outside engineer.
+
+**Owner decision required:** name the emergency delegate(s) and decide whether their goal is
+`recover`, `export-and-shutdown`, or `keep-running temporarily`.
+
+**Architecture fit:** this protects Sovereign Memory by keeping ownership of the data and audit
+trail recoverable without moving secrets into the repo.
+
+## grimnir#66 - GDPR / data map / retention / erasure
+
+**Problem:** T11 in [`threat-model.md`](threat-model.md) notes that third-party/client/accounting
+data accumulates across stores without a formal map, retention default, or erasure path.
+
+**Smallest useful artifact:** a data lifecycle map with one row per store, not a legal policy.
+
+Initial rows to cover:
+
+| Store | Data class | Authority | Retention shape | Erasure shape |
+|---|---|---|---|---|
+| Munin | memory, summaries, traces, task results | `munin-memory` | owner-defined by namespace | delete/correct entry; log erasure action |
+| Mimir | files and generated artifacts | `mimir` | source-folder policy | remove source file; expire backup copies |
+| Verdandi | audit events | `verdandi` | append-only with redaction | tombstone/redact where required; do not rewrite hash history casually |
+| Heimdall | metrics, alerts, briefing rendering | `heimdall` | operational window | prune metrics through existing maintenance |
+| Hugin | task inputs/outputs/workspaces | `hugin` | short-lived workspace, durable result in Munin | remove workspace artifacts; keep audited action record |
+| Ratatoskr | Telegram-derived task context | `ratatoskr` | only what is needed for routing/audit | delete local transient records; source deletion is Telegram-side |
+| Skuld | daily briefing synthesis | `skuld` | only if briefings are kept | delete generated briefings from Munin if not needed |
+| noxctl / Fortnox exports | accounting/client data | `fortnox-mcp` / Fortnox | statutory/accounting rules win | delete local exports when no longer needed |
+| Backups | Munin/Mimir copies | Brokkr | backup retention window | best-effort expiration; document non-immediate deletion |
+| M5 ledger | capability/eval evidence, verdict metadata | `gille-inference` | eval evidence window | remove or redact payload-derived artifacts if they contain personal data |
+
+**Owner decision required:** choose default retention windows for four data classes:
+`client/accounting`, `personal memory`, `operational telemetry`, and `transient task artifacts`.
+
+**Architecture fit:** this is Pillar 1 hygiene. It should stay practical: map stores, defaults, and
+erasure mechanics before writing broad GDPR prose.
+
+## grimnir#67 - System ROI ledger + exit/off-ramp
+
+**Problem:** Grimnir measures local-model capability, but it does not yet measure whether the system
+itself is worth its maintenance cost, risk surface, and operator attention.
+
+**Smallest useful artifact:** a monthly system ROI ledger with evidence categories, plus an explicit
+off-ramp rule in the vision.
+
+Suggested ledger fields:
+
+| Field | Why it matters |
+|---|---|
+| `period` | monthly cadence is enough |
+| `ops_minutes` | maintenance burden |
+| `frontier_spend_usd` | actual cloud model spend |
+| `local_inference_value_usd` | value/savings attributed to M5 routing, quality-adjusted where possible |
+| `human_hours_saved_estimate` | rough but visible productivity value |
+| `incidents_prevented_or_detected` | value from monitoring, security scan, drift detection |
+| `services_cut_or_kept` | evidence that bloat is being controlled |
+| `decision` | keep, fix, cut, or revisit |
+
+**Owner decision required:** define the exit threshold. A usable first version: "If a service has no
+measured use, no pillar-protection role, and no owner-reviewed reason to keep it for two monthly
+reviews, cut it or archive it."
+
+**Architecture fit:** this applies the Self-Knowing Inference idea to the system itself. The risk is
+false precision, so the first ledger should accept estimates and evidence notes rather than pretend
+to be accounting-grade.
+
+## grimnir#69 - Skuld revive-or-cut decision
+
+**Problem:** Skuld is now represented as a timer-only briefing producer, but its actual value is not
+yet proven. A daily briefing can either be a useful memory/inference synthesis or a stale automation
+that adds maintenance surface.
+
+**Smallest useful artifact:** a time-boxed revive-or-cut decision record.
+
+Two acceptable paths:
+
+- **Revive:** run Skuld for a four-week trial with traces, human usefulness marks, and at least one
+  concrete action captured per useful briefing.
+- **Cut:** remove Skuld from the deployed component inventory and keep Heimdall/Munin views only if
+  another producer exists.
+
+**Owner decision required:** choose `four-week trial` or `cut now`.
+
+**Architecture fit:** revive fits both pillars only if the briefing reads sovereign memory and
+produces measurable orientation value. Cut fits the "cut bloat continuously" principle if that
+evidence is absent.
+
+## grimnir#70 - Interactive-session trust posture
+
+**Problem:** T2 in [`threat-model.md`](threat-model.md) is a high residual risk: interactive Claude
+Code/Codex/Desktop sessions can read untrusted content while holding memory, files, tools, and
+egress. Hugin queue gating does not protect those sessions.
+
+**Smallest useful artifact:** an operator-facing trust posture for interactive sessions, not a new
+enforcement framework.
+
+Suggested posture:
+
+- Treat raw email, Telegram forwards, web pages, PDFs, and documents as untrusted until summarized
+  or inspected in a read-only pass.
+- Do not combine untrusted-content reading with external sends, credential use, deploys, or broad
+  filesystem edits in the same reasoning context unless the operator explicitly accepts the risk.
+- For mutating work that follows untrusted input, prefer a fresh session or Hugin-mediated task path
+  so the action can be gated and audited.
+- Record when an interactive session intentionally bypasses Hugin gating for a consequential action.
+
+**Owner decision required:** choose the acceptable friction level: `advisory-only`, `fresh-session
+required after untrusted input`, or `route consequential mutations through Hugin`.
+
+**Architecture fit:** this protects Sovereign Memory from the current lethal-trifecta gap while
+avoiding premature policy bloat. The later technical fix can be narrower once the desired friction
+level is explicit.
+
+## grimnir#58 - Tenant validation status
+
+grimnir#58 remains blocked by verdandi#15. The Grimnir-side docs should not claim end-to-end tenant
+conformance until off-Pi Verdandi intake and key provisioning exist, and Seam D has been rerun.
+
+**Owner decision required:** none in Grimnir before verdandi#15. The next Grimnir action is to rerun
+and update [`tenant-validation-2026-07-04.md`](tenant-validation-2026-07-04.md) after the Verdandi
+blocker lands.
+
+## Recommended next documents
+
+To keep this cluster small, split only when the owner decisions above are answered:
+
+- `docs/succession-checklist.md` for grimnir#65, without secrets.
+- `docs/data-lifecycle.md` for grimnir#66, store map first and legal prose second.
+- A short `System ROI / off-ramp` section in `docs/vision.md` for grimnir#67.
+- A one-page Skuld decision record for grimnir#69.
+- A short `Interactive session posture` section in `docs/threat-model.md` or a companion note for
+  grimnir#70.


### PR DESCRIPTION
## Summary
- add a working decision brief for the current Roadmap now cluster
- index the brief from README and CLAUDE.md
- update STATUS.md with the fanout review and accepted implementation sequencing

## Review / validation
- make test
- M5 delegated architecture review: PASS
- manual Codex review against docs/vision.md, docs/tenant-contract.md, and docs/authority.md

## Notes
No service code changes. grimnir#58 remains explicitly blocked on verdandi#15.