### PR TITLE
Fail closed when rsync deploy targets contain runtime data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-registry-smoke test-failure-recovery-doc test-registry-checkout test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -21,13 +21,16 @@ test-security-delta: ## Unit tests for the scan_escalated/parse_prev_counts help
 test-registry-smoke: ## Schema/consistency smoke check for services.json (issue #48)
 	@bash scripts/tests/registry-smoke.test.sh
 
+test-deploy-persistent-paths: ## Fail closed before rsync can delete an in-target runtime path
+	@bash scripts/tests/deploy-persistent-paths.test.sh
+
 test-failure-recovery-doc: ## Regression test: assert docs/failure-recovery.md defines the undo convention (issue #46)
 	@bash tests/scripts/test-failure-recovery-doc.sh
 
 test-registry-checkout: ## Unit tests for the registry-checkout integrity helpers (issue #47)
 	@bash scripts/tests/registry-checkout.test.sh
 
-test: test-security-skip test-security-delta test-registry-smoke test-failure-recovery-doc test-registry-checkout ## Run all test suites
+test: test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -10,6 +10,7 @@
 | **Port assignments** | `services.json` | `generate-architecture.sh`, `deploy.sh`, `security-scan.sh`, `docs/architecture.md` |
 | **Hostnames / hosts** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
 | **Deploy paths, targets & systemd units** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
+| **Persistent/runtime paths and rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |
 | **Repo names / GitHub ownership** | `docs/conventions.md` | `docs/architecture.md`, generator |
 | **Service patterns / conventions** | `docs/conventions.md` | per-repo CLAUDE.md |

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -10,7 +10,8 @@
 | **Port assignments** | `services.json` | `generate-architecture.sh`, `deploy.sh`, `security-scan.sh`, `docs/architecture.md` |
 | **Hostnames / hosts** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
 | **Deploy paths, targets & systemd units** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
-| **Persistent/runtime paths and rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
+| **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
+| **Global rsync safety exclusions** (`.env`, `.git`, dependencies, tests, deploy marker) | `scripts/deploy.sh` | deploy persistence tests |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |
 | **Repo names / GitHub ownership** | `docs/conventions.md` | `docs/architecture.md`, generator |
 | **Service patterns / conventions** | `docs/conventions.md` | per-repo CLAUDE.md |
@@ -33,6 +34,12 @@
 4. **Munin is live state, not architecture.** Munin project statuses reflect current work and blockers. They are not authoritative for system design, ports, or conventions.
 
 5. **Per-repo CLAUDE.md owns component-level detail.** If `docs/architecture.md` and a component's `CLAUDE.md` disagree on how that component works, the component's `CLAUDE.md` wins (it's closer to the code).
+
+6. **Persistent paths mean runtime data, not globally protected deploy metadata.** Each
+   rsync-deployed component declares its mutable runtime/data locations in `persistent_paths`.
+   Component-specific in-target locations require a matching `rsync_excludes` entry. The deploy
+   script separately preserves `.env` for every rsync component as global credential policy, so a
+   component with `persistent_paths: []` does not imply that its in-target `.env` may be deleted.
 
 ## Validation
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,11 +10,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
-REGISTRY="$GRIMNIR_DIR/services.json"
+REGISTRY="${REGISTRY_PATH:-$GRIMNIR_DIR/services.json}"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
+REGISTRY_VALIDATOR="$SCRIPT_DIR/lib/validate-registry.js"
 
 # Read deployable services from registry:
-# name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json
+# name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json|rsync_excludes_json
+if ! REGISTRY_PATH="$REGISTRY" node --input-type=commonjs "$REGISTRY_VALIDATOR"; then
+  echo "ERROR: Refusing deploy because registry validation failed" >&2
+  exit 1
+fi
+
 SERVICES=()
 while IFS= read -r line; do
   [[ -n "$line" ]] && SERVICES+=("$line")
@@ -124,8 +130,17 @@ unit_rows() {
     '
 }
 
+rsync_exclude_rows() {
+  local excludes_json=$1
+  RSYNC_EXCLUDES_JSON="$excludes_json" node --input-type=commonjs -e '
+    var excludes = JSON.parse(process.env.RSYNC_EXCLUDES_JSON || "[]");
+    excludes.forEach(function (exclude) { process.stdout.write(exclude + "\n"); });
+  '
+}
+
 deploy_service() {
   local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync} units_json=${9:-[]}
+  local rsync_excludes_json=${10:-[]}
   local local_path
   local remote_host
   local remote
@@ -216,15 +231,19 @@ deploy_service() {
     fail=$((fail + 1))
     return
   fi
-  if ! rsync -az --delete \
-    --exclude='node_modules/' \
-    --exclude='.git' \
-    --exclude='.git/' \
-    --exclude='.env' \
-    --exclude='tests/' \
-    --exclude='.DS_Store' \
-    --exclude='.deployed-commit' \
-    "$local_path/" "$remote:$deploy_path/"; then
+  local rsync_exclude rsync_args
+  rsync_args=(-az --delete
+    --exclude='node_modules/'
+    --exclude='.git'
+    --exclude='.git/'
+    --exclude='.env'
+    --exclude='tests/'
+    --exclude='.DS_Store'
+    --exclude='.deployed-commit')
+  while IFS= read -r rsync_exclude; do
+    [[ -n "$rsync_exclude" ]] && rsync_args+=("--exclude=${rsync_exclude}")
+  done < <(rsync_exclude_rows "$rsync_excludes_json")
+  if ! rsync "${rsync_args[@]}" "$local_path/" "$remote:$deploy_path/"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -339,7 +358,7 @@ deploy_service() {
 requested=("$@")
 
 for entry in "${SERVICES[@]}"; do
-  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope deploy_mode units_json <<< "$entry"
+  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope deploy_mode units_json rsync_excludes_json <<< "$entry"
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false
@@ -349,7 +368,7 @@ for entry in "${SERVICES[@]}"; do
     $match || continue
   fi
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}"
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}"
 done
 
 # Summary

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,9 +13,11 @@ GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
 REGISTRY="${REGISTRY_PATH:-$GRIMNIR_DIR/services.json}"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 REGISTRY_VALIDATOR="$SCRIPT_DIR/lib/validate-registry.js"
+# shellcheck source=scripts/lib/deploy-safety.sh
+source "$SCRIPT_DIR/lib/deploy-safety.sh"
 
-# Read deployable services from registry:
-# name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json|rsync_excludes_json
+# Validate the full registry before producing JSON Lines deploy records. No
+# network or filesystem mutation occurs before this gate passes.
 if ! REGISTRY_PATH="$REGISTRY" node --input-type=commonjs "$REGISTRY_VALIDATOR"; then
   echo "ERROR: Refusing deploy because registry validation failed" >&2
   exit 1
@@ -43,6 +45,24 @@ skip=0
 results=()
 DEPLOY_USER="${DEPLOY_USER:-magnus}"
 LOCAL_REPOS_ROOT="${LOCAL_REPOS_ROOT:-$HOME/repos}"
+
+if [[ ! "$DEPLOY_USER" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+  echo "ERROR: DEPLOY_USER must be a safe POSIX account name" >&2
+  exit 1
+fi
+
+service_field() {
+  local record=$1 field=$2
+  SERVICE_RECORD="$record" SERVICE_FIELD="$field" node --input-type=commonjs -e '
+    var record = JSON.parse(process.env.SERVICE_RECORD);
+    var value = record[process.env.SERVICE_FIELD];
+    if (value !== null && typeof value === "object") {
+      process.stdout.write(JSON.stringify(value));
+    } else {
+      process.stdout.write(String(value));
+    }
+  '
+}
 
 resolve_host() {
   local input=$1
@@ -147,6 +167,7 @@ deploy_service() {
   local branch
   local commit
   local dirty_state
+  local q_deploy_path
 
   echo -e "\n${BOLD}=== ${name} (${host}) ===${NC}"
 
@@ -184,6 +205,7 @@ deploy_service() {
     return
   fi
   remote="${DEPLOY_USER}@${remote_host}"
+  q_deploy_path=$(posix_shell_quote "$deploy_path")
 
   # Build locally before syncing if runtime expects generated artifacts like dist/
   # (irrelevant in git-pull mode — nothing local is shipped)
@@ -209,11 +231,11 @@ deploy_service() {
     # files. Either would let the stamp certify a non-canonical tree, so both
     # fail the deploy loudly instead.
     local pull_cmd
-    pull_cmd="git -C '$deploy_path' fetch --quiet origin && "
-    pull_cmd+="git -C '$deploy_path' checkout --quiet main && "
-    pull_cmd+="git -C '$deploy_path' pull --ff-only --quiet origin main && "
-    pull_cmd+="if [ -n \"\$(git -C '$deploy_path' status --porcelain)\" ]; then echo 'ERROR: checkout dirty after pull' >&2; exit 1; fi && "
-    pull_cmd+="if [ \"\$(git -C '$deploy_path' rev-parse HEAD)\" != \"\$(git -C '$deploy_path' rev-parse origin/main)\" ]; then echo 'ERROR: HEAD != origin/main after pull (stray local commits?)' >&2; exit 1; fi"
+    pull_cmd="git -C ${q_deploy_path} fetch --quiet origin && "
+    pull_cmd+="git -C ${q_deploy_path} checkout --quiet main && "
+    pull_cmd+="git -C ${q_deploy_path} pull --ff-only --quiet origin main && "
+    pull_cmd+="if [ -n \"\$(git -C ${q_deploy_path} status --porcelain)\" ]; then echo 'ERROR: checkout dirty after pull' >&2; exit 1; fi && "
+    pull_cmd+="if [ \"\$(git -C ${q_deploy_path} rev-parse HEAD)\" != \"\$(git -C ${q_deploy_path} rev-parse origin/main)\" ]; then echo 'ERROR: HEAD != origin/main after pull (stray local commits?)' >&2; exit 1; fi"
     # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
     if ! ssh -o ConnectTimeout=10 "$remote" "$pull_cmd"; then
       echo -e "${RED}FAILED${NC}"
@@ -225,7 +247,7 @@ deploy_service() {
 
   echo "==> Syncing to ${remote}:${deploy_path}..."
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
-  if ! ssh "$remote" "mkdir -p '$deploy_path'"; then
+  if ! ssh "$remote" "mkdir -p ${q_deploy_path}"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -243,7 +265,7 @@ deploy_service() {
   while IFS= read -r rsync_exclude; do
     [[ -n "$rsync_exclude" ]] && rsync_args+=("--exclude=${rsync_exclude}")
   done < <(rsync_exclude_rows "$rsync_excludes_json")
-  if ! rsync "${rsync_args[@]}" "$local_path/" "$remote:$deploy_path/"; then
+  if ! rsync "${rsync_args[@]}" "$local_path/" "${remote}:$(posix_shell_quote "${deploy_path}/")"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -252,7 +274,7 @@ deploy_service() {
 
   echo "==> Installing production dependencies on ${remote_host}..."
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
-  if ! ssh "$remote" "cd '$deploy_path' && if [ -f package.json ]; then npm install --omit=dev; fi"; then
+  if ! ssh "$remote" "cd ${q_deploy_path} && if [ -f package.json ]; then npm install --omit=dev; fi"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -261,8 +283,9 @@ deploy_service() {
 
   fi # end rsync-mode block (deploy_mode != git-pull)
 
-  local cmd="cd '$deploy_path' && "
+  local cmd="cd ${q_deploy_path} && "
   local rows unit_name unit_kind unit_actual_scope unit_file companion_file
+  local q_unit_src q_unit_root q_user_dest q_system_dest q_unit_label
   local user_needs_reload=false system_needs_reload=false
   local user_services=() system_services=() user_timers=() system_timers=()
 
@@ -270,31 +293,42 @@ deploy_service() {
   while IFS='|' read -r unit_name unit_kind unit_actual_scope; do
     [[ -n "$unit_name" ]] || continue
     unit_file="${unit_name}.${unit_kind}"
+    q_unit_src=$(posix_shell_quote "systemd/${unit_file}")
+    q_unit_root=$(posix_shell_quote "$unit_file")
+    q_user_dest=$(posix_shell_quote ".config/systemd/user/${unit_file}")
+    q_system_dest=$(posix_shell_quote "/etc/systemd/system/${unit_file}")
+    q_unit_label=$(posix_shell_quote "$unit_file")
 
     if [[ "$unit_actual_scope" == "user" ]]; then
-      cmd+="unit_src=''; for f in systemd/${unit_file} ${unit_file}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
-      cmd+="[ -n \"\$unit_src\" ] || { echo 'ERROR: unit file missing: ${unit_file}' >&2; exit 1; }; "
-      cmd+="install -D -m644 \"\$unit_src\" \"\$HOME/.config/systemd/user/${unit_file}\" && "
+      cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
+      cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
+      cmd+="install -D -m644 \"\$unit_src\" \"\$HOME\"/${q_user_dest} && "
       user_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
         user_services+=("$unit_name")
       elif [[ "$unit_kind" == "timer" ]]; then
         companion_file="${unit_name}.service"
-        cmd+="companion_src=''; for f in systemd/${companion_file} ${companion_file}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
-        cmd+="if [ -n \"\$companion_src\" ]; then install -D -m644 \"\$companion_src\" \"\$HOME/.config/systemd/user/${companion_file}\"; fi && "
+        q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
+        q_unit_root=$(posix_shell_quote "$companion_file")
+        q_user_dest=$(posix_shell_quote ".config/systemd/user/${companion_file}")
+        cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
+        cmd+="if [ -n \"\$companion_src\" ]; then install -D -m644 \"\$companion_src\" \"\$HOME\"/${q_user_dest}; fi && "
         user_timers+=("$unit_name")
       fi
     else
-      cmd+="unit_src=''; for f in systemd/${unit_file} ${unit_file}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
-      cmd+="[ -n \"\$unit_src\" ] || { echo 'ERROR: unit file missing: ${unit_file}' >&2; exit 1; }; "
-      cmd+="sudo install -D -m644 \"\$unit_src\" \"/etc/systemd/system/${unit_file}\" && "
+      cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
+      cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
+      cmd+="sudo install -D -m644 \"\$unit_src\" ${q_system_dest} && "
       system_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
         system_services+=("$unit_name")
       elif [[ "$unit_kind" == "timer" ]]; then
         companion_file="${unit_name}.service"
-        cmd+="companion_src=''; for f in systemd/${companion_file} ${companion_file}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
-        cmd+="if [ -n \"\$companion_src\" ]; then sudo install -D -m644 \"\$companion_src\" \"/etc/systemd/system/${companion_file}\"; fi && "
+        q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
+        q_unit_root=$(posix_shell_quote "$companion_file")
+        q_system_dest=$(posix_shell_quote "/etc/systemd/system/${companion_file}")
+        cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
+        cmd+="if [ -n \"\$companion_src\" ]; then sudo install -D -m644 \"\$companion_src\" ${q_system_dest}; fi && "
         system_timers+=("$unit_name")
       fi
     fi
@@ -307,19 +341,19 @@ deploy_service() {
     cmd+="sudo systemctl daemon-reload && "
   fi
   for unit_name in ${user_services[@]+"${user_services[@]}"}; do
-    cmd+="systemctl --user restart ${unit_name}.service && "
+    cmd+="systemctl --user restart $(posix_shell_quote "${unit_name}.service") && "
   done
   for unit_name in ${system_services[@]+"${system_services[@]}"}; do
     # Kill any leftover user-unit instance holding the port before the system unit restarts.
-    cmd+="{ systemctl --user stop ${unit_name}.service 2>/dev/null || true; } && "
-    cmd+="{ systemctl --user disable ${unit_name}.service 2>/dev/null || true; } && "
-    cmd+="sudo systemctl restart ${unit_name}.service && "
+    cmd+="{ systemctl --user stop $(posix_shell_quote "${unit_name}.service") 2>/dev/null || true; } && "
+    cmd+="{ systemctl --user disable $(posix_shell_quote "${unit_name}.service") 2>/dev/null || true; } && "
+    cmd+="sudo systemctl restart $(posix_shell_quote "${unit_name}.service") && "
   done
   for unit_name in ${user_timers[@]+"${user_timers[@]}"}; do
-    cmd+="systemctl --user enable --now ${unit_name}.timer && "
+    cmd+="systemctl --user enable --now $(posix_shell_quote "${unit_name}.timer") && "
   done
   for unit_name in ${system_timers[@]+"${system_timers[@]}"}; do
-    cmd+="sudo systemctl enable --now ${unit_name}.timer && "
+    cmd+="sudo systemctl enable --now $(posix_shell_quote "${unit_name}.timer") && "
   done
   # Stamp the deployed commit so Heimdall's drift detector has an authoritative
   # source (excluded from rsync above so --delete won't clobber it). Heimdall
@@ -330,7 +364,7 @@ deploy_service() {
     # just pulled) — stamp that, not the local checkout's commit.
     cmd+="git rev-parse HEAD > .deployed-commit && "
   else
-    cmd+="printf '%s\\n' '${commit_full}' > .deployed-commit && "
+    cmd+="printf '%s\\n' $(posix_shell_quote "$commit_full") > .deployed-commit && "
   fi
   cmd+="echo 'DEPLOY_OK'"
 
@@ -358,7 +392,16 @@ deploy_service() {
 requested=("$@")
 
 for entry in "${SERVICES[@]}"; do
-  IFS='|' read -r name repo host deploy_path unit_type needs_build unit_scope deploy_mode units_json rsync_excludes_json <<< "$entry"
+  name=$(service_field "$entry" name)
+  repo=$(service_field "$entry" repo)
+  host=$(service_field "$entry" host)
+  deploy_path=$(service_field "$entry" deploy_path)
+  unit_type=$(service_field "$entry" unit_type)
+  needs_build=$(service_field "$entry" needs_build)
+  unit_scope=$(service_field "$entry" unit_scope)
+  deploy_mode=$(service_field "$entry" deploy_mode)
+  units_json=$(service_field "$entry" systemd_units)
+  rsync_excludes_json=$(service_field "$entry" rsync_excludes)
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false

--- a/scripts/lib/deploy-safety.sh
+++ b/scripts/lib/deploy-safety.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Quote one argument for a POSIX shell. The output is safe to interpolate into
+# the command string passed to ssh or rsync's remote shell.
+posix_shell_quote() {
+  local value=$1 quoted="'"
+  while [[ "$value" == *"'"* ]]; do
+    quoted+="${value%%\'*}'\\''"
+    value="${value#*\'}"
+  done
+  printf "%s%s'" "$quoted" "$value"
+}

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -4,7 +4,7 @@
 //   REGISTRY_PATH=/path/to/services.json QUERY=<query> node --input-type=commonjs scripts/lib/registry.js
 //
 // Queries:
-//   deploy       — components where deploy=true, output: name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json|rsync_excludes_json (deploy.sh format)
+//   deploy       — components where deploy=true, output: one JSON object per line (deploy.sh format)
 //   scan         — components where scan=true, output: space-separated repo names
 //   components   — all component names, space-separated
 //   systemd      — all systemd unit names, space-separated
@@ -48,8 +48,8 @@ var components = data.components;
 
 switch (query) {
   case 'deploy': {
-    // Output format matches what deploy.sh needs:
-    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope|deploy_mode|units_json|rsync_excludes_json
+    // JSON Lines keeps registry strings structured through the shell boundary.
+    // deploy.sh parses each object as JSON; it never delimiter-splits values.
     var deployable = components.filter(function (c) { return c.deploy; });
     deployable.forEach(function (c) {
       // Determine primary unit type/scope from first systemd unit.
@@ -63,13 +63,19 @@ switch (query) {
         unitScope = c.systemd_units[0].scope || 'system';
       }
       var deployPath = c.deploy_path || ('/home/magnus/repos/' + c.repo);
-      var needsBuild = c.needs_build ? 'true' : 'false';
       var deployMode = c.deploy_mode || 'rsync';
-      var units = JSON.stringify(c.systemd_units || []);
-      var rsyncExcludes = JSON.stringify(c.rsync_excludes || []);
-      process.stdout.write(
-        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '|' + deployMode + '|' + units + '|' + rsyncExcludes + '\n'
-      );
+      process.stdout.write(JSON.stringify({
+        name: c.name,
+        repo: c.repo,
+        host: c.host,
+        deploy_path: deployPath,
+        unit_type: unitType,
+        needs_build: Boolean(c.needs_build),
+        unit_scope: unitScope,
+        deploy_mode: deployMode,
+        systemd_units: c.systemd_units || [],
+        rsync_excludes: c.rsync_excludes || []
+      }) + '\n');
     });
     break;
   }

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -4,7 +4,7 @@
 //   REGISTRY_PATH=/path/to/services.json QUERY=<query> node --input-type=commonjs scripts/lib/registry.js
 //
 // Queries:
-//   deploy       — components where deploy=true, output: name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json (deploy.sh format)
+//   deploy       — components where deploy=true, output: name|repo|host|deploy_path|unit_type|needs_build|unit_scope|deploy_mode|units_json|rsync_excludes_json (deploy.sh format)
 //   scan         — components where scan=true, output: space-separated repo names
 //   components   — all component names, space-separated
 //   systemd      — all systemd unit names, space-separated
@@ -49,7 +49,7 @@ var components = data.components;
 switch (query) {
   case 'deploy': {
     // Output format matches what deploy.sh needs:
-    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope|deploy_mode|units_json
+    // name|repo|host|deploy_path|primary_unit_type|needs_build|unit_scope|deploy_mode|units_json|rsync_excludes_json
     var deployable = components.filter(function (c) { return c.deploy; });
     deployable.forEach(function (c) {
       // Determine primary unit type/scope from first systemd unit.
@@ -66,8 +66,9 @@ switch (query) {
       var needsBuild = c.needs_build ? 'true' : 'false';
       var deployMode = c.deploy_mode || 'rsync';
       var units = JSON.stringify(c.systemd_units || []);
+      var rsyncExcludes = JSON.stringify(c.rsync_excludes || []);
       process.stdout.write(
-        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '|' + deployMode + '|' + units + '\n'
+        c.name + '|' + c.repo + '|' + c.host + '|' + deployPath + '|' + unitType + '|' + needsBuild + '|' + unitScope + '|' + deployMode + '|' + units + '|' + rsyncExcludes + '\n'
       );
     });
     break;

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -53,6 +53,16 @@ if (!Array.isArray(data.components)) {
 var VALID_UNIT_TYPES = ['service', 'timer'];
 var VALID_UNIT_SCOPES = ['system', 'user'];
 var VALID_UNIT_NAME = /^[A-Za-z0-9_.@-]+$/;
+var INVALID_RSYNC_EXCLUDE_CHARS = /[\x00-\x1f*?[\]{}\\]/;
+
+function isWithinPath(candidate, parent) {
+  if (parent === '/') return path.posix.isAbsolute(candidate);
+  return candidate === parent || candidate.indexOf(parent + '/') === 0;
+}
+
+function normalizedRootExclude(value) {
+  return path.posix.normalize(value).replace(/^\/+/, '').replace(/\/+$/, '');
+}
 
 var seenNames = {};
 var seenPorts = {};
@@ -109,10 +119,70 @@ data.components.forEach(function (c, i) {
   if (c.deploy === true) {
     if (typeof c.deploy_path !== 'string' || !c.deploy_path) {
       fail(label + ': deploy=true requires a non-empty "deploy_path"');
+    } else if (!path.posix.isAbsolute(c.deploy_path) || path.posix.normalize(c.deploy_path) !== c.deploy_path ||
+        c.deploy_path === '/') {
+      fail(label + ': deploy_path must be a normalized absolute path below /');
     }
     if (typeof c.host !== 'string' || !c.host) {
       fail(label + ': deploy=true requires a non-empty "host"');
     }
+  }
+
+  var deployMode = c.deploy_mode || 'rsync';
+  var persistentPathsValid = true;
+  var rsyncExcludesValid = true;
+
+  if (c.persistent_paths !== undefined && !Array.isArray(c.persistent_paths)) {
+    fail(label + ': "persistent_paths" must be an array when present');
+    persistentPathsValid = false;
+  }
+  if (c.rsync_excludes !== undefined && !Array.isArray(c.rsync_excludes)) {
+    fail(label + ': "rsync_excludes" must be an array when present');
+    rsyncExcludesValid = false;
+  }
+  if (c.deploy === true && deployMode === 'rsync' && !Array.isArray(c.persistent_paths)) {
+    fail(label + ': rsync deploy requires an explicit "persistent_paths" array (use [] only after auditing runtime writes)');
+    persistentPathsValid = false;
+  }
+
+  var persistentPaths = persistentPathsValid && Array.isArray(c.persistent_paths) ? c.persistent_paths : [];
+  persistentPaths.forEach(function (persistentPath, pi) {
+    if (typeof persistentPath !== 'string' || !persistentPath || !path.posix.isAbsolute(persistentPath) ||
+        path.posix.normalize(persistentPath) !== persistentPath) {
+      fail(label + '.persistent_paths[' + pi + ']: must be a normalized absolute path');
+      persistentPathsValid = false;
+    }
+  });
+
+  var rsyncExcludes = rsyncExcludesValid && Array.isArray(c.rsync_excludes) ? c.rsync_excludes : [];
+  rsyncExcludes.forEach(function (exclude, ei) {
+    if (typeof exclude !== 'string' || exclude.length < 2 || exclude.charAt(0) !== '/' ||
+        exclude === '/' || INVALID_RSYNC_EXCLUDE_CHARS.test(exclude) || exclude.indexOf('//') !== -1 ||
+        exclude.split('/').indexOf('..') !== -1 || exclude.split('/').indexOf('.') !== -1) {
+      fail(label + '.rsync_excludes[' + ei + ']: must be a literal, root-anchored rsync path such as "/data/"');
+      rsyncExcludesValid = false;
+    }
+  });
+
+  if (c.deploy === true && deployMode === 'rsync' && typeof c.deploy_path === 'string' &&
+      c.deploy_path && persistentPathsValid && rsyncExcludesValid) {
+    var normalizedDeployPath = path.posix.normalize(c.deploy_path);
+    var normalizedExcludes = rsyncExcludes.map(normalizedRootExclude);
+    persistentPaths.forEach(function (persistentPath) {
+      if (!isWithinPath(persistentPath, normalizedDeployPath)) return;
+      if (persistentPath === normalizedDeployPath) {
+        fail(label + ': persistent path equals rsync deploy_path and cannot be protected by a child exclusion: ' + persistentPath);
+        return;
+      }
+      var relativePath = path.posix.relative(normalizedDeployPath, persistentPath);
+      var protectedByExclude = normalizedExcludes.some(function (exclude) {
+        return relativePath === exclude || relativePath.indexOf(exclude + '/') === 0;
+      });
+      if (!protectedByExclude) {
+        fail(label + ': persistent path inside rsync deploy_path must be covered by rsync_excludes: ' +
+          persistentPath + ' (expected a root-anchored exclusion for /' + relativePath + ')');
+      }
+    });
   }
 
   if (!Array.isArray(c.systemd_units)) {

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -53,6 +53,9 @@ if (!Array.isArray(data.components)) {
 var VALID_UNIT_TYPES = ['service', 'timer'];
 var VALID_UNIT_SCOPES = ['system', 'user'];
 var VALID_UNIT_NAME = /^[A-Za-z0-9_.@-]+$/;
+var VALID_COMPONENT_ID = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+var VALID_HOST = /^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/;
+var VALID_ABSOLUTE_PATH = /^\/[A-Za-z0-9._@%+,=:\/-]+$/;
 var INVALID_RSYNC_EXCLUDE_CHARS = /[\x00-\x1f*?[\]{}\\]/;
 
 function isWithinPath(candidate, parent) {
@@ -64,6 +67,11 @@ function normalizedRootExclude(value) {
   return path.posix.normalize(value).replace(/^\/+/, '').replace(/\/+$/, '');
 }
 
+function isCanonicalAbsolutePath(value) {
+  return typeof value === 'string' && VALID_ABSOLUTE_PATH.test(value) && value !== '/' &&
+    value.charAt(value.length - 1) !== '/' && path.posix.normalize(value) === value;
+}
+
 var seenNames = {};
 var seenPorts = {};
 
@@ -73,15 +81,15 @@ data.components.forEach(function (c, i) {
     fail(label + ': component must be an object');
     return;
   }
-  if (typeof c.name === 'string' && c.name) {
+  if (typeof c.name === 'string' && VALID_COMPONENT_ID.test(c.name)) {
     label = c.name;
   } else {
-    fail(label + ': missing/invalid required field "name" (non-empty string)');
+    fail(label + ': missing/invalid required field "name" (safe identifier)');
   }
 
   ['repo'].forEach(function (field) {
-    if (typeof c[field] !== 'string' || !c[field]) {
-      fail(label + ': missing/invalid required field "' + field + '" (non-empty string)');
+    if (typeof c[field] !== 'string' || !VALID_COMPONENT_ID.test(c[field])) {
+      fail(label + ': missing/invalid required field "' + field + '" (safe identifier)');
     }
   });
 
@@ -95,8 +103,8 @@ data.components.forEach(function (c, i) {
     fail(label + ': "deploy_mode" must be "rsync" or "git-pull" when present, got "' + c.deploy_mode + '"');
   }
 
-  if (c.host !== null && typeof c.host !== 'string') {
-    fail(label + ': field "host" must be a string or null');
+  if (c.host !== null && (typeof c.host !== 'string' || !VALID_HOST.test(c.host))) {
+    fail(label + ': field "host" must be a safe hostname/address or null');
   }
   if (c.port !== undefined && c.port !== null && typeof c.port !== 'number') {
     fail(label + ': field "port" must be a number or null');
@@ -116,14 +124,15 @@ data.components.forEach(function (c, i) {
     }
   }
 
+  if (c.deploy_path !== undefined && !isCanonicalAbsolutePath(c.deploy_path)) {
+    fail(label + ': deploy_path must be a canonical absolute path below / with no trailing slash');
+  }
+
   if (c.deploy === true) {
     if (typeof c.deploy_path !== 'string' || !c.deploy_path) {
       fail(label + ': deploy=true requires a non-empty "deploy_path"');
-    } else if (!path.posix.isAbsolute(c.deploy_path) || path.posix.normalize(c.deploy_path) !== c.deploy_path ||
-        c.deploy_path === '/') {
-      fail(label + ': deploy_path must be a normalized absolute path below /');
     }
-    if (typeof c.host !== 'string' || !c.host) {
+    if (typeof c.host !== 'string' || !VALID_HOST.test(c.host)) {
       fail(label + ': deploy=true requires a non-empty "host"');
     }
   }
@@ -147,9 +156,8 @@ data.components.forEach(function (c, i) {
 
   var persistentPaths = persistentPathsValid && Array.isArray(c.persistent_paths) ? c.persistent_paths : [];
   persistentPaths.forEach(function (persistentPath, pi) {
-    if (typeof persistentPath !== 'string' || !persistentPath || !path.posix.isAbsolute(persistentPath) ||
-        path.posix.normalize(persistentPath) !== persistentPath) {
-      fail(label + '.persistent_paths[' + pi + ']: must be a normalized absolute path');
+    if (!isCanonicalAbsolutePath(persistentPath)) {
+      fail(label + '.persistent_paths[' + pi + ']: must be a canonical absolute path below / with no trailing slash');
       persistentPathsValid = false;
     }
   });

--- a/scripts/tests/deploy-persistent-paths.test.sh
+++ b/scripts/tests/deploy-persistent-paths.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Proves deploy.sh fails before rsync on an unsafe registry and passes declared
+# root-anchored exclusions through to rsync for an audited in-target data path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY="$SCRIPT_DIR/../deploy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/repos/alpha"
+
+cat > "$TMP_DIR/bin/ssh" << 'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"DEPLOY_OK"* ]]; then
+  echo "DEPLOY_OK"
+fi
+exit 0
+EOF
+
+cat > "$TMP_DIR/bin/rsync" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$RSYNC_CAPTURE"
+exit 0
+EOF
+
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync"
+
+cat > "$TMP_DIR/unsafe.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": ["/srv/alpha/data"], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+
+RSYNC_CAPTURE="$TMP_DIR/unsafe-rsync.args"
+export RSYNC_CAPTURE
+if REGISTRY_PATH="$TMP_DIR/unsafe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/unsafe.out" 2>&1; then
+  fail "unsafe registry must stop deploy"
+else
+  pass "unsafe registry stops deploy"
+fi
+if [[ -e "$RSYNC_CAPTURE" ]]; then
+  fail "unsafe registry must fail before rsync"
+else
+  pass "unsafe registry fails before rsync"
+fi
+
+cat > "$TMP_DIR/safe.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": ["/srv/alpha/data"], "rsync_excludes": ["/data/"],
+      "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+
+RSYNC_CAPTURE="$TMP_DIR/safe-rsync.args"
+export RSYNC_CAPTURE
+if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/safe.out" 2>&1; then
+  pass "safe registry completes mocked deploy"
+else
+  fail "safe registry completes mocked deploy"
+  sed -n '1,160p' "$TMP_DIR/safe.out"
+fi
+if grep -Fxq -- '--exclude=/data/' "$RSYNC_CAPTURE"; then
+  pass "declared persistent-path exclusion reaches rsync"
+else
+  fail "declared persistent-path exclusion reaches rsync"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/tests/deploy-persistent-paths.test.sh
+++ b/scripts/tests/deploy-persistent-paths.test.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEPLOY="$SCRIPT_DIR/../deploy.sh"
+# shellcheck source=scripts/lib/deploy-safety.sh
+source "$SCRIPT_DIR/../lib/deploy-safety.sh"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -22,10 +24,22 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
+assert_shell_quote_round_trip() {
+  local desc=$1 value=$2 quoted actual
+  quoted=$(posix_shell_quote "$value")
+  actual=$(sh -c "set -- $quoted; printf '%s' \"\$1\"")
+  if [[ "$actual" == "$value" ]]; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
 mkdir -p "$TMP_DIR/bin" "$TMP_DIR/repos/alpha"
 
 cat > "$TMP_DIR/bin/ssh" << 'EOF'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SSH_CAPTURE"
 if [[ "$*" == *"DEPLOY_OK"* ]]; then
   echo "DEPLOY_OK"
 fi
@@ -40,6 +54,35 @@ EOF
 
 chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync"
 
+SSH_CAPTURE="$TMP_DIR/ssh.calls"
+RSYNC_CAPTURE="$TMP_DIR/rsync.args"
+export SSH_CAPTURE RSYNC_CAPTURE
+
+assert_shell_quote_round_trip "POSIX quote round-trips plain text" "alpha"
+assert_shell_quote_round_trip "POSIX quote round-trips apostrophes and shell syntax" \
+  "alpha'\$(touch $TMP_DIR/must-not-exist);beta"
+if [[ -e "$TMP_DIR/must-not-exist" ]]; then
+  fail "POSIX quote must not execute embedded shell syntax"
+else
+  pass "POSIX quote does not execute embedded shell syntax"
+fi
+
+assert_rejected_before_remote() {
+  local desc=$1 fixture=$2
+  rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+  if REGISTRY_PATH="$fixture" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+      PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/rejected.out" 2>&1; then
+    fail "$desc: deploy must fail"
+  else
+    pass "$desc: deploy fails"
+  fi
+  if [[ -e "$SSH_CAPTURE" || -e "$RSYNC_CAPTURE" ]]; then
+    fail "$desc: must invoke neither ssh nor rsync"
+  else
+    pass "$desc: invokes neither ssh nor rsync"
+  fi
+}
+
 cat > "$TMP_DIR/unsafe.json" << 'EOF'
 {
   "components": [
@@ -53,19 +96,77 @@ cat > "$TMP_DIR/unsafe.json" << 'EOF'
 }
 EOF
 
-RSYNC_CAPTURE="$TMP_DIR/unsafe-rsync.args"
-export RSYNC_CAPTURE
-if REGISTRY_PATH="$TMP_DIR/unsafe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
-    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/unsafe.out" 2>&1; then
-  fail "unsafe registry must stop deploy"
-else
-  pass "unsafe registry stops deploy"
-fi
-if [[ -e "$RSYNC_CAPTURE" ]]; then
-  fail "unsafe registry must fail before rsync"
-else
-  pass "unsafe registry fails before rsync"
-fi
+assert_rejected_before_remote "unexcluded persistent path" "$TMP_DIR/unsafe.json"
+
+cat > "$TMP_DIR/trailing-slash.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha/",
+      "persistent_paths": ["/srv/alpha/data"], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "trailing-slash deploy path" "$TMP_DIR/trailing-slash.json"
+
+cat > "$TMP_DIR/injected-name.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha|evil", "repo": "alpha", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "delimiter-bearing component name" "$TMP_DIR/injected-name.json"
+
+cat > "$TMP_DIR/injected-repo.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha'evil", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "shell-bearing repo name" "$TMP_DIR/injected-repo.json"
+
+cat > "$TMP_DIR/injected-host.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": "h1;evil", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "shell-bearing host" "$TMP_DIR/injected-host.json"
+
+cat > "$TMP_DIR/injected-path.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha$(evil)",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "shell-bearing deploy path" "$TMP_DIR/injected-path.json"
 
 cat > "$TMP_DIR/safe.json" << 'EOF'
 {
@@ -81,8 +182,7 @@ cat > "$TMP_DIR/safe.json" << 'EOF'
 }
 EOF
 
-RSYNC_CAPTURE="$TMP_DIR/safe-rsync.args"
-export RSYNC_CAPTURE
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
 if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
     PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/safe.out" 2>&1; then
   pass "safe registry completes mocked deploy"
@@ -94,6 +194,21 @@ if grep -Fxq -- '--exclude=/data/' "$RSYNC_CAPTURE"; then
   pass "declared persistent-path exclusion reaches rsync"
 else
   fail "declared persistent-path exclusion reaches rsync"
+fi
+if grep -Fxq -- '--exclude=.env' "$RSYNC_CAPTURE"; then
+  pass "global .env policy preserves in-target service credentials"
+else
+  fail "global .env policy preserves in-target service credentials"
+fi
+if grep -Fxq -- "magnus@h1:'/srv/alpha/'" "$RSYNC_CAPTURE"; then
+  pass "rsync remote path uses POSIX shell quoting"
+else
+  fail "rsync remote path uses POSIX shell quoting"
+fi
+if grep -Fq -- "mkdir -p '/srv/alpha'" "$SSH_CAPTURE"; then
+  pass "ssh remote deploy path uses POSIX shell quoting"
+else
+  fail "ssh remote deploy path uses POSIX shell quoting"
 fi
 
 echo ""

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -71,7 +71,7 @@ cat > "$TMP_DIR/valid.json" << 'EOF'
     {
       "name": "alpha", "repo": "alpha", "host": "h1.local", "port": 3030,
       "deploy": true, "scan": true, "deploy_path": "/home/magnus/repos/alpha",
-      "needs_build": true,
+      "needs_build": true, "persistent_paths": ["/home/magnus/.local/share/alpha"],
       "systemd_units": [{ "name": "alpha", "type": "service" }]
     },
     {
@@ -90,6 +90,72 @@ assert_eq "valid registry -> exit 0" "0" "$(run_validator "$TMP_DIR/valid.json")
 # ── Real repo registry (regression: must always pass) ─────────────────────
 REPO_REGISTRY="$SCRIPT_DIR/../../services.json"
 assert_eq "real services.json -> exit 0" "0" "$(run_validator "$REPO_REGISTRY")"
+
+# ── rsync persistent-path safety ───────────────────────────────────────────
+cat > "$TMP_DIR/missing-persistent-paths.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/srv/alpha", "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "rsync deploy without persistent_paths audit -> exit 1" "1" "$(run_validator "$TMP_DIR/missing-persistent-paths.json")"
+
+cat > "$TMP_DIR/internal-persistent-unprotected.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/srv/alpha", "persistent_paths": ["/srv/alpha/data"],
+      "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "persistent path inside rsync target without exclusion -> exit 1" "1" "$(run_validator "$TMP_DIR/internal-persistent-unprotected.json")"
+
+cat > "$TMP_DIR/internal-persistent-protected.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/srv/alpha", "persistent_paths": ["/srv/alpha/data/db"],
+      "rsync_excludes": ["/data/"], "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "ancestor exclusion protects persistent path inside rsync target -> exit 0" "0" "$(run_validator "$TMP_DIR/internal-persistent-protected.json")"
+
+cat > "$TMP_DIR/persistent-equals-target.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/srv/alpha", "persistent_paths": ["/srv/alpha"],
+      "rsync_excludes": ["/data/"], "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "persistent path equal to rsync target -> exit 1" "1" "$(run_validator "$TMP_DIR/persistent-equals-target.json")"
+
+cat > "$TMP_DIR/root-deploy-path.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/", "persistent_paths": ["/var/lib/alpha"],
+      "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "filesystem root cannot be an rsync deploy target -> exit 1" "1" "$(run_validator "$TMP_DIR/root-deploy-path.json")"
+
+cat > "$TMP_DIR/unsafe-rsync-exclude.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/srv/alpha", "persistent_paths": ["/srv/alpha/data"],
+      "rsync_excludes": ["/**/data*"], "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "wildcard rsync exclusion -> exit 1" "1" "$(run_validator "$TMP_DIR/unsafe-rsync-exclude.json")"
 
 # ── Malformed JSON ──────────────────────────────────────────────────────────
 echo '{ not valid json' > "$TMP_DIR/bad-json.json"
@@ -253,12 +319,27 @@ deploy_row() {  # $1 = registry path, $2 = component name
     | grep "^$2|" || true
 }
 assert_eq "real services.json: hugin deploy row unchanged by appended timer" \
-  'hugin|hugin|huginmunin.local|/home/magnus/repos/hugin|service|true|user|rsync|[{"name":"hugin","type":"service","scope":"user"},{"name":"hugin-daily-analysis","type":"timer"}]' \
+  'hugin|hugin|huginmunin.local|/home/magnus/repos/hugin|service|true|user|rsync|[{"name":"hugin","type":"service","scope":"user"},{"name":"hugin-daily-analysis","type":"timer"}]|[]' \
   "$(deploy_row "$REPO_REGISTRY" hugin)"
 
 assert_eq "real services.json: skuld timer deploys via user manager" \
-  'skuld|skuld|huginmunin.local|/home/magnus/repos/skuld|timer|true|user|rsync|[{"name":"skuld","type":"timer","scope":"user"}]' \
+  'skuld|skuld|huginmunin.local|/home/magnus/repos/skuld|timer|true|user|rsync|[{"name":"skuld","type":"timer","scope":"user"}]|[]' \
   "$(deploy_row "$REPO_REGISTRY" skuld)"
+
+component_persistent_paths() {  # $1 = registry path, $2 = component name
+  REGISTRY_PATH="$1" COMPONENT_NAME="$2" node --input-type=commonjs -e '
+    var data = require(process.env.REGISTRY_PATH);
+    var component = data.components.filter(function (c) { return c.name === process.env.COMPONENT_NAME; })[0];
+    process.stdout.write(JSON.stringify(component && component.persistent_paths || []));
+  '
+}
+assert_eq "real services.json: Verdandi protects legacy data and declares canonical migration target" \
+  '["/home/magnus/repos/verdandi/data","/home/magnus/.local/share/verdandi"]' \
+  "$(component_persistent_paths "$REPO_REGISTRY" verdandi)"
+
+assert_eq "real services.json: Verdandi deploy carries legacy data exclusion" \
+  'verdandi|verdandi|huginmunin.local|/home/magnus/repos/verdandi|service|true|user|rsync|[{"name":"verdandi","type":"service","scope":"user"}]|["/data/"]' \
+  "$(deploy_row "$REPO_REGISTRY" verdandi)"
 
 cat > "$TMP_DIR/order.json" << 'EOF'
 {
@@ -269,7 +350,7 @@ cat > "$TMP_DIR/order.json" << 'EOF'
 }
 EOF
 assert_eq "deploy row derives type/scope from systemd_units[0] (service+user first)" \
-  'svc|svc|h1.local|/x|service|true|user|rsync|[{"name":"svc","type":"service","scope":"user"},{"name":"svc-daily","type":"timer"}]' \
+  'svc|svc|h1.local|/x|service|true|user|rsync|[{"name":"svc","type":"service","scope":"user"},{"name":"svc-daily","type":"timer"}]|[]' \
   "$(deploy_row "$TMP_DIR/order.json" svc)"
 
 echo ""

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -146,6 +146,17 @@ cat > "$TMP_DIR/root-deploy-path.json" << 'EOF'
 EOF
 assert_eq "filesystem root cannot be an rsync deploy target -> exit 1" "1" "$(run_validator "$TMP_DIR/root-deploy-path.json")"
 
+cat > "$TMP_DIR/trailing-slash-deploy-path.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1", "port": null, "deploy": true, "scan": false,
+      "deploy_path": "/srv/alpha/", "persistent_paths": ["/srv/alpha/data"],
+      "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "trailing slash cannot bypass deploy-path containment -> exit 1" "1" "$(run_validator "$TMP_DIR/trailing-slash-deploy-path.json")"
+
 cat > "$TMP_DIR/unsafe-rsync-exclude.json" << 'EOF'
 {
   "components": [
@@ -249,6 +260,18 @@ cat > "$TMP_DIR/bad-unit-name.json" << 'EOF'
 EOF
 assert_eq "invalid systemd unit name -> exit 1" "1" "$(run_validator "$TMP_DIR/bad-unit-name.json")"
 
+# ── Registry strings crossing deploy shell boundaries must be strict ───────
+cat > "$TMP_DIR/unsafe-component-strings.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha|evil", "repo": "alpha'evil", "host": "h1;evil", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha$(evil)",
+      "persistent_paths": [], "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "unsafe name/repo/host/path strings -> exit 1" "1" "$(run_validator "$TMP_DIR/unsafe-component-strings.json")"
+
 # ── Duplicate node name ──────────────────────────────────────────────────────
 cat > "$TMP_DIR/dup-node.json" << 'EOF'
 {
@@ -307,24 +330,37 @@ assert_clean_failure "null entry in systemd_units" "$TMP_DIR/null-unit.json"
 echo '{ "components": [], "nodes": [null] }' > "$TMP_DIR/null-node.json"
 assert_clean_failure "null entry in nodes" "$TMP_DIR/null-node.json"
 
-# ── registry.js deploy-query invariant (#43 / #33) ──────────────────────────
-# The `deploy` projection derives each component's primary unit_type/scope from
+# ── registry.js structured deploy-query invariant (#43 / #33) ──────────────
+# The JSON Lines `deploy` projection derives each component's primary unit_type/scope from
 # systemd_units[0]. hugin must stay a user-scoped rsync service even after a
 # system-scoped `hugin-daily-analysis` timer was appended to its systemd_units —
 # appending units must never change the deploy row. Pin the real services.json
 # plus the ordering contract on a synthetic fixture.
 REGISTRY_JS="$SCRIPT_DIR/../lib/registry.js"
-deploy_row() {  # $1 = registry path, $2 = component name
+deploy_field() {  # $1 = registry path, $2 = component name, $3 = field
   REGISTRY_PATH="$1" QUERY=deploy node --input-type=commonjs "$REGISTRY_JS" 2>/dev/null \
-    | grep "^$2|" || true
+    | COMPONENT_NAME="$2" COMPONENT_FIELD="$3" node --input-type=commonjs -e '
+        var input = "";
+        process.stdin.on("data", function (chunk) { input += chunk; });
+        process.stdin.on("end", function () {
+          var rows = input.trim().split("\n").filter(Boolean).map(JSON.parse);
+          var row = rows.filter(function (r) { return r.name === process.env.COMPONENT_NAME; })[0];
+          if (!row) process.exit(1);
+          var value = row[process.env.COMPONENT_FIELD];
+          process.stdout.write(value !== null && typeof value === "object" ? JSON.stringify(value) : String(value));
+        });
+      '
 }
-assert_eq "real services.json: hugin deploy row unchanged by appended timer" \
-  'hugin|hugin|huginmunin.local|/home/magnus/repos/hugin|service|true|user|rsync|[{"name":"hugin","type":"service","scope":"user"},{"name":"hugin-daily-analysis","type":"timer"}]|[]' \
-  "$(deploy_row "$REPO_REGISTRY" hugin)"
+assert_eq "real services.json: hugin primary unit remains service" "service" \
+  "$(deploy_field "$REPO_REGISTRY" hugin unit_type)"
+assert_eq "real services.json: hugin deploy scope remains user" "user" \
+  "$(deploy_field "$REPO_REGISTRY" hugin unit_scope)"
+assert_eq "real services.json: hugin structured units include appended timer" \
+  '[{"name":"hugin","type":"service","scope":"user"},{"name":"hugin-daily-analysis","type":"timer"}]' \
+  "$(deploy_field "$REPO_REGISTRY" hugin systemd_units)"
 
 assert_eq "real services.json: skuld timer deploys via user manager" \
-  'skuld|skuld|huginmunin.local|/home/magnus/repos/skuld|timer|true|user|rsync|[{"name":"skuld","type":"timer","scope":"user"}]|[]' \
-  "$(deploy_row "$REPO_REGISTRY" skuld)"
+  "user" "$(deploy_field "$REPO_REGISTRY" skuld unit_scope)"
 
 component_persistent_paths() {  # $1 = registry path, $2 = component name
   REGISTRY_PATH="$1" COMPONENT_NAME="$2" node --input-type=commonjs -e '
@@ -338,8 +374,7 @@ assert_eq "real services.json: Verdandi protects legacy data and declares canoni
   "$(component_persistent_paths "$REPO_REGISTRY" verdandi)"
 
 assert_eq "real services.json: Verdandi deploy carries legacy data exclusion" \
-  'verdandi|verdandi|huginmunin.local|/home/magnus/repos/verdandi|service|true|user|rsync|[{"name":"verdandi","type":"service","scope":"user"}]|["/data/"]' \
-  "$(deploy_row "$REPO_REGISTRY" verdandi)"
+  '["/data/"]' "$(deploy_field "$REPO_REGISTRY" verdandi rsync_excludes)"
 
 cat > "$TMP_DIR/order.json" << 'EOF'
 {
@@ -349,9 +384,10 @@ cat > "$TMP_DIR/order.json" << 'EOF'
   ]
 }
 EOF
-assert_eq "deploy row derives type/scope from systemd_units[0] (service+user first)" \
-  'svc|svc|h1.local|/x|service|true|user|rsync|[{"name":"svc","type":"service","scope":"user"},{"name":"svc-daily","type":"timer"}]|[]' \
-  "$(deploy_row "$TMP_DIR/order.json" svc)"
+assert_eq "deploy JSON derives type from systemd_units[0]" "service" \
+  "$(deploy_field "$TMP_DIR/order.json" svc unit_type)"
+assert_eq "deploy JSON derives scope from systemd_units[0]" "user" \
+  "$(deploy_field "$TMP_DIR/order.json" svc unit_scope)"
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/services.json
+++ b/services.json
@@ -8,6 +8,7 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/munin-memory",
+      "persistent_paths": ["/home/magnus/.munin-memory"],
       "needs_build": true,
       "systemd_units": [
         { "name": "munin-memory", "type": "service" }
@@ -21,6 +22,7 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/repos/hugin",
+      "persistent_paths": ["/home/magnus/workspace", "/home/magnus/.hugin"],
       "needs_build": true,
       "systemd_units": [
         { "name": "hugin", "type": "service", "scope": "user" },
@@ -35,6 +37,7 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/repos/heimdall",
+      "persistent_paths": ["/home/magnus/.heimdall"],
       "needs_build": false,
       "systemd_units": [
         { "name": "heimdall", "type": "service" },
@@ -50,6 +53,7 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/repos/ratatoskr",
+      "persistent_paths": [],
       "needs_build": true,
       "systemd_units": [
         { "name": "ratatoskr", "type": "service" }
@@ -63,6 +67,7 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/repos/skuld",
+      "persistent_paths": [],
       "needs_build": true,
       "systemd_units": [
         { "name": "skuld", "type": "timer", "scope": "user" }
@@ -76,6 +81,7 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/mimir-server",
+      "persistent_paths": ["/home/magnus/mimir", "/var/lib/mimir"],
       "needs_build": true,
       "systemd_units": [
         { "name": "mimir", "type": "service" }
@@ -114,6 +120,11 @@
       "deploy": true,
       "scan": true,
       "deploy_path": "/home/magnus/repos/verdandi",
+      "persistent_paths": [
+        "/home/magnus/repos/verdandi/data",
+        "/home/magnus/.local/share/verdandi"
+      ],
+      "rsync_excludes": ["/data/"],
       "needs_build": true,
       "systemd_units": [
         { "name": "verdandi", "type": "service", "scope": "user" }


### PR DESCRIPTION
## Summary

Adds a registry-backed deploy safety contract after the Verdandi data-loss incident.

- every rsync-deployed component must explicitly declare audited persistent paths
- any persistent path beneath an rsync `--delete` target must be covered by a literal root-anchored exclusion
- registry validation runs before any SSH, rsync, build, or service mutation
- component-specific exclusions are passed to rsync only after validation
- Verdandi declares both its legacy checkout-local path and the accepted canonical external path; `/data/` is protected during the transition

## Incident linkage

Verdandi production had `VERDANDI_DATA_DIR=/home/magnus/repos/verdandi/data`, while Grimnir deployed that checkout with `rsync --delete` and no `data/` exclusion. The July 8 deployment is the likely deletion mechanism for the lost historical audit database.

## Validation

- registry validation: 37/37
- mocked deploy safety: 4/4
- full `make test`
- changed-script shellcheck and bash syntax
- Node syntax
- diff check

The accepted owner-decision documents are intentionally not included in this PR; their exact retention windows still await owner confirmation.