### PR TITLE
Fix scope-aware systemd validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test-systemd-status test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -30,7 +30,10 @@ test-failure-recovery-doc: ## Regression test: assert docs/failure-recovery.md d
 test-registry-checkout: ## Unit tests for the registry-checkout integrity helpers (issue #47)
 	@bash scripts/tests/registry-checkout.test.sh
 
-test: test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout ## Run all test suites
+test-systemd-status: ## Scope-aware local/remote systemd status checks (issue #63)
+	@bash scripts/tests/systemd-status.test.sh
+
+test: test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test-systemd-status ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,33 @@
 # Grimnir System — Status
 
-**Last session:** 2026-07-10 (Codex) — merged/deployed safeguards and recovery readiness reconciled
-**Branch:** main (status reconciled via PR #76)
+**Last session:** 2026-07-12 (Codex) — issue #63 scope-aware validator fix prepared
+**Branch:** codex/grimnir-63-user-units
+
+## Active Session (2026-07-12) — issue #63 scope-aware unit validation
+
+Prepared a focused fix for `grimnir#63`. Although earlier work had started honoring the registry's
+unit scope, the checks were embedded and untested, remote user-manager access only set
+`XDG_RUNTIME_DIR`, shell arguments were quoted ad hoc, and a manager/SSH failure collapsed into an
+ambiguous status. The branch now:
+
+- centralizes read-only local and remote systemd status checks in `scripts/lib/systemd-status.sh`;
+- uses the system manager for system units and the user manager for user units, with explicit
+  `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` locally and over SSH;
+- reuses the audited POSIX quoting helper for remote action/unit arguments;
+- preserves known inactive/failed states as failures while surfacing an unreachable manager as a
+  warning rather than a false inactive report; and
+- adds 23 regression assertions covering local/remote system and user scope, unreachable managers,
+  environment setup, and hostile shell syntax.
+
+Local `make test` passes 167 assertions. Full `shellcheck` and `bash -n` over scripts and tests also
+pass. No production host or service was touched.
+
+### Pending / next
+
+- Commit and push `codex/grimnir-63-user-units`, open the ready PR closing #63, obtain independent
+  review, then merge/deploy only after CI and review are green.
+- Deployment after merge: from a current clean Grimnir checkout, run `make deploy ARGS="grimnir"`;
+  verify remote HEAD/marker and run `./scripts/generate-architecture.sh --validate` on huginmunin.
 
 ## Current State (2026-07-10)
 

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -30,6 +30,10 @@ REPOS_DIR="$HOME/repos"
 REGISTRY="$GRIMNIR_DIR/services.json"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 
+# shellcheck source=scripts/lib/systemd-status.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/systemd-status.sh"
+
 read -ra COMPONENTS <<< "$(REGISTRY_PATH="$REGISTRY" QUERY=components node --input-type=commonjs "$REGISTRY_JS")"
 
 # ─── CLI args ───────────────────────────────────────────────
@@ -62,25 +66,6 @@ unit_rows_from_json() {
       ].join("|") + "\n");
     });
   '
-}
-
-systemctl_user() {
-  local user=${SYSTEMD_USER:-magnus}
-  local uid runtime
-  uid="$(id -u "$user" 2>/dev/null || echo 1000)"
-  runtime="/run/user/$uid"
-
-  if [[ "$(id -un 2>/dev/null || true)" == "$user" ]]; then
-    XDG_RUNTIME_DIR="$runtime" systemctl --user "$@" 2>/dev/null || echo 'unknown'
-  else
-    sudo -u "$user" XDG_RUNTIME_DIR="$runtime" systemctl --user "$@" 2>/dev/null || echo 'unknown'
-  fi
-}
-
-remote_systemctl_user() {
-  local host=$1 action=$2 unit=$3 user=${SYSTEMD_USER:-magnus}
-  ssh -o ConnectTimeout=5 -o BatchMode=yes "${user}@${host}" \
-    "XDG_RUNTIME_DIR=/run/user/\$(id -u) systemctl --user '$action' '$unit'" 2>/dev/null || echo 'unknown'
 }
 
 health_status_local() {
@@ -160,6 +145,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
 
     STATUS_LINE=""
     COMPONENT_OK=true
+    COMPONENT_WARN=false
 
     # Determine if host is local or remote
     if [[ "$v_host" == "huginmunin.local" ]] || [[ "$v_host" == "huginmunin" ]]; then
@@ -176,25 +162,24 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
         [[ -z "$unit_name" ]] && continue
         unit="${unit_name}.${unit_kind}"
         if [[ "$IS_LOCAL" == "true" ]]; then
-          if [[ "$unit_scope" == "user" ]]; then
-            active="$(systemctl_user is-active "$unit")"
-          else
-            active="$(systemctl is-active "$unit" 2>/dev/null || echo 'unknown')"
-          fi
+          active="$(local_systemctl_status "$unit_scope" is-active "$unit")"
         else
-          if [[ "$unit_scope" == "user" ]]; then
-            active="$(remote_systemctl_user "$v_host" is-active "$unit")"
-          else
-            active="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "systemctl is-active '$unit'" 2>/dev/null || echo 'unknown')"
-          fi
+          active="$(remote_systemctl_status "$v_host" "$unit_scope" is-active "$unit")"
         fi
 
-        if [[ "$active" == "active" ]]; then
-          STATUS_LINE+=" unit:$unit($unit_scope)=active"
-        else
-          STATUS_LINE+=" unit:$unit($unit_scope)=$active"
-          COMPONENT_OK=false
-        fi
+        case "$(systemctl_status_severity "$active" "$unit_scope")" in
+          pass)
+            STATUS_LINE+=" unit:$unit($unit_scope)=active"
+            ;;
+          warn)
+            STATUS_LINE+=" unit:$unit($unit_scope)=unreachable"
+            COMPONENT_WARN=true
+            ;;
+          fail)
+            STATUS_LINE+=" unit:$unit($unit_scope)=$active"
+            COMPONENT_OK=false
+            ;;
+        esac
       done <<< "$unit_rows"
     fi
 
@@ -274,12 +259,15 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     fi
 
     # Emit result line
-    if [[ "$COMPONENT_OK" == "true" ]]; then
-      RESULTS+="✅ $v_name:$STATUS_LINE\n"
-      PASS=$((PASS + 1))
-    else
+    if [[ "$COMPONENT_OK" != "true" ]]; then
       RESULTS+="❌ $v_name:$STATUS_LINE\n"
       FAIL=$((FAIL + 1))
+    elif [[ "$COMPONENT_WARN" == "true" ]]; then
+      RESULTS+="⚠️  $v_name:$STATUS_LINE\n"
+      WARN=$((WARN + 1))
+    else
+      RESULTS+="✅ $v_name:$STATUS_LINE\n"
+      PASS=$((PASS + 1))
     fi
   done < <(REGISTRY_PATH="$REGISTRY" QUERY=validate node --input-type=commonjs "$REGISTRY_JS")
 
@@ -442,8 +430,8 @@ service_status_row() {
   local active enabled pid mem mem_mb started
   local -a systemctl_prefix
   if [[ "$unit_scope" == "user" ]]; then
-    active="$(systemctl_user is-active "$unit")"
-    enabled="$(systemctl_user is-enabled "$unit")"
+    active="$(local_systemctl_status user is-active "$unit")"
+    enabled="$(local_systemctl_status user is-enabled "$unit")"
   else
     systemctl_prefix=(systemctl)
     active="$("${systemctl_prefix[@]}" is-active "$unit" 2>/dev/null || echo 'unknown')"

--- a/scripts/lib/systemd-status.sh
+++ b/scripts/lib/systemd-status.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Read-only, scope-aware systemd status helpers used by architecture validation.
+
+SYSTEMD_STATUS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/deploy-safety.sh
+source "$SYSTEMD_STATUS_LIB_DIR/deploy-safety.sh"
+
+normalize_systemctl_status() {
+  local status=${1%%$'\n'*}
+  status=${status%$'\r'}
+  case "$status" in
+    active|inactive|failed|activating|deactivating|reloading|maintenance|unknown)
+      printf '%s\n' "$status"
+      ;;
+    *)
+      # A missing status normally means that the manager (or the remote host)
+      # could not be reached. Do not turn that transport failure into a false
+      # inactive report.
+      printf '%s\n' 'unreachable'
+      ;;
+  esac
+}
+
+systemctl_status_severity() {
+  local status=$1 scope=${2:-system}
+  case "$status" in
+    active) printf '%s\n' pass ;;
+    unreachable)
+      if [[ "$scope" == "user" ]]; then
+        printf '%s\n' warn
+      else
+        printf '%s\n' fail
+      fi
+      ;;
+    *) printf '%s\n' fail ;;
+  esac
+}
+
+systemctl_user() {
+  local user=${SYSTEMD_USER:-magnus}
+  local uid runtime bus
+
+  uid="$(id -u "$user" 2>/dev/null || true)"
+  [[ "$uid" =~ ^[0-9]+$ ]] || return 1
+  runtime="/run/user/$uid"
+  bus="unix:path=$runtime/bus"
+
+  if [[ "$(id -un 2>/dev/null || true)" == "$user" ]]; then
+    XDG_RUNTIME_DIR="$runtime" DBUS_SESSION_BUS_ADDRESS="$bus" systemctl --user "$@"
+  else
+    sudo -u "$user" env XDG_RUNTIME_DIR="$runtime" \
+      DBUS_SESSION_BUS_ADDRESS="$bus" systemctl --user "$@"
+  fi
+}
+
+local_systemctl_status() {
+  local scope=$1 action=$2 unit=$3 user=${SYSTEMD_USER:-magnus}
+  local output
+
+  if [[ "$scope" == "user" ]]; then
+    output="$(systemctl_user "$action" "$unit" 2>/dev/null || true)"
+  else
+    output="$(systemctl "$action" "$unit" 2>/dev/null || true)"
+  fi
+
+  normalize_systemctl_status "$output"
+}
+
+remote_systemctl_status() {
+  local host=$1 scope=$2 action=$3 unit=$4 user=${SYSTEMD_USER:-magnus}
+  local output command
+
+  command=''
+  if [[ "$scope" == "user" ]]; then
+    # Expanded by the remote shell, not by this process.
+    # shellcheck disable=SC2016
+    command='uid=$(id -u) || exit; export XDG_RUNTIME_DIR=/run/user/$uid; export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus; '
+    command+='systemctl --user '
+  else
+    command+='systemctl '
+  fi
+  command+="$(posix_shell_quote "$action") $(posix_shell_quote "$unit")"
+
+  output="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "${user}@${host}" "$command" \
+    2>/dev/null || true)"
+  normalize_systemctl_status "$output"
+}

--- a/scripts/tests/systemd-status.test.sh
+++ b/scripts/tests/systemd-status.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Regression tests for scope-aware local/remote systemd validation (#63).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/systemd-status.sh
+source "$SCRIPT_DIR/../lib/systemd-status.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+MOCK_BIN="$TMP_DIR/bin"
+mkdir -p "$MOCK_BIN"
+export SYSTEMD_STATUS_TEST_LOG="$TMP_DIR/systemctl.log"
+export SYSTEMD_USER=tester
+
+cat > "$MOCK_BIN/id" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -un) printf '%s\n' tester ;;
+  -u) printf '%s\n' 1001 ;;
+  *) printf '%s\n' 1001 ;;
+esac
+EOF
+
+cat > "$MOCK_BIN/systemctl" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf 'runtime=%s\n' "${XDG_RUNTIME_DIR:-}"
+  printf 'bus=%s\n' "${DBUS_SESSION_BUS_ADDRESS:-}"
+  printf 'arg=%s\n' "$@"
+} > "$SYSTEMD_STATUS_TEST_LOG"
+if [[ "${SYSTEMD_STATUS_TEST_EMPTY:-false}" == "true" ]]; then
+  exit 1
+fi
+printf '%s\n' "${SYSTEMD_STATUS_TEST_RESULT:-active}"
+[[ "${SYSTEMD_STATUS_TEST_RESULT:-active}" == "active" ]]
+EOF
+
+cat > "$MOCK_BIN/ssh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${SYSTEMD_STATUS_TEST_SSH_FAIL:-false}" == "true" ]]; then
+  exit 255
+fi
+while [[ "${1:-}" == "-o" ]]; do shift 2; done
+printf 'target=%s\n' "$1" > "$SYSTEMD_STATUS_TEST_SSH_LOG"
+shift
+PATH="$SYSTEMD_STATUS_TEST_PATH" /bin/sh -c "$1"
+EOF
+
+chmod +x "$MOCK_BIN/id" "$MOCK_BIN/systemctl" "$MOCK_BIN/ssh"
+export PATH="$MOCK_BIN:$PATH"
+export SYSTEMD_STATUS_TEST_PATH="$PATH"
+export SYSTEMD_STATUS_TEST_SSH_LOG="$TMP_DIR/ssh.log"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local description=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    printf '  PASS: %s\n' "$description"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %s (expected %q, got %q)\n' "$description" "$expected" "$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_log_line() {
+  local description=$1 expected=$2
+  if grep -Fxq -- "$expected" "$SYSTEMD_STATUS_TEST_LOG"; then
+    printf '  PASS: %s\n' "$description"
+    PASS=$((PASS + 1))
+  else
+    printf '  FAIL: %s (missing %q)\n' "$description" "$expected"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo 'systemd status helper tests'
+
+export SYSTEMD_STATUS_TEST_RESULT=inactive
+export XDG_RUNTIME_DIR=/inherited/runtime
+assert_eq 'local system scope preserves inactive state' inactive \
+  "$(local_systemctl_status system is-active alpha.service)"
+assert_log_line 'local system scope omits --user' 'arg=is-active'
+assert_log_line 'local system scope passes the unit as one argument' 'arg=alpha.service'
+assert_log_line 'local system scope preserves its inherited runtime dir' 'runtime=/inherited/runtime'
+unset XDG_RUNTIME_DIR
+
+export SYSTEMD_STATUS_TEST_RESULT=active
+assert_eq 'local user scope queries the user manager' active \
+  "$(local_systemctl_status user is-active hugin.service)"
+assert_log_line 'local user scope passes --user' 'arg=--user'
+assert_log_line 'local user scope sets XDG_RUNTIME_DIR' 'runtime=/run/user/1001'
+assert_log_line 'local user scope sets the bus address' 'bus=unix:path=/run/user/1001/bus'
+
+export SYSTEMD_STATUS_TEST_RESULT=inactive
+assert_eq 'remote system scope preserves inactive state' inactive \
+  "$(remote_systemctl_status pi.example system is-active beta.timer)"
+assert_eq 'remote system scope uses the requested SSH target' 'target=tester@pi.example' \
+  "$(cat "$SYSTEMD_STATUS_TEST_SSH_LOG")"
+assert_log_line 'remote system scope omits --user' 'arg=is-active'
+
+export SYSTEMD_STATUS_TEST_RESULT=active
+assert_eq 'remote user scope reaches the user manager' active \
+  "$(remote_systemctl_status pi.example user is-active skuld.timer)"
+assert_log_line 'remote user scope passes --user' 'arg=--user'
+assert_log_line 'remote user scope exports XDG_RUNTIME_DIR' 'runtime=/run/user/1001'
+assert_log_line 'remote user scope exports the bus address' 'bus=unix:path=/run/user/1001/bus'
+
+export SYSTEMD_STATUS_TEST_SSH_FAIL=true
+assert_eq 'unreachable remote manager is reported honestly' unreachable \
+  "$(remote_systemctl_status pi.example user is-active hugin.service)"
+unset SYSTEMD_STATUS_TEST_SSH_FAIL
+
+export SYSTEMD_STATUS_TEST_EMPTY=true
+assert_eq 'empty local manager response is reported honestly' unreachable \
+  "$(local_systemctl_status user is-active hugin.service)"
+unset SYSTEMD_STATUS_TEST_EMPTY
+assert_eq 'unreachable manager is a warning, not an inactive failure' warn \
+  "$(systemctl_status_severity unreachable user)"
+assert_eq 'unreachable system manager remains a failure' fail \
+  "$(systemctl_status_severity unreachable system)"
+assert_eq 'known inactive unit remains a failure' fail \
+  "$(systemctl_status_severity inactive user)"
+
+marker="$TMP_DIR/injected"
+malicious_unit="odd'; touch $marker; printf '.service"
+export SYSTEMD_STATUS_TEST_RESULT=active
+assert_eq 'remote shell quoting preserves a hostile unit argument' active \
+  "$(remote_systemctl_status pi.example user is-active "$malicious_unit")"
+assert_log_line 'hostile unit reaches systemctl as one argument' "arg=$malicious_unit"
+if [[ ! -e "$marker" ]]; then
+  printf '  PASS: hostile unit cannot execute shell syntax\n'
+  PASS=$((PASS + 1))
+else
+  printf '  FAIL: hostile unit executed shell syntax\n'
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- centralize read-only local and remote systemd status checks
- query `scope:user` units through the user manager with explicit runtime and bus environment
- preserve known inactive states as failures, but surface an unreachable user manager as a warning instead of a false inactive result
- reuse the audited POSIX shell-quoting helper and add regression coverage for system/user scope, local/remote execution, unreachable managers, and hostile arguments

## Root cause

The original validator dropped unit scope and always queried the system manager. A partial earlier correction embedded separate user-manager paths directly in the generator, but the remote path only set `XDG_RUNTIME_DIR`, used ad hoc quoting, and collapsed manager/transport failures into an ambiguous status. This left remote user checks fragile and the behavior untested.

Closes #63.

## Checks

- `make test` — 167 assertions pass, including 23 new systemd-status assertions
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `bash -n scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`

## Deployment and verification

After merge, from a clean, current Grimnir checkout:

```sh
make deploy ARGS="grimnir"
```

Then verify on huginmunin that the remote checkout HEAD and `.deployed-commit` equal the merge commit, and run:

```sh
./scripts/generate-architecture.sh --validate
```

Confirm user-scoped `hugin.service`, `skuld.timer`, and `verdandi.service` are queried as `(user)`, known inactive units remain issues, and an unreachable user manager is a warning.

## Rollback

Revert the merge commit, redeploy Grimnir with the same selective command, and rerun validation. This change is read-only validation logic; it does not mutate unit or service state.