### PR TITLE
Reconcile Grimnir status and Codex guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,9 @@ contains architecture docs, conventions, and cross-project references.
 
 No service code lives here — each component has its own repo.
 
+The shared project inventory, key-document map, and script guidance below are intentionally
+synchronized with `CLAUDE.md`; update both files together whenever that shared guidance changes.
+
 ## Codex workflow
 
 - Read `STATUS.md` first for current execution state and resumption context.
@@ -57,7 +60,7 @@ No service code lives here — each component has its own repo.
 - `docs/gap-analysis-2026-07-03.md` — Critic-corrected ecosystem gap analysis vs vision v0.2: ranked
   gaps, quick wins, cut list, and corrections log (the source of the 23-ticket fleet program)
 - `docs/threat-model.md` — Consolidated threat model (v0.1): assets, trust boundaries, adversaries,
-  and a T1–T11 key-threats table mapped to owning tickets
+  and a T1–T11 key-threats table mapped to owning tickets (from the 2026-07-06 blind-spot audit)
 - `docs/roadmap-now-decision-brief.md` — Index of the adopted "now" decisions: succession (#65),
   GDPR/data lifecycle (#66), system ROI/off-ramp (#67), Skuld revive-or-cut (#69), interactive-session
   trust posture (#70), and the #58 Verdandi blocker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# Grimnir — AGENTS.md
+
+## What this is
+
+This is the **system-level** documentation repository for the Grimnir personal AI infrastructure. It
+contains architecture docs, conventions, and cross-project references.
+
+No service code lives here — each component has its own repo.
+
+## Codex workflow
+
+- Read `STATUS.md` first for current execution state and resumption context.
+- Treat `services.json` as the component-inventory authority; see `docs/authority.md` for the wider
+  authority map.
+- Keep component implementation changes in their owning repositories. Grimnir changes should be
+  system-level documentation, registry, deployment orchestration, or cross-component validation.
+- Run `make test` for repository changes. Run `shellcheck scripts/*.sh scripts/lib/*.sh
+  scripts/tests/*.sh` when shell code changes.
+- Do not place credentials, recovery material, private-envelope contents, or private locators in
+  git.
+
+## Component repos
+
+> Component inventory (names, hosts, ports, systemd units) is defined in [`services.json`](services.json).
+> All scripts read from it — see `docs/authority.md` for the authority map.
+
+| Component | Repo | Role |
+|-----------|------|------|
+| Munin Memory | `munin-memory` | Persistent memory MCP server |
+| Hugin | `hugin` | Task dispatcher |
+| Mimir | `mimir` | Authenticated file server |
+| Heimdall | `heimdall` | Monitoring dashboard |
+| Ratatoskr | `ratatoskr` | Telegram router + concierge |
+| Skuld | `skuld` (grimnir-bot org) | Daily intelligence briefing |
+| Fortnox MCP | `fortnox-mcp` | Accounting CLI + MCP |
+| Brokkr | `brokkr` | Platform/substrate layer — hardware, OS, storage, backups (peer, not a service) |
+
+## Key documents
+
+- `docs/architecture.md` — Full system architecture guide (topology, components, security, data flow)
+- `docs/full-architecture.md` — Ignored, auto-generated comprehensive doc (run `make docs` or
+  `scripts/generate-architecture.sh` on the Pi to regenerate a local snapshot)
+- `docs/conventions.md` — Naming, GitHub ownership, service patterns
+- `docs/role-separation.md` — Why the canonical grimnir checkout must not double as a deploy target
+  or hugin workspace, and the validate check that alarms on drift (issue #47)
+- `docs/observability-and-improvement.md` — How components capture traces, score outputs, and feed the
+  self-improving loop
+- `docs/tenant-contract.md` — The minimal agent↔substrate contract any agent must satisfy to act
+  through the substrate (Munin access, gateway routing, safety gating, audit emission) plus a cheap
+  validation plan
+- `docs/tenant-validation-2026-07-04.md` — Evidence note from the first real non-Claude tenant run
+  (Codex CLI, grimnir#58): seams A/B/C passed on transport, D blocked, per-tenant identity missing
+  everywhere; harness in `scripts/tenant-validation/`
+- `docs/failure-recovery.md` — The autonomous-mutation undo convention: every autonomous mutation
+  leaves a reversal recipe (`git_revert`, snapshot, or irreversible plus mitigation) and an audit
+  event (issue #46)
+- `docs/gap-analysis-2026-07-03.md` — Critic-corrected ecosystem gap analysis vs vision v0.2: ranked
+  gaps, quick wins, cut list, and corrections log (the source of the 23-ticket fleet program)
+- `docs/threat-model.md` — Consolidated threat model (v0.1): assets, trust boundaries, adversaries,
+  and a T1–T11 key-threats table mapped to owning tickets
+- `docs/roadmap-now-decision-brief.md` — Index of the adopted "now" decisions: succession (#65),
+  GDPR/data lifecycle (#66), system ROI/off-ramp (#67), Skuld revive-or-cut (#69), interactive-session
+  trust posture (#70), and the #58 Verdandi blocker
+- `docs/succession-checklist.md` — Public, non-secret export-and-shutdown checklist for the emergency
+  delegate; private-envelope contents stay out of git
+- `docs/data-lifecycle.md` — Store-by-store retention, correction, erasure, and backup-expiry map
+- `docs/interactive-session-posture.md` — Required Hugin handoff (or constrained fresh-session
+  fallback) for consequential mutations after untrusted input
+- `docs/skuld-trial-decision.md` — 28-day evidence record and keep/cut gate for the Skuld briefing
+  producer
+- `docs/agent-harness-bakeoff-2026-07-08.md` — Evidence note on open-source, model-agnostic agent
+  harnesses. Goose and OpenCode both completed M5-backed edit/test loops; OpenCode is the recommended
+  first Hugin coding-lane adapter, Goose the general-worker candidate.
+- `services.json` — **Single source of truth** for component inventory (names, hosts, ports, systemd
+  units). All scripts read from it via `scripts/lib/registry.js`
+
+## Scripts
+
+| Script | Purpose | Run with |
+|--------|---------|----------|
+| `scripts/deploy.sh` | Deploy services to Pi hosts (all or selective) | `make deploy` or `make deploy ARGS="munin-memory"` |
+| `scripts/generate-architecture.sh` | Generate deployment snapshot + full-architecture.md | `make docs` (Pi only) |
+| `scripts/security-scan.sh` | Scan all repos for vulnerabilities and secrets | `make security` |
+
+> OS patching (`setup-host-patching.sh`) and maintenance reports (`maintenance-report.sh`) have moved
+> to the `brokkr` repo. Use `make patching` / `make maintenance-os` / `make maintenance-deps` from
+> `brokkr/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,9 @@ This is the **system-level** documentation repository for the Grimnir personal A
 
 No service code lives here — each component has its own repo.
 
+The shared project inventory, key-document map, and script guidance below are intentionally
+synchronized with `AGENTS.md`; update both files together whenever that shared guidance changes.
+
 ## Component repos
 
 > Component inventory (names, hosts, ports, systemd units) is defined in [`services.json`](services.json).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Grimnir System — Status
 
 **Last session:** 2026-07-10 (Codex) — merged/deployed safeguards and recovery readiness reconciled
-**Branch:** main
+**Branch:** main (status reconciled via PR #76)
 
 ## Current State (2026-07-10)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,15 @@
 # Grimnir System — Status
 
-**Last session:** 2026-07-10 (Codex) — roadmap-now owner decisions recorded
-**Branch:** codex/owner-decisions-20260710-v2
+**Last session:** 2026-07-10 (Codex) — merged/deployed safeguards and recovery readiness reconciled
+**Branch:** main
 
-## Active Session (2026-07-10) — roadmap-now owner decisions
+## Current State (2026-07-10)
 
-Converted the five owner choices in `docs/roadmap-now-decision-brief.md` into the deliberately small
-artifacts already scoped there:
+### Roadmap-now decisions
+
+Grimnir PR #75 merged as `e2dfa9c` after three review/fix rounds, 144 local assertions, and green
+GitHub test/shellcheck. It converted the five accepted owner choices in
+`docs/roadmap-now-decision-brief.md` into the deliberately small artifacts already scoped there:
 
 - Sara is the emergency delegate with **export-and-shutdown only** authority. The public succession
   checklist contains no locator, credential, recovery material, or private-envelope contents.
@@ -14,7 +17,7 @@ artifacts already scoped there:
   whole-substrate readiness remains blocked while the safe action is stop-and-preserve. Mimir's live
   proof on 2026-07-10 used an immutable 1,643-file encrypted backup: `cryptcheck` reported zero
   differences, the full scratch restore compared exactly, the stamp was fresh, and Heimdall reported
-  pass. The component repo's local `STATUS.md` may lag this production evidence.
+  pass. Mimir PR #19 reconciled its component status with that evidence and merged as `0bf441c`.
 - Provisional retention defaults are now explicit: statutory/contractual duties otherwise 24 months
   after an engagement ends for client/accounting data; personal memory until correction/deletion
   with annual review; operational telemetry for six months; transient artifacts for 30 days.
@@ -24,11 +27,51 @@ artifacts already scoped there:
 - Consequential mutations after untrusted input route through Hugin, with a constrained fresh-session
   fallback only when Hugin cannot perform the action.
 
-No retention deletion job, service change, secret, private locator, merge, or deployment is part of
-this docs-only change.
+No retention deletion job, service change, secret, or private locator was part of the decision
+package. Grimnir was deployed to huginmunin after merge; remote HEAD and `.deployed-commit` both
+equal `e2dfa9c4a7fa9bbab563d7520c4a4ff8a65e8541`, and the complete post-deploy test suite passed.
+
+### Merged safeguards and deployment state
+
+- **Mimir PR #18** merged as `b197e1d` and is deployed. Its encrypted off-site backup is active
+  after an immutable 1,643-file backup, `cryptcheck`, full restore, exact comparison, fresh stamp,
+  and Heimdall pass. The follow-up status reconciliation is Mimir PR #19 (`0bf441c`).
+- **Hugin PR #159** merged as `f7bf00e` and is deployed. CI, build, 1,498 tests, and a live
+  provenance probe passed. The existing production npm audit debt remains one moderate and one high
+  finding and is separate follow-up work.
+- **Brokkr PR #42** merged as `8b90fba` and is deployed. The M5 dead-man timer is active and its
+  production probe, three-miss alert/recovery drill, and forced direct-fallback drill passed. User
+  receipt confirmation for the drill messages remains pending.
+- **Grimnir PR #74** merged as `a3eb01f` and is deployed. It added fail-closed persistent-path
+  protection around rsync `--delete` deploy targets, including Verdandi's legacy checkout-local data
+  path. CI, the full local suite, and the post-deploy suite passed.
+- **Verdandi PR #18** merged as `532677d` after CI, 88 tests, build/lint, and evidence-integrity
+  review. Production remains intentionally inactive and undeployed until image-first physical
+  SD-card recovery. No new data directory or generation has been created.
+- **Brokkr PR #43** merged as `2336f07` after 111 assertions, green CI, and three review/fix rounds.
+  Its external-heartbeat support is intentionally not deployed until its protected external check
+  URL can be provisioned directly on M5.
+
+### Recovery and external-heartbeat readiness
+
+- No credible Verdandi database was found locally, in named NAS backups, or in encrypted Mimir
+  current. The nonfunctional service was stopped and reset after its missing checkout-local data
+  directory caused a restart loop. The evidence-preserving next action is bounded offline SD-card
+  recovery before any new genesis.
+- M5 is prepared for image-first recovery with GNU ddrescue, extundelete, Sleuth Kit,
+  TestDisk/PhotoRec, SQLite, and e2fsprogs. Its owner-only recovery workspace is on the internal NVMe
+  with about 1.46 TiB free. No removable media or huginmunin was touched during preparation.
+- The Healthchecks.io free-account signup was submitted and the site confirmed that an email was
+  sent. Activation through the magic link is still required before creating the check, provisioning
+  its protected URL on M5, and deploying Brokkr PR #43.
 
 ### Pending / next
 
+- Activate the Healthchecks.io account, create the external check, provision its protected URL
+  directly on M5, then deploy and verify Brokkr PR #43.
+- Coordinate a huginmunin outage and physical SD-card handoff for bounded offline Verdandi recovery
+  before any new genesis.
+- Confirm receipt of the Brokkr outage, recovery, and labelled direct-fallback drill messages.
 - Confirm out of band that Sara can locate the private succession envelope and complete a dry
   walkthrough; do not put the locator or envelope contents in git.
 - Add and drill a routine Verdandi export/restore procedure in its owning repo before claiming the

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,20 +44,24 @@ equal `e2dfa9c4a7fa9bbab563d7520c4a4ff8a65e8541`, and the complete post-deploy t
   receipt confirmation for the drill messages remains pending.
 - **Grimnir PR #74** merged as `a3eb01f` and is deployed. It added fail-closed persistent-path
   protection around rsync `--delete` deploy targets, including Verdandi's legacy checkout-local data
-  path. CI, the full local suite, and the post-deploy suite passed.
+  path. It merged before PR #75 and is an ancestor of the deployed `e2dfa9c`; CI, the full local
+  suite, and the post-deploy suite passed.
 - **Verdandi PR #18** merged as `532677d` after CI, 88 tests, build/lint, and evidence-integrity
   review. Production remains intentionally inactive and undeployed until image-first physical
   SD-card recovery. No new data directory or generation has been created.
 - **Brokkr PR #43** merged as `2336f07` after 111 assertions, green CI, and three review/fix rounds.
-  Its external-heartbeat support is intentionally not deployed until its protected external check
-  URL can be provisioned directly on M5.
+  The canonical M5 Brokkr checkout is deliberately pinned to PR #42 (`8b90fba`) until the protected
+  external check URL can be provisioned directly on M5. The external heartbeat is config-gated and
+  inert without that URL, so code availability alone cannot emit pings.
 
 ### Recovery and external-heartbeat readiness
 
 - No credible Verdandi database was found locally, in named NAS backups, or in encrypted Mimir
   current. The nonfunctional service was stopped and reset after its missing checkout-local data
-  directory caused a restart loop. The evidence-preserving next action is bounded offline SD-card
-  recovery before any new genesis.
+  directory caused a restart loop. A live huginmunin check found the old `Restart=always` unit still
+  enabled but inactive; `systemctl --user disable --now verdandi.service` left it disabled/inactive,
+  and the checkpoint timer is not found/inactive. The evidence-preserving next action is bounded
+  offline SD-card recovery before any new genesis.
 - M5 is prepared for image-first recovery with GNU ddrescue, extundelete, Sleuth Kit,
   TestDisk/PhotoRec, SQLite, and e2fsprogs. Its owner-only recovery workspace is on the internal NVMe
   with about 1.46 TiB free. No removable media or huginmunin was touched during preparation.


### PR DESCRIPTION
## Summary

- reconcile `STATUS.md` with the merged and deployed safeguard work from 2026-07-10
- record the evidence-preserving Verdandi recovery posture and M5 recovery readiness
- record the remaining Healthchecks activation blocker before Brokkr PR #43 can deploy
- add a version-controlled `AGENTS.md` synchronized with the current project guidance in `CLAUDE.md`, plus Codex-specific workflow notes

The status intentionally excludes local worktree paths, stale-branch cleanup, untracked review-file inventory, and other laptop-only hygiene.

## Impact

Future Codex and Claude sessions get the same current component inventory, key-document map, script guidance, deployment state, and recovery blockers without publishing workstation-local handoff details.

## Validation

- `make test` (144 assertions passed)
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `git diff --check`