### PR TITLE
Harden validation, scanning, and deployment truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: shellcheck scripts/
         run: shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: Run test suites

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test-systemd-status test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test-systemd-status test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -18,6 +18,12 @@ test-security-skip: ## Regression test: assert security-scan skips test/eval fix
 test-security-delta: ## Unit tests for the scan_escalated/parse_prev_counts helpers
 	@bash scripts/tests/security-scan-delta.test.sh
 
+test-security-completeness: ## Fail closed when npm audit or repository coverage is incomplete
+	@bash scripts/tests/security-scan-completeness.test.sh
+
+test-munin-rpc: ## Reject HTTP, JSON-RPC, and MCP tool errors from scheduled writes
+	@bash scripts/tests/munin-rpc.test.sh
+
 test-registry-smoke: ## Schema/consistency smoke check for services.json (issue #48)
 	@bash scripts/tests/registry-smoke.test.sh
 
@@ -33,7 +39,7 @@ test-registry-checkout: ## Unit tests for the registry-checkout integrity helper
 test-systemd-status: ## Scope-aware local/remote systemd status checks (issue #63)
 	@bash scripts/tests/systemd-status.test.sh
 
-test: test-security-skip test-security-delta test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test-systemd-status ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-registry-checkout test-systemd-status ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,50 @@
 # Grimnir System — Status
 
+**Last session:** 2026-07-13 (Codex) — general hardening sprint prepared for fallback review
+**Branch:** `codex/grimnir-hardening-20260713` (isolated worktree; not pushed/deployed)
+
+## Active Session (2026-07-13) — validation, scan, and deploy truth hardening
+
+Prepared the parent-approved Grimnir hardening slice from current `origin/main` without touching the
+intentionally dirty canonical laptop checkout.
+
+- Registry validation now compares the exact local HEAD to the exact live `origin/main` SHA. A clean
+  local-ahead/diverged checkout fails; origin/network uncertainty warns and can never re-stamp the
+  deployment marker. Rsync markers must be regular files containing a full Git SHA.
+- Security scanning now rejects npm error/malformed/incomplete results instead of counting them as
+  zero vulnerabilities, records coverage separately from finding severity, rejects unknown repo
+  filters, and exits non-zero when the scan or its Munin persistence is incomplete.
+- Scheduled Munin writes now reject HTTP, JSON-RPC, and MCP tool errors. Registry validation exits
+  non-zero after persisting real findings, so a successful timer run means the checks and durable
+  operator record both succeeded.
+- Rsync deployments now require a clean Git worktree, remove remote `.git` directories or worktree
+  pointer files, use `npm ci --omit=dev` with lockfiles, require every declared service/timer plus
+  the component health endpoint to pass before writing the marker, and therefore repair missing
+  Hugin/Mimir markers only through a verified normal deployment.
+- Added Heimdall's existing `heimdall-boot-check.timer` to `services.json`; normal Heimdall deploys
+  now refresh its companion service, enable/start the timer, and validate it with the other units.
+- Pinned GitHub Actions to immutable v4 SHAs and reconciled bounded architecture, threat-model,
+  role-separation, authority, and scheduled-task documentation with deployed reality.
+
+### Verification / handoff
+
+- Added focused regressions for exact freshness, marker validity, npm-audit completeness, strict
+  Munin RPC handling, clean/reproducible/health-gated deploys, and Heimdall boot-check refresh/enable.
+- `make test` passes all 220 assertions. Full `bash -n`, ShellCheck, and `git diff --check` gates pass.
+- A full read-only fleet scan completed with no coverage gaps. It still reports existing cross-repo
+  debt (critical 3, high 8, moderate 12, low 4) plus one potential Heimdall bearer-token match at
+  `src/panel-ingest.js:168`; the Heimdall owner must classify that source-only match without exposing
+  any value. Those component findings are not changed from this system-documentation repository.
+- No PR, push, merge, deployment, live marker repair, Orin access, or Munin mutation was performed.
+- After review/merge, deploy Grimnir first, then selectively deploy Hugin and Mimir through the
+  normal registry script to repair their missing markers, and deploy Heimdall to refresh the
+  boot-check units. Run live validation last; it will remain non-zero until all required evidence is
+  healthy and persisted.
+- Residual risk: rsync changes are not automatically rolled back after a failed post-sync gate. The
+  old marker remains unmodified; rollback is a clean selective redeploy of its recorded commit.
+
+---
+
 **Last session:** 2026-07-12 (Codex) — issue #63 scope-aware validator fix prepared
 **Branch:** codex/grimnir-63-user-units
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,13 +14,14 @@ intentionally dirty canonical laptop checkout.
 - Security scanning now rejects npm error/malformed/incomplete results instead of counting them as
   zero vulnerabilities, records coverage separately from finding severity, rejects unknown repo
   filters, and exits non-zero when the scan or its Munin persistence is incomplete.
-- Scheduled Munin writes now reject HTTP, JSON-RPC, and MCP tool errors. Registry validation exits
-  non-zero after persisting real findings, so a successful timer run means the checks and durable
-  operator record both succeeded.
+- Scheduled Munin writes now reject HTTP, JSON-RPC, MCP protocol errors, and malformed or
+  `{ok:false}` inner tool results. Registry validation exits non-zero after persisting real findings,
+  so a successful timer run means the checks and durable operator record both succeeded.
 - Rsync deployments now require a clean Git worktree, remove remote `.git` directories or worktree
-  pointer files, use `npm ci --omit=dev` with lockfiles, require every declared service/timer plus
-  the component health endpoint to pass before writing the marker, and therefore repair missing
-  Hugin/Mimir markers only through a verified normal deployment.
+  pointer files, use `npm ci --omit=dev` with lockfiles, and require every declared service/timer
+  plus the component health endpoint to pass before writing the marker. Both rsync and git-pull
+  capture the prior accepted SHA and invalidate the marker before the first remote tree mutation;
+  any failed deployment is markerless/unknown rather than falsely certified.
 - Added Heimdall's existing `heimdall-boot-check.timer` to `services.json`; normal Heimdall deploys
   now refresh its companion service, enable/start the timer, and validate it with the other units.
 - Pinned GitHub Actions to immutable v4 SHAs and reconciled bounded architecture, threat-model,
@@ -30,7 +31,7 @@ intentionally dirty canonical laptop checkout.
 
 - Added focused regressions for exact freshness, marker validity, npm-audit completeness, strict
   Munin RPC handling, clean/reproducible/health-gated deploys, and Heimdall boot-check refresh/enable.
-- `make test` passes all 220 assertions. Full `bash -n`, ShellCheck, and `git diff --check` gates pass.
+- `make test` passes all 234 assertions. Full `bash -n`, ShellCheck, and `git diff --check` gates pass.
 - A full read-only fleet scan completed with no coverage gaps. It still reports existing cross-repo
   debt (critical 3, high 8, moderate 12, low 4) plus one potential Heimdall bearer-token match at
   `src/panel-ingest.js:168`; the Heimdall owner must classify that source-only match without exposing
@@ -41,7 +42,8 @@ intentionally dirty canonical laptop checkout.
   boot-check units. Run live validation last; it will remain non-zero until all required evidence is
   healthy and persisted.
 - Residual risk: rsync changes are not automatically rolled back after a failed post-sync gate. The
-  old marker remains unmodified; rollback is a clean selective redeploy of its recorded commit.
+  target deliberately remains markerless/unknown; rollback is a clean selective redeploy of the
+  prior accepted SHA captured in the deployment log before mutation.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # The Grimnir System — Architecture Guide
 
 > Internal reference document for the Grimnir personal AI infrastructure.
-> Last updated: 2026-06-29.
+> Last updated: 2026-07-13.
 
 ---
 
@@ -21,7 +21,8 @@ Every conversation with Claude starts from zero. There is no memory between sess
 
 Three principles guide every decision:
 
-- **Sovereignty** — All data lives on Magnus's hardware. The Pis hold the database, the files, and the backups. Cloud AI services are stateless tools; they process but don't store.
+- **Sovereignty** — Authoritative data at rest lives on Magnus's hardware. Cloud AI services may
+  process prompts under their own retention terms, but are never storage authority for Grimnir.
 - **Privacy** — Writes to memory are scanned for secrets before storage. Auth is required at every layer. Sensitive documents get summaries in Munin but full text stays on the Pi.
 - **Simplicity** — Each service is a single-purpose Node.js/TypeScript application. No frameworks beyond Express/Fastify for HTTP. No ORMs. No Kubernetes. SQLite for storage. systemd for process management.
 
@@ -39,7 +40,7 @@ Three principles guide every decision:
 | **Verdandi** | Tamper-evident audit log | 3036 | Pi 1 | `verdandi` |
 | **Mimir** | Authenticated file server | 3031 | Pi 2 (NAS) | `mimir` |
 | **noxctl** | Accounting CLI + MCP | — | Laptop (global) | `fortnox-mcp` |
-| **Home-server gateway** | Local-inference gateway + micro-orchestrator | 8080 | BosGame M5 (`inference.gille.ai`, live) | `home-server-inference-evaluation` |
+| **Home-server gateway** | Local-inference gateway + micro-orchestrator | 8080 | BosGame M5 (`inference.gille.ai`, live) | `gille-inference` |
 
 ---
 
@@ -139,7 +140,8 @@ Both Pis are Raspberry Pi 5 units (8 GB RAM) in Flirc passive-cooling aluminum c
 
 ### Network model
 
-- **Local services** bind to `127.0.0.1` — never exposed on the LAN directly.
+- **Local services** bind either to loopback or an explicitly selected tailnet address. Tailscale
+  reachability is not authentication; network services retain their own bearer/OAuth control.
 - **Cloudflare Tunnels** provide HTTPS ingress from the internet, with edge-layer authentication (CF Access).
 - **Tailscale** provides encrypted Pi-to-Pi and laptop-to-Pi communication for rsync, SSH, and backups.
 - **Public endpoints:** `munin-memory.gille.ai`, `heimdall.gille.ai`, `mimir.gille.ai`
@@ -730,7 +732,8 @@ All services follow the same deployment model:
 4. **Health endpoints** — long-running HTTP services expose `/health` for Heimdall monitoring; timer-only components are validated through systemd state and their Munin outputs.
 5. **Deploy modes differ by component** — most services deploy by rsync; `grimnir` uses `git pull --ff-only` because its canonical checkout is also the registry source.
 
-There is no CI/CD pipeline. Deploys are manual and intentional — appropriate for a single-operator system.
+GitHub Actions runs shellcheck and the repository regression suite on pull requests and `main`.
+Deployment remains manual and intentional; CI success never deploys a host.
 
 ### The debate/review process
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -727,10 +727,11 @@ This isn't just convenience; it's necessity. Claude.ai and Claude Mobile can acc
 All services follow the same deployment model:
 
 1. **Build locally** — `npm run build` compiles TypeScript to `dist/`
-2. **Deploy via script** — `scripts/deploy.sh` reads `services.json`, syncs or pulls the target tree, runs `npm install --omit=dev` where applicable, installs every declared systemd unit, restarts services, and enables timers. `.env` files are preserved on the Pi and never overwritten.
-3. **systemd manages the process or schedule** — services use `Restart=always` where appropriate; timer components run oneshot jobs on schedule.
-4. **Health endpoints** — long-running HTTP services expose `/health` for Heimdall monitoring; timer-only components are validated through systemd state and their Munin outputs.
-5. **Deploy modes differ by component** — most services deploy by rsync; `grimnir` uses `git pull --ff-only` because its canonical checkout is also the registry source.
+2. **Deploy via script** — `scripts/deploy.sh` reads `services.json`, syncs or pulls the target tree, uses `npm ci --omit=dev` when a lockfile exists, installs every declared systemd unit, restarts services, and enables timers. `.env` files are preserved on the Pi and never overwritten.
+3. **Acceptance markers fail unknown** — before either rsync or git-pull mutates a remote tree, the script logs any prior accepted full SHA and removes `.deployed-commit`. Only successful unit and HTTP health gates create the new marker. A failed deployment therefore remains markerless/unknown; rollback means redeploying the logged prior SHA from a clean worktree.
+4. **systemd manages the process or schedule** — services use `Restart=always` where appropriate; timer components run oneshot jobs on schedule.
+5. **Health endpoints** — long-running HTTP services expose `/health` for Heimdall monitoring; timer-only components are validated through systemd state and their Munin outputs.
+6. **Deploy modes differ by component** — most services deploy by rsync; `grimnir` uses `git pull --ff-only` because its canonical checkout is also the registry source.
 
 GitHub Actions runs shellcheck and the repository regression suite on pull requests and `main`.
 Deployment remains manual and intentional; CI success never deploys a host.

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -48,6 +48,8 @@ The generator should warn on discrepancies it can detect:
 - Systemd units in `services.json` vs units actually present on the host
 - Component repos in `services.json` vs directories in `~/repos/`
 - Deploy path in `services.json` vs WorkingDirectory / EnvironmentFile paths in unit files
+- Git-pull checkout HEAD vs the exact live `origin/main` SHA (an unreachable origin is never current)
+- Missing, symlinked, or malformed rsync deployment markers
 
 ## Document boundary: `architecture.md` vs `snapshot.md`
 

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -41,6 +41,11 @@
    script separately preserves `.env` for every rsync component as global credential policy, so a
    component with `persistent_paths: []` does not imply that its in-target `.env` may be deleted.
 
+7. **Deployment markers certify acceptance, not merely copied files.** `deploy.sh` captures the
+   prior valid SHA and removes the marker before the first rsync/git-pull tree mutation. Dependency,
+   unit-refresh, restart, or health failure leaves the target markerless/unknown until a verified
+   rollback or redeploy writes a new accepted SHA.
+
 ## Validation
 
 The generator should warn on discrepancies it can detect:

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -109,6 +109,21 @@ Three actor classes were named in the gap analysis that opened this issue.
 None of them currently emit a reversal recipe — this section is the adoption
 target for each, to be picked up as separate tickets in their owning repos.
 
+### Service deployment pre-state
+
+Separate from the three autonomous actor classes below, `scripts/deploy.sh` mechanically captures a
+valid prior `.deployed-commit` SHA in the operator log,
+then invalidates that acceptance marker before the first rsync or git-pull tree mutation. It writes
+the new SHA only after dependency, unit, restart, and health gates succeed. A failed deployment is
+therefore deliberately markerless/unknown, never certified by the old SHA.
+
+- **Reversal recipe:** perform a clean selective redeploy of the captured prior SHA. Rsync is not
+  transactional, so marker absence is the signal to rollback or finish a verified redeploy—not a
+  claim that the old files are still intact.
+- **Transport uncertainty:** if marker invalidation cannot be confirmed, code mutation does not
+  begin. If transport fails after later mutation starts, treat live state as unknown and inspect it
+  before choosing the captured rollback commit.
+
 ### Auto dependency bumps
 
 Currently: `scripts/security-scan.sh` (this repo) only *detects*

--- a/docs/role-separation.md
+++ b/docs/role-separation.md
@@ -1,8 +1,10 @@
 # Separating the three roles of `~/repos/grimnir` on huginmunin
 
-> Status: recommendation. This document decides the target separation and records
-> what ships now vs. what is deferred. Tracks issue #47. The hugin-side change is
-> hugin#139; the delta-alert follow-up is grimnir#2.
+> Status: adopted and deployed. Grimnir now advances its canonical checkout by
+> guarded `git pull --ff-only`; Hugin uses separate task workspaces. Daily
+> validation checks branch/cleanliness plus exact equality with live origin and
+> refuses to re-stamp an unproved checkout. The option analysis below is retained
+> as the decision history for issue #47.
 
 ## The problem
 

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -1,7 +1,7 @@
 # Scheduled Tasks Registry
 
 > All automated tasks running on Grimnir infrastructure.
-> Last updated: 2026-07-07.
+> Last updated: 2026-07-13.
 
 ---
 
@@ -34,6 +34,17 @@ All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where no
 | **Purpose** | Rebuild indexes, prune old metrics (retention policy), vacuum SQLite |
 | **Output** | Modified SQLite DB (smaller, faster queries) |
 | **Why it exists** | Without pruning, the metrics table grows unbounded on the Pi's SD card |
+
+### Heimdall Post-Boot Check
+
+| Field | Value |
+|-------|-------|
+| **Schedule** | Once, 90 seconds after boot |
+| **Unit** | `heimdall-boot-check.timer` / `heimdall-boot-check.service` |
+| **Repo** | `heimdall` |
+| **Purpose** | Probe required services after network and tailnet startup settle |
+| **Output** | Heimdall events/alerts in `~/.heimdall/heimdall.db` |
+| **Why it exists** | Detect services that did not recover after a host reboot |
 
 ### Skuld Daily Briefing
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,8 +1,7 @@
-# Grimnir — Threat Model (v0.1)
+# Grimnir — Threat Model (v0.2)
 
-> **Status:** v0.1 — 2026-07-06, owner-reviewed 2026-07-07. Seeded by a local M5 model, then
-> verified and edited against the 2026-07-06 blind-spot audit. Every residual-**High** row in §5
-> is tracked as a `from:grimnir` ticket (see the *Tracked* column).
+> **Status:** v0.2 — owner-reviewed v0.1 refreshed 2026-07-13 against deployed controls and
+> explicit recovery/activation blocks. Every residual-**High** row in §5 remains tracked.
 >
 > Companion to [`architecture.md`](architecture.md) (the *how*) and [`vision.md`](vision.md) (the
 > *why*). This is the *what-we-defend-against* — the artifact that was deferred as "Phase B" and is
@@ -57,14 +56,14 @@
 
 | # | Threat | Vector | Current control | Residual | Tracked |
 |---|---|---|---|---|---|
-| T1 | Exfiltration via the **lethal trifecta** | Injection in ingested content → agent with memory+files+exec → egress | Hugin queue-path injection/exfil scanners + egress policy | **H** — detective only; `bypassPermissions` unconditional | hugin#149 |
+| T1 | Exfiltration via the **lethal trifecta** | Injection in ingested content → agent with memory+files+exec → egress | Hugin queue-path scanners plus permission profiles: default/read-only requests use `dontAsk`; only explicit `Capabilities: code` + `trusted-code` uses `bypassPermissions` | **H** — trusted-code remains deliberately powerful and content scanners are detective | hugin#149 shipped; continue review |
 | T2 | Same trifecta on **interactive sessions** | Claude Code / Desktop reading raw email/Telegram with full Munin+Mimir access | Operator posture requires Hugin handoff for consequential mutations after untrusted input, with a constrained fresh-session fallback | **H** — procedural, not enforced | grimnir#70 |
-| T3 | Command injection → fleet code-exec | Ratatoskr `/repo` path-traversal; LLM output submitted verbatim | Telegram owner-allowlist | **H** | ratatoskr#36 |
-| T4 | Autonomous action unattributable / unlogged | Hugin mutates (commits/deploys/writes) but emits nothing to Verdandi; shared static tokens = no per-tenant identity | append-only Verdandi exists but is unfed by Hugin | **H** | hugin#148, verdandi#15 |
-| T5 | Audit-chain forgery on a compromised box | Attacker owns Pi 1, rewrites the chain and re-hashes | append-only trigger + SHA-256 chain; `GET /api/verify` | **M** — verify is manual + same-box; no off-box anchor | verdandi#16 |
-| T6 | Supply-chain compromise | Malicious transitive npm dep in a Node service | weekly `security-scan.sh` (`npm audit`) + systemd sandbox | **M** | (scan exists) |
+| T3 | Command injection → fleet code-exec | Ratatoskr `/repo` path-traversal; LLM-produced repo context | Owner allowlist plus task-writer validation; live probes reject traversal and newline/field injection before task creation | **M** — an owner-authorized task can still execute within an allowed repo | ratatoskr#36 shipped |
+| T4 | Autonomous action unattributable / unlogged | Hugin mutates (commits/deploys/writes) without end-to-end tenant identity or Verdandi receipt | Signed submitter provenance now survives Hugin lifecycle transitions and is logged in Munin | **H** — Verdandi/per-tenant chain is still missing | hugin#148, verdandi#15 |
+| T5 | Audit-chain forgery or loss | Attacker owns Pi 1, or the only credible chain is lost | Recovery-gated Verdandi safeguards and verify/anchor code are merged | **H** — production is intentionally disabled pending image-first recovery; no recovered chain or routine export may be claimed | Verdandi recovery block |
+| T6 | Supply-chain compromise | Malicious transitive npm dep in a Node service | Weekly `security-scan.sh`, incomplete-scan failure, systemd sandbox, immutable CI action pins | **M** — audit databases and dependency provenance are not complete prevention | per-repo dependency triage |
 | T7 | Physical theft → plaintext data at rest | Stolen Pi / SD card / NAS disk | file perms `0600`; **SD cards likely NOT encrypted — verify** | **H** if unencrypted | brokkr#40 |
-| T8 | Silent total-host failure | Pi 1 dies; monitoring + alerting die with it | on-box watchdog only | **M/H** — no off-box dead-man's switch | brokkr#38 |
+| T8 | Silent total-host failure | Pi 1 dies; monitoring + alerting die with it | M5 dead-man timer and independent Telegram fallback are live and drilled | **M** — truly external Healthchecks path is merged but intentionally inactive until its protected URL is provisioned | Healthchecks activation block |
 | T9 | Backup loss / unrecoverable restore | Host/storage loss; Verdandi cannot be routinely exported or restored | Munin and Mimir encrypted off-site backups are live; Mimir passed an immutable full restore on 2026-07-10; Verdandi has no routine export/DR procedure | **H** | brokkr#39 |
 | T10 | Poisoned memory drives bad action | A false stored "fact" retrieved and acted on repeatedly | secret-scan on write; no correction / expiry path | **M** | munin-memory#192 |
 | T11 | Third-party data retained without enforceable lifecycle / erasure | Client/accounting/person data accumulates across Mimir, Munin, Fortnox exports, backups | Store map and provisional retention defaults now exist; enforcement is per-store/manual and complete erasure is not implemented | **H** | grimnir#66 |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -160,12 +160,13 @@ rsync_exclude_rows() {
 
 deploy_service() {
   local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync} units_json=${9:-[]}
-  local rsync_excludes_json=${10:-[]}
+  local rsync_excludes_json=${10:-[]} health_port=${11:-}
   local local_path
   local remote_host
   local remote
   local branch
   local commit
+  local commit_full
   local dirty_state
   local q_deploy_path
 
@@ -181,6 +182,12 @@ deploy_service() {
     return
   fi
 
+  if ! git -C "$local_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: Local source is not a git worktree: $local_path" >&2
+    results+=("${RED}✗${NC} ${name}")
+    fail=$((fail + 1))
+    return
+  fi
   branch=$(git -C "$local_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   commit=$(git -C "$local_path" rev-parse --short HEAD 2>/dev/null || echo "unknown")
   commit_full=$(git -C "$local_path" rev-parse HEAD 2>/dev/null || echo "$commit")
@@ -190,11 +197,12 @@ deploy_service() {
     echo "Source: origin/main (deploy_mode=git-pull — local tree not shipped; local: ${branch} @ ${commit})"
   else
     if [[ -n "$(git -C "$local_path" status --porcelain 2>/dev/null)" ]]; then
-      dirty_state="dirty"
-      echo -e "${YELLOW}WARN${NC} Deploying local working tree with uncommitted changes"
-    else
-      dirty_state="clean"
+      echo "ERROR: Refusing rsync deploy from a dirty working tree: $local_path" >&2
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+      return
     fi
+    dirty_state="clean"
     echo "Source: ${local_path} (${branch} @ ${commit}, ${dirty_state})"
   fi
 
@@ -246,8 +254,10 @@ deploy_service() {
   else
 
   echo "==> Syncing to ${remote}:${deploy_path}..."
+  local prepare_destination_cmd
+  prepare_destination_cmd=$(prepare_rsync_destination_command "$deploy_path")
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
-  if ! ssh "$remote" "mkdir -p ${q_deploy_path}"; then
+  if ! ssh "$remote" "$prepare_destination_cmd"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -274,7 +284,7 @@ deploy_service() {
 
   echo "==> Installing production dependencies on ${remote_host}..."
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
-  if ! ssh "$remote" "cd ${q_deploy_path} && if [ -f package.json ]; then npm install --omit=dev; fi"; then
+  if ! ssh "$remote" "cd ${q_deploy_path} && if [ -f package.json ]; then if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi; fi"; then
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -355,10 +365,33 @@ deploy_service() {
   for unit_name in ${system_timers[@]+"${system_timers[@]}"}; do
     cmd+="sudo systemctl enable --now $(posix_shell_quote "${unit_name}.timer") && "
   done
+  # A successful restart/enable command is only an accepted deployment when
+  # every declared unit remains active and any declared HTTP health endpoint
+  # answers successfully. Keep the old marker until these gates pass.
+  for unit_name in ${user_services[@]+"${user_services[@]}"}; do
+    cmd+="systemctl --user is-active --quiet $(posix_shell_quote "${unit_name}.service") && "
+  done
+  for unit_name in ${system_services[@]+"${system_services[@]}"}; do
+    cmd+="sudo systemctl is-active --quiet $(posix_shell_quote "${unit_name}.service") && "
+  done
+  for unit_name in ${user_timers[@]+"${user_timers[@]}"}; do
+    cmd+="systemctl --user is-active --quiet $(posix_shell_quote "${unit_name}.timer") && "
+  done
+  for unit_name in ${system_timers[@]+"${system_timers[@]}"}; do
+    cmd+="sudo systemctl is-active --quiet $(posix_shell_quote "${unit_name}.timer") && "
+  done
+  if [[ -n "$health_port" && "$health_port" != "null" ]]; then
+    cmd+="{ health_ok=false; for attempt in 1 2 3 4 5; do "
+    cmd+="for target in localhost 127.0.0.1 \$(hostname -I 2>/dev/null || true); do "
+    cmd+="[ -n \"\$target\" ] || continue; case \"\$target\" in *:*) continue ;; esac; "
+    cmd+="for path in /health /api/health; do if curl -fsS --max-time 3 \"http://\${target}:${health_port}\${path}\" >/dev/null 2>&1; then health_ok=true; break 2; fi; done; done; "
+    cmd+="[ \"\$health_ok\" = true ] && break; sleep 1; done; "
+    cmd+="[ \"\$health_ok\" = true ] || { printf 'ERROR: health check failed on port %s\\n' $(posix_shell_quote "$health_port") >&2; exit 1; }; } && "
+  fi
   # Stamp the deployed commit so Heimdall's drift detector has an authoritative
   # source (excluded from rsync above so --delete won't clobber it). Heimdall
   # reads <deploy_path>/.deployed-commit instead of trusting /health (often no
-  # commit) or the on-Pi .git (stale — rsync excludes it).
+  # commit) or an on-Pi .git (rsync deployments remove repository metadata).
   if [[ "$deploy_mode" == "git-pull" ]]; then
     # In git-pull mode the remote HEAD is the ground truth (origin/main was
     # just pulled) — stamp that, not the local checkout's commit.
@@ -402,6 +435,7 @@ for entry in "${SERVICES[@]}"; do
   deploy_mode=$(service_field "$entry" deploy_mode)
   units_json=$(service_field "$entry" systemd_units)
   rsync_excludes_json=$(service_field "$entry" rsync_excludes)
+  health_port=$(service_field "$entry" port)
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false
@@ -411,7 +445,7 @@ for entry in "${SERVICES[@]}"; do
     $match || continue
   fi
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}"
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}" "${health_port:-}"
 done
 
 # Summary

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -158,6 +158,40 @@ rsync_exclude_rows() {
   '
 }
 
+previous_accepted_commit="unknown"
+
+invalidate_remote_deploy_marker() {
+  local remote=$1 deploy_path=$2 command output line marker_result=""
+  previous_accepted_commit="unknown"
+  command=$(prepare_deploy_marker_invalidation_command "$deploy_path")
+
+  # This is a separate round trip by design: no code-tree mutation may begin
+  # unless the remote confirms that the accepted-deployment marker is absent.
+  if ! output=$(ssh -o ConnectTimeout=10 "$remote" "$command" 2>&1); then
+    [[ -n "$output" ]] && echo "$output" >&2
+    echo "ERROR: Could not confirm deployment-marker invalidation; no code mutation attempted" >&2
+    return 1
+  fi
+  while IFS= read -r line; do
+    case "$line" in
+      DEPLOY_MARKER_INVALIDATED:*) marker_result=${line#DEPLOY_MARKER_INVALIDATED:} ;;
+    esac
+  done <<< "$output"
+  if [[ "$marker_result" == "unknown" ]]; then
+    previous_accepted_commit="unknown"
+  elif [[ "$marker_result" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
+    previous_accepted_commit="$marker_result"
+  else
+    echo "ERROR: Remote did not provide a trustworthy marker-invalidation receipt; no code mutation attempted" >&2
+    return 1
+  fi
+  echo "Previous accepted deployment: ${previous_accepted_commit} (marker invalidated)"
+}
+
+report_markerless_failure() {
+  echo "Deployment state is markerless/unknown; rollback candidate: ${previous_accepted_commit}" >&2
+}
+
 deploy_service() {
   local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync} units_json=${9:-[]}
   local rsync_excludes_json=${10:-[]} health_port=${11:-}
@@ -227,6 +261,13 @@ deploy_service() {
     fi
   fi
 
+  if ! invalidate_remote_deploy_marker "$remote" "$deploy_path"; then
+    echo -e "${RED}FAILED${NC}"
+    results+=("${RED}✗${NC} ${name}")
+    fail=$((fail + 1))
+    return
+  fi
+
   if [[ "$deploy_mode" == "git-pull" ]]; then
     # git-pull mode (Option A, docs/role-separation.md): the checkout IS the
     # deployment. Fast-forward it to origin/main — never force, never rsync —
@@ -246,6 +287,7 @@ deploy_service() {
     pull_cmd+="if [ \"\$(git -C ${q_deploy_path} rev-parse HEAD)\" != \"\$(git -C ${q_deploy_path} rev-parse origin/main)\" ]; then echo 'ERROR: HEAD != origin/main after pull (stray local commits?)' >&2; exit 1; fi"
     # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
     if ! ssh -o ConnectTimeout=10 "$remote" "$pull_cmd"; then
+      report_markerless_failure
       echo -e "${RED}FAILED${NC}"
       results+=("${RED}✗${NC} ${name}")
       fail=$((fail + 1))
@@ -258,6 +300,7 @@ deploy_service() {
   prepare_destination_cmd=$(prepare_rsync_destination_command "$deploy_path")
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
   if ! ssh "$remote" "$prepare_destination_cmd"; then
+    report_markerless_failure
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -276,6 +319,7 @@ deploy_service() {
     [[ -n "$rsync_exclude" ]] && rsync_args+=("--exclude=${rsync_exclude}")
   done < <(rsync_exclude_rows "$rsync_excludes_json")
   if ! rsync "${rsync_args[@]}" "$local_path/" "${remote}:$(posix_shell_quote "${deploy_path}/")"; then
+    report_markerless_failure
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -285,6 +329,7 @@ deploy_service() {
   echo "==> Installing production dependencies on ${remote_host}..."
   # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
   if ! ssh "$remote" "cd ${q_deploy_path} && if [ -f package.json ]; then if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi; fi"; then
+    report_markerless_failure
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
@@ -367,7 +412,8 @@ deploy_service() {
   done
   # A successful restart/enable command is only an accepted deployment when
   # every declared unit remains active and any declared HTTP health endpoint
-  # answers successfully. Keep the old marker until these gates pass.
+  # answers successfully. The prior marker was invalidated before mutation, so
+  # every failure remains explicitly markerless/unknown until rollback/redeploy.
   for unit_name in ${user_services[@]+"${user_services[@]}"}; do
     cmd+="systemctl --user is-active --quiet $(posix_shell_quote "${unit_name}.service") && "
   done
@@ -415,6 +461,7 @@ deploy_service() {
     fi
   else
     echo "$output"
+    report_markerless_failure
     echo -e "${RED}FAILED${NC}"
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -33,6 +33,9 @@ REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 # shellcheck source=scripts/lib/systemd-status.sh
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/systemd-status.sh"
+# shellcheck source=scripts/lib/munin-rpc.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/munin-rpc.sh"
 
 read -ra COMPONENTS <<< "$(REGISTRY_PATH="$REGISTRY" QUERY=components node --input-type=commonjs "$REGISTRY_JS")"
 
@@ -89,6 +92,28 @@ health_status_local() {
 health_status_remote() {
   local host=$1 port=$2 user=${SYSTEMD_USER:-magnus}
   ssh -o ConnectTimeout=5 -o BatchMode=yes "${user}@${host}" "port='$port'; last=000; for target in localhost 127.0.0.1 \$(hostname -I 2>/dev/null || true); do [ -n \"\$target\" ] || continue; case \"\$target\" in *:*) continue ;; esac; for path in /health /api/health; do code=\$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 \"http://\${target}:\${port}\${path}\" 2>/dev/null || true); if [ \"\$code\" = 200 ]; then echo 200; exit 0; fi; [ -n \"\$code\" ] && last=\"\$code\"; done; done; echo \"\$last\"" 2>/dev/null || echo '000'
+}
+
+remote_git_checkout_freshness() {
+  local host=$1 checkout=$2 branch=${3:-main} user=${SYSTEMD_USER:-magnus}
+  local q_checkout q_ref command output local_sha remote_sha
+  q_checkout="$(posix_shell_quote "$checkout")"
+  q_ref="$(posix_shell_quote "refs/heads/${branch}")"
+  command="local_sha=\$(git -C ${q_checkout} rev-parse HEAD 2>/dev/null) || { printf '%s\\n' missing; exit 0; }; "
+  command+="remote_line=\$(git -C ${q_checkout} ls-remote --exit-code origin ${q_ref} 2>/dev/null) || { printf '%s\\n' unreachable; exit 0; }; "
+  # shellcheck disable=SC2016 # these variables expand on the remote host
+  command+='remote_sha=${remote_line%%[[:space:]]*}; printf '\''%s|%s\n'\'' "$local_sha" "$remote_sha"'
+  output="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "${user}@${host}" "$command" 2>/dev/null)" || {
+    echo "unreachable"
+    return 0
+  }
+  case "$output" in
+    missing|unreachable) echo "$output" ;;
+    *)
+      IFS='|' read -r local_sha remote_sha <<< "$output"
+      classify_registry_freshness "${local_sha:-}" "${remote_sha:-}" ok
+      ;;
+  esac
 }
 
 # ─── Validate mode ────────────────────────────────────────
@@ -205,23 +230,35 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
       repo_path="${v_deploy_path:-/home/magnus/repos/$v_repo}"
       if [[ "$IS_LOCAL" == "true" ]]; then
         if [[ "$v_deploy_mode" == "git-pull" ]]; then
-          if [[ -d "$repo_path/.git" ]]; then
-            behind="$(cd "$repo_path" && git fetch --dry-run 2>&1 | grep -c '\.\.') " || behind="0"
-            behind="${behind// /}"
-            if [[ "$behind" -gt 0 ]]; then
-              STATUS_LINE+=" repo:behind-origin"
-              COMPONENT_OK=false
-            else
-              STATUS_LINE+=" repo:current"
-            fi
-          else
+          if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
             STATUS_LINE+=" repo:not-found"
             COMPONENT_OK=false
+          else
+            repo_freshness="$(check_registry_freshness "$repo_path" main)"
+            case "$repo_freshness" in
+              current) STATUS_LINE+=" repo:current" ;;
+              mismatch)
+                STATUS_LINE+=" repo:remote-mismatch"
+                COMPONENT_OK=false
+                ;;
+              *)
+                STATUS_LINE+=" repo:origin-unreachable"
+                COMPONENT_WARN=true
+                ;;
+            esac
           fi
         else
-          if [[ -f "$repo_path/.deployed-commit" ]]; then
-            marker="$(head -c 12 "$repo_path/.deployed-commit" 2>/dev/null || true)"
-            STATUS_LINE+=" deploy:stamped:${marker:-unknown}"
+          if [[ -L "$repo_path/.deployed-commit" ]]; then
+            STATUS_LINE+=" deploy:marker-symlink"
+            COMPONENT_OK=false
+          elif [[ -f "$repo_path/.deployed-commit" ]]; then
+            marker="$(tr -d '\r\n' < "$repo_path/.deployed-commit" 2>/dev/null || true)"
+            if [[ "$(classify_deploy_marker "$marker" regular)" == "valid" ]]; then
+              STATUS_LINE+=" deploy:stamped:${marker:0:12}"
+            else
+              STATUS_LINE+=" deploy:marker-invalid"
+              COMPONENT_OK=false
+            fi
           else
             STATUS_LINE+=" deploy:marker-missing"
             COMPONENT_OK=false
@@ -229,30 +266,41 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
         fi
       else
         if [[ "$v_deploy_mode" == "git-pull" ]]; then
-          remote_check="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "if [ -d '$repo_path/.git' ]; then cd '$repo_path' && { git fetch --dry-run 2>&1 | grep -c '\.\.' || true; }; else echo missing; fi" 2>/dev/null || echo '-1')"
-          remote_check="${remote_check// /}"
-          if [[ "$remote_check" == "-1" ]]; then
-            STATUS_LINE+=" repo:ssh-failed"
-            COMPONENT_OK=false
-          elif [[ "$remote_check" == "missing" ]]; then
-            STATUS_LINE+=" repo:not-found"
-            COMPONENT_OK=false
-          elif [[ "$remote_check" -gt 0 ]]; then
-            STATUS_LINE+=" repo:behind-origin"
-            COMPONENT_OK=false
-          else
-            STATUS_LINE+=" repo:current"
-          fi
+          remote_check="$(remote_git_checkout_freshness "$v_host" "$repo_path" main)"
+          case "$remote_check" in
+            current) STATUS_LINE+=" repo:current" ;;
+            mismatch)
+              STATUS_LINE+=" repo:remote-mismatch"
+              COMPONENT_OK=false
+              ;;
+            missing)
+              STATUS_LINE+=" repo:not-found"
+              COMPONENT_OK=false
+              ;;
+            *)
+              STATUS_LINE+=" repo:origin-unreachable"
+              COMPONENT_WARN=true
+              ;;
+          esac
         else
-          remote_check="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "if [ -f '$repo_path/.deployed-commit' ]; then printf 'stamped:%s' \"\$(head -c 12 '$repo_path/.deployed-commit')\"; else echo marker-missing; fi" 2>/dev/null || echo 'ssh-failed')"
+          q_marker="$(posix_shell_quote "$repo_path/.deployed-commit")"
+          remote_check="$(ssh -o ConnectTimeout=5 -o BatchMode=yes "magnus@${v_host}" "if [ -L ${q_marker} ]; then echo marker-symlink; elif [ -f ${q_marker} ]; then printf 'stamped:%s' \"\$(tr -d '\\r\\n' < ${q_marker})\"; else echo marker-missing; fi" 2>/dev/null || echo 'ssh-failed')"
           if [[ "$remote_check" == "ssh-failed" ]]; then
             STATUS_LINE+=" deploy:ssh-failed"
             COMPONENT_OK=false
           elif [[ "$remote_check" == "marker-missing" ]]; then
             STATUS_LINE+=" deploy:marker-missing"
             COMPONENT_OK=false
+          elif [[ "$remote_check" == "marker-symlink" ]]; then
+            STATUS_LINE+=" deploy:marker-symlink"
+            COMPONENT_OK=false
+          elif [[ "$remote_check" == stamped:* ]] &&
+               [[ "$(classify_deploy_marker "${remote_check#stamped:}" regular)" == "valid" ]]; then
+            marker="${remote_check#stamped:}"
+            STATUS_LINE+=" deploy:stamped:${marker:0:12}"
           else
-            STATUS_LINE+=" deploy:$remote_check"
+            STATUS_LINE+=" deploy:marker-invalid"
+            COMPONENT_OK=false
           fi
         fi
       fi
@@ -281,14 +329,23 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   REGISTRY_DEFAULT_BRANCH="${GRIMNIR_DEFAULT_BRANCH:-main}"
   checkout_verdict="$(check_registry_checkout "$REGISTRY_CHECKOUT" "$REGISTRY_DEFAULT_BRANCH")"
   checkout_detail="$(registry_checkout_detail "$checkout_verdict" "$REGISTRY_DEFAULT_BRANCH")"
+  checkout_freshness="$(check_registry_freshness "$REGISTRY_CHECKOUT" "$REGISTRY_DEFAULT_BRANCH")"
+  freshness_detail="$(registry_freshness_detail "$checkout_freshness")"
   if [[ "$(registry_checkout_is_alert "$checkout_verdict")" == "yes" ]]; then
     RESULTS+="❌ registry-checkout: ${checkout_detail} ($REGISTRY_CHECKOUT)\n"
     FAIL=$((FAIL + 1))
     # Best-effort Telegram alert (never fails this script — notify.sh is safe
     # under set -euo pipefail). This is the poisoned-registry early warning.
     notify_telegram "⚠️ grimnir registry checkout poisoned: ${checkout_detail} at ${REGISTRY_CHECKOUT} on $(hostname). Registry consumers may read a stale/wrong services.json until reconciled to ${REGISTRY_DEFAULT_BRANCH}." || true
+  elif [[ "$checkout_freshness" == "mismatch" ]]; then
+    RESULTS+="❌ registry-checkout: ${checkout_detail}, ${freshness_detail} ($REGISTRY_CHECKOUT)\n"
+    FAIL=$((FAIL + 1))
+    notify_telegram "⚠️ grimnir registry checkout differs from live origin/main at ${REGISTRY_CHECKOUT} on $(hostname). Refusing to re-stamp the deployment marker." || true
+  elif [[ "$checkout_freshness" == "unreachable" ]]; then
+    RESULTS+="⚠️  registry-checkout: ${checkout_detail}, ${freshness_detail} ($REGISTRY_CHECKOUT)\n"
+    WARN=$((WARN + 1))
   else
-    RESULTS+="✅ registry-checkout: ${checkout_detail} ($REGISTRY_CHECKOUT)\n"
+    RESULTS+="✅ registry-checkout: ${checkout_detail}, ${freshness_detail} ($REGISTRY_CHECKOUT)\n"
     PASS=$((PASS + 1))
     # Self-heal the git-pull deploy marker (#33). Sessions pull this canonical
     # checkout forward OUTSIDE a deploy, leaving .deployed-commit — what Heimdall's
@@ -299,7 +356,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     # refused (e.g. this service's read-only sandbox — see ReadWritePaths in
     # grimnir-validate.service); surface it instead of letting the drift silently
     # persist.
-    if ! restamp_deploy_marker "$REGISTRY_CHECKOUT" "$checkout_verdict"; then
+    if ! restamp_deploy_marker "$REGISTRY_CHECKOUT" "$checkout_verdict" "$checkout_freshness"; then
       RESULTS+="⚠️  deploy-marker: .deployed-commit not safely writable (read-only mount or symlink) — Heimdall drift may false-flag\n"
       WARN=$((WARN + 1))
     fi
@@ -312,16 +369,11 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   echo ""
 
   # Write to Munin if token available
+  VALIDATION_PERSISTED=false
   if [[ -n "$MUNIN_TOKEN" ]]; then
     # Munin helpers (inline — validation mode is self-contained)
     _munin_call() {
-      curl -s --max-time 10 \
-        -X POST http://localhost:3030/mcp \
-        -H "Content-Type: application/json" \
-        -H "Accept: application/json, text/event-stream" \
-        -H "Authorization: Bearer $MUNIN_TOKEN" \
-        -d "$1" 2>/dev/null | \
-        sed -n 's/^data: //p' | head -1 || echo "{}"
+      munin_http_jsonrpc "$MUNIN_TOKEN" "$1"
     }
 
     validation_content="## Registry Validation — $TIMESTAMP
@@ -344,7 +396,11 @@ $(echo -e "$RESULTS")"
         }
       }))
     ')"
-    _munin_call "$write_payload" > /dev/null 2>&1 || echo "⚠ Failed to write validation results to Munin"
+    if _munin_call "$write_payload" > /dev/null 2>&1; then
+      VALIDATION_PERSISTED=true
+    else
+      echo "⚠ Failed to write validation results to Munin"
+    fi
 
     # Also log the event
     log_payload="$(CONTENT_VAL="Registry validation: $PASS ok, $FAIL issues at $TIMESTAMP" node --input-type=commonjs -e '
@@ -360,13 +416,23 @@ $(echo -e "$RESULTS")"
         }
       }))
     ')"
-    _munin_call "$log_payload" > /dev/null 2>&1 || true
+    if ! _munin_call "$log_payload" > /dev/null 2>&1; then
+      echo "⚠ Failed to append validation event to Munin"
+      VALIDATION_PERSISTED=false
+    fi
 
-    echo "📡 Results written to Munin (validation/registry/latest)"
+    if [[ "$VALIDATION_PERSISTED" == "true" ]]; then
+      echo "📡 Results written to Munin (validation/registry/latest)"
+    fi
   else
     echo "⚠ No Munin token — results printed to stdout only"
   fi
 
+  # A systemd-successful run means both the live checks and their durable
+  # operator-facing record succeeded. Findings remain in stdout/Munin first.
+  if [[ "$FAIL" -gt 0 ]] || [[ "$VALIDATION_PERSISTED" != "true" ]]; then
+    exit 1
+  fi
   exit 0
 fi
 
@@ -403,13 +469,7 @@ munin_call() {
     echo "(Munin token not available)"
     return 1
   fi
-  curl -s --max-time 10 \
-    -X POST http://localhost:3030/mcp \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "Authorization: Bearer $MUNIN_TOKEN" \
-    -d "$payload" 2>/dev/null | \
-    sed -n 's/^data: //p' | head -1 || echo "{}"
+  munin_http_jsonrpc "$MUNIN_TOKEN" "$payload"
 }
 
 munin_tool_call() {

--- a/scripts/lib/deploy-safety.sh
+++ b/scripts/lib/deploy-safety.sh
@@ -20,3 +20,18 @@ prepare_rsync_destination_command() {
   quoted_path=$(posix_shell_quote "$deploy_path")
   printf 'mkdir -p %s && rm -rf -- %s/.git' "$quoted_path" "$quoted_path"
 }
+
+# Build the remote command that transitions a deploy target from an accepted
+# commit to "unknown" before code can change. A prior valid full SHA is emitted
+# for the operator's rollback log; malformed/missing markers become `unknown`.
+prepare_deploy_marker_invalidation_command() {
+  local deploy_path=$1 quoted_marker
+  quoted_marker=$(posix_shell_quote "${deploy_path}/.deployed-commit")
+  printf 'marker=%s; prior=unknown; ' "$quoted_marker"
+  # shellcheck disable=SC2016 # variables expand on the remote host
+  printf '%s' 'if [ -f "$marker" ] && [ ! -L "$marker" ]; then candidate=$(tr -d '\''\r\n'\'' < "$marker") || exit 1; case "$candidate" in ""|*[!0-9a-fA-F]*) ;; *) candidate_len=${#candidate}; if [ "$candidate_len" -ge 40 ] && [ "$candidate_len" -le 64 ]; then prior=$candidate; fi ;; esac; fi; '
+  # shellcheck disable=SC2016 # variables expand on the remote host
+  printf '%s' 'rm -f -- "$marker" || exit 1; if [ -e "$marker" ] || [ -L "$marker" ]; then printf '\''ERROR: deploy marker invalidation failed\n'\'' >&2; exit 1; fi; '
+  # shellcheck disable=SC2016 # variables expand on the remote host
+  printf '%s' 'printf '\''DEPLOY_MARKER_INVALIDATED:%s\n'\'' "$prior"'
+}

--- a/scripts/lib/deploy-safety.sh
+++ b/scripts/lib/deploy-safety.sh
@@ -10,3 +10,13 @@ posix_shell_quote() {
   done
   printf "%s%s'" "$quoted" "$value"
 }
+
+# Rsync deployments are release directories, never Git checkouts. Remove any
+# stale repository metadata before syncing: `.git` can be either a directory or
+# a worktree pointer file, and leaving the latter can point the Pi at a path
+# that only exists on the developer laptop.
+prepare_rsync_destination_command() {
+  local deploy_path=$1 quoted_path
+  quoted_path=$(posix_shell_quote "$deploy_path")
+  printf 'mkdir -p %s && rm -rf -- %s/.git' "$quoted_path" "$quoted_path"
+}

--- a/scripts/lib/munin-rpc.sh
+++ b/scripts/lib/munin-rpc.sh
@@ -2,15 +2,25 @@
 # Strict JSON-RPC transport for scheduled Grimnir jobs.
 #
 # A successful curl exit is not sufficient: proxies can return HTTP errors and
-# MCP can return JSON-RPC or tool-level errors with a readable body. Callers use
-# this helper so failed validation/security writes never masquerade as durable.
+# MCP can return JSON-RPC, protocol-level, or inner `{ok:false}` tool errors with
+# a readable body. Callers use this helper so failed validation/security writes
+# never masquerade as durable.
 
 munin_rpc_response_ok() {
   node --input-type=commonjs -e '
     var input = require("fs").readFileSync("/dev/stdin", "utf8");
-    var value;
+    var value, inner;
     try { value = JSON.parse(input); } catch (_) { process.exit(1); }
     if (!value || value.error || !value.result || value.result.isError === true) process.exit(1);
+    var content = value.result.content;
+    if (!Array.isArray(content) || content.length === 0) process.exit(1);
+    var text = content.find(function (item) {
+      return item && item.type === "text" && typeof item.text === "string";
+    });
+    if (!text) process.exit(1);
+    try { inner = JSON.parse(text.text); } catch (_) { process.exit(1); }
+    if (!inner || typeof inner !== "object" || Array.isArray(inner) ||
+        inner.ok !== true || inner.error) process.exit(1);
   ' 2>/dev/null
 }
 

--- a/scripts/lib/munin-rpc.sh
+++ b/scripts/lib/munin-rpc.sh
@@ -1,0 +1,37 @@
+# shellcheck shell=bash
+# Strict JSON-RPC transport for scheduled Grimnir jobs.
+#
+# A successful curl exit is not sufficient: proxies can return HTTP errors and
+# MCP can return JSON-RPC or tool-level errors with a readable body. Callers use
+# this helper so failed validation/security writes never masquerade as durable.
+
+munin_rpc_response_ok() {
+  node --input-type=commonjs -e '
+    var input = require("fs").readFileSync("/dev/stdin", "utf8");
+    var value;
+    try { value = JSON.parse(input); } catch (_) { process.exit(1); }
+    if (!value || value.error || !value.result || value.result.isError === true) process.exit(1);
+  ' 2>/dev/null
+}
+
+munin_http_jsonrpc() {
+  local token="${1:-}" payload="${2:-}" url="${MUNIN_RPC_URL:-http://localhost:3030/mcp}"
+  local raw data
+  [[ -n "$token" && -n "$payload" ]] || return 1
+
+  raw="$(curl -fsS --max-time 10 \
+    -X POST "$url" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $token" \
+    -d "$payload" 2>/dev/null)" || return 1
+
+  if [[ "$raw" == data:* ]] || [[ "$raw" == *$'\ndata:'* ]]; then
+    data="$(printf '%s\n' "$raw" | awk 'sub(/^data:[[:space:]]?/, "") { print; exit }')"
+  else
+    data="$raw"
+  fi
+  [[ -n "$data" ]] || return 1
+  printf '%s' "$data" | munin_rpc_response_ok || return 1
+  printf '%s\n' "$data"
+}

--- a/scripts/lib/registry-checkout.sh
+++ b/scripts/lib/registry-checkout.sh
@@ -1,13 +1,11 @@
 # shellcheck shell=bash
 # registry-checkout.sh — integrity check for the canonical grimnir checkout.
 #
-# The grimnir checkout on huginmunin (default: ~/repos/grimnir) plays three
-# colliding roles today (issue #47): rsync deploy target, the git checkout that
-# every registry consumer reads services.json from, and — until hugin#139 lands
-# — a hugin task workspace. When a hugin task strands it on a feature branch, or
-# a deploy leaves the tree dirty, consumers silently read a poisoned registry.
-# Two such incidents landed in two weeks (#33, #44). These helpers make that
-# state observable and alert-worthy from the daily grimnir-validate run.
+# The grimnir checkout on huginmunin (default: ~/repos/grimnir) is the canonical
+# checkout every registry consumer reads. It is now separated from Hugin task
+# workspaces and advances via git-pull deploys, but a stray local commit, dirty
+# tree, branch switch, or unreachable origin can still make its services.json
+# untrustworthy. These helpers keep every one of those states explicit.
 #
 # classify_registry_checkout <git_ok> <branch> <default_branch> <dirty>
 #   Pure verdict function (no git, no filesystem, no network). Inputs:
@@ -35,6 +33,13 @@
 #   network) and returns the classifier verdict. Never aborts the caller: a
 #   missing path, a non-git directory, or an empty argument all resolve to
 #   "alert-no-git" rather than a set -e abort. default_branch defaults to "main".
+#
+# check_registry_freshness <checkout_path> [default_branch]
+#   Compares the exact local HEAD to the exact SHA returned by `git ls-remote`
+#   for origin/<default_branch>, without mutating local refs. Echoes:
+#     current      exact SHA match
+#     mismatch     local HEAD differs (ahead, behind, or diverged)
+#     unreachable  either SHA cannot be proved (including network/auth failure)
 #
 # Sourced by both scripts/generate-architecture.sh (--validate mode) and the
 # registry-checkout unit test, so the logic has a single definition. bash 3.2+.
@@ -105,24 +110,81 @@ check_registry_checkout() {
   classify_registry_checkout "$git_ok" "$branch" "$default_branch" "$dirty"
 }
 
+classify_registry_freshness() {
+  local local_sha="${1:-}" remote_sha="${2:-}" lookup_status="${3:-unreachable}"
+  if [[ "$lookup_status" != "ok" ]] ||
+     [[ ! "$local_sha" =~ ^[0-9a-fA-F]{40,64}$ ]] ||
+     [[ ! "$remote_sha" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
+    echo "unreachable"
+  elif [[ "$local_sha" == "$remote_sha" ]]; then
+    echo "current"
+  else
+    echo "mismatch"
+  fi
+}
+
+registry_freshness_detail() {
+  case "${1:-unreachable}" in
+    current)     echo "HEAD exactly matches origin" ;;
+    mismatch)    echo "HEAD differs from live origin (ahead, behind, or diverged)" ;;
+    unreachable) echo "live origin SHA could not be verified" ;;
+    *)           echo "unknown freshness verdict: ${1}" ;;
+  esac
+}
+
+classify_deploy_marker() {
+  local marker="${1:-}" kind="${2:-regular}"
+  case "$kind" in
+    missing|symlink) echo "$kind" ;;
+    regular)
+      if [[ "$marker" =~ ^[0-9a-fA-F]{40,64}$ ]]; then
+        echo "valid"
+      else
+        echo "invalid"
+      fi
+      ;;
+    *) echo "invalid" ;;
+  esac
+}
+
+check_registry_freshness() {
+  local checkout="${1:-}" default_branch="${2:-main}"
+  local local_sha remote_line remote_sha
+
+  [[ -n "$checkout" ]] || { echo "unreachable"; return 0; }
+  local_sha="$(git -C "$checkout" rev-parse HEAD 2>/dev/null)" || {
+    echo "unreachable"
+    return 0
+  }
+  remote_line="$(git -C "$checkout" ls-remote --exit-code origin "refs/heads/${default_branch}" 2>/dev/null)" || {
+    echo "unreachable"
+    return 0
+  }
+  read -r remote_sha _ <<< "$remote_line"
+  classify_registry_freshness "$local_sha" "${remote_sha:-}" ok
+}
+
 # Re-stamp the git-pull deploy marker (#33). Heimdall's drift detector reads
 # <checkout>/.deployed-commit to decide whether a git-pull component is behind
 # origin. deploy.sh stamps that marker, but the canonical grimnir checkout also
 # gets pulled forward by ad-hoc sessions OUTSIDE a deploy, which leaves the marker
 # stale and makes Heimdall false-flag every grimnir unit as behind. Re-stamp HEAD
 # into the marker — but ONLY when the caller has already verified the checkout is
-# clean AND on its default branch (verdict "ok"); never bless a dirty or
-# branch-stranded tree. Guarded on an existing marker so it never fabricates one
-# on a non-deploy checkout (e.g. a laptop run).
+# clean, on its default branch (verdict "ok"), AND exactly equal to live origin
+# (freshness "current"); never bless a dirty, branch-stranded, local-ahead,
+# diverged, or origin-unreachable tree. Guarded on an existing marker so it never
+# fabricates one on a non-deploy checkout (e.g. a laptop run).
 #
 # Returns:
-#   0 — stamped, or intentionally skipped (verdict != ok, or no marker present)
-#   1 — marker present + verdict ok, but the write FAILED (e.g. a read-only mount,
-#       as under grimnir-validate.service's sandbox). The caller MUST surface this
-#       rather than swallow it, or the marker silently stays stale.
+#   0 — stamped, or intentionally skipped (unproved checkout or no marker present)
+#   1 — marker present + proved checkout, but the write FAILED (e.g. a read-only
+#       mount, as under grimnir-validate.service's sandbox). The caller MUST
+#       surface this rather than swallow it, or the marker silently stays stale.
 restamp_deploy_marker() {
-  local checkout="${1:-}" verdict="${2:-}"
-  [[ "$verdict" == "ok" ]] || return 0
+  local checkout="${1:-}" verdict="${2:-}" freshness="${3:-unreachable}"
+  # A clean main branch is not sufficient: a clean local-ahead or diverged
+  # checkout is exactly the state the deploy marker must never certify.
+  [[ "$verdict" == "ok" && "$freshness" == "current" ]] || return 0
   local marker="${checkout}/.deployed-commit"
   # Refuse a symlinked marker. The marker is gitignored (outside git's dirty
   # check), and both this write and the validate service's ReadWritePaths

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -68,6 +68,7 @@ switch (query) {
         name: c.name,
         repo: c.repo,
         host: c.host,
+        port: c.port || null,
         deploy_path: deployPath,
         unit_type: unitType,
         needs_build: Boolean(c.needs_build),

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -106,8 +106,9 @@ data.components.forEach(function (c, i) {
   if (c.host !== null && (typeof c.host !== 'string' || !VALID_HOST.test(c.host))) {
     fail(label + ': field "host" must be a safe hostname/address or null');
   }
-  if (c.port !== undefined && c.port !== null && typeof c.port !== 'number') {
-    fail(label + ': field "port" must be a number or null');
+  if (c.port !== undefined && c.port !== null &&
+      (!Number.isInteger(c.port) || c.port < 1 || c.port > 65535)) {
+    fail(label + ': field "port" must be an integer from 1 through 65535 or null');
   }
 
   if (c.name && seenNames[c.name]) {

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -8,7 +8,7 @@
 #   Phase 1: npm audit --json for each repo with package-lock.json
 #   Phase 2: Secret regex scan on all git-tracked files
 #
-# Writes results to Munin unless --dry-run or no token available.
+# Writes results to Munin unless --dry-run; a live run without durable writes fails.
 # Always prints a human-readable summary to stdout.
 #
 # NEVER outputs actual secret values — only file:line:pattern-category.
@@ -16,22 +16,25 @@
 
 set -euo pipefail
 
-SCANNER_VERSION="1.2.0"
+SCANNER_VERSION="1.3.0"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
-REPOS_DIR="$HOME/repos"
+REPOS_DIR="${REPOS_DIR:-$HOME/repos}"
 
 # ─── Source shared helpers ─────────────────────────────────────
 # shellcheck source=scripts/lib/notify.sh
 # shellcheck disable=SC1091  # dynamic path; use shellcheck -x to follow
 source "$SCRIPT_DIR/lib/notify.sh"
+# shellcheck source=scripts/lib/munin-rpc.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/munin-rpc.sh"
 TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 SCAN_DATE="$(date -u '+%Y-%m-%d')"
 HOSTNAME_VAL="$(hostname)"
 
 # Read scannable components from the service registry (single source of truth)
-REGISTRY="$GRIMNIR_DIR/services.json"
+REGISTRY="${REGISTRY_PATH:-$GRIMNIR_DIR/services.json}"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 COMPONENTS="$(REGISTRY_PATH="$REGISTRY" QUERY=scan node --input-type=commonjs "$REGISTRY_JS")"
 if [[ -z "$COMPONENTS" ]]; then
@@ -94,13 +97,7 @@ munin_call() {
     echo "(Munin token not available)"
     return 1
   fi
-  curl -s --max-time 10 \
-    -X POST http://localhost:3030/mcp \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "Authorization: Bearer $MUNIN_TOKEN" \
-    -d "$payload" 2>/dev/null | \
-    sed -n 's/^data: //p' | head -1 || echo "{}"
+  munin_http_jsonrpc "$MUNIN_TOKEN" "$payload"
 }
 
 munin_tool_call() {
@@ -141,6 +138,13 @@ repo_get() {
 
 # ─── Build component list ─────────────────────────────────────
 if [[ -n "$FILTER_REPO" ]]; then
+  case " $COMPONENTS " in
+    *" $FILTER_REPO "*) ;;
+    *)
+      echo "ERROR: --repo must name a scan-enabled component from services.json: $FILTER_REPO" >&2
+      exit 1
+      ;;
+  esac
   SCAN_COMPONENTS="$FILTER_REPO"
 else
   SCAN_COMPONENTS="$COMPONENTS"
@@ -172,7 +176,7 @@ for repo in $SCAN_COMPONENTS; do
   dir="$REPOS_DIR/$repo"
 
   # Collect git provenance
-  if [[ -d "$dir/.git" ]]; then
+  if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     repo_set "$repo" "commit" "$(git -C "$dir" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
     repo_set "$repo" "branch" "$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
   else
@@ -222,38 +226,53 @@ for repo in $SCAN_COMPONENTS; do
 
   # Parse npm audit JSON: validate, extract severities, collect package names
   # Single node call writes individual results to temp files (avoids $() quoting issues)
+  rm -f "$SCAN_TMP/_a_ok" "$SCAN_TMP/_a_error" "$SCAN_TMP/_a_crit" \
+    "$SCAN_TMP/_a_high" "$SCAN_TMP/_a_mod" "$SCAN_TMP/_a_low" \
+    "$SCAN_TMP/_a_total" "$SCAN_TMP/_a_json"
   printf '%s' "$audit_raw" > "$SCAN_TMP/_audit_raw"
   OUTDIR="$SCAN_TMP" node --input-type=commonjs -e '
     var fs = require("fs");
     var out = process.env.OUTDIR;
     try {
       var d = JSON.parse(fs.readFileSync(out + "/_audit_raw", "utf8"));
-      var v = (d.metadata && d.metadata.vulnerabilities) || {};
-      var c = v.critical || 0, h = v.high || 0, m = v.moderate || 0, l = v.low || 0;
+      if (!d || typeof d !== "object" || d.error) throw new Error("npm-error-response");
+      var v = d.metadata && d.metadata.vulnerabilities;
+      if (!v || typeof v !== "object" || Array.isArray(v)) throw new Error("missing-vulnerability-metadata");
+      function count(name) {
+        var value = v[name];
+        if (!Number.isInteger(value) || value < 0) throw new Error("invalid-" + name + "-count");
+        return value;
+      }
+      var c = count("critical"), h = count("high"), m = count("moderate"), l = count("low");
+      if (!d.vulnerabilities || typeof d.vulnerabilities !== "object" || Array.isArray(d.vulnerabilities)) {
+        throw new Error("missing-vulnerability-details");
+      }
       fs.writeFileSync(out + "/_a_ok", "true");
       fs.writeFileSync(out + "/_a_crit", String(c));
       fs.writeFileSync(out + "/_a_high", String(h));
       fs.writeFileSync(out + "/_a_mod", String(m));
       fs.writeFileSync(out + "/_a_low", String(l));
       fs.writeFileSync(out + "/_a_total", String(c + h + m + l));
-      var vulns = d.vulnerabilities || {};
+      var vulns = d.vulnerabilities;
       var pkgs = Object.entries(vulns).map(function(e) { return {name: e[0], severity: e[1].severity}; });
       var json = {critical: c, high: h, moderate: m, low: l, total: c+h+m+l, packages: pkgs};
       fs.writeFileSync(out + "/_a_json", JSON.stringify(json));
     } catch(e) {
       fs.writeFileSync(out + "/_a_ok", "false");
+      fs.writeFileSync(out + "/_a_error", String(e && e.message || "invalid-audit-json"));
     }
   ' 2>/dev/null
 
   if [[ "$(cat "$SCAN_TMP/_a_ok" 2>/dev/null)" != "true" ]]; then
-    repo_set "$repo" "audit_status" "error:invalid-json"
+    audit_error="$(cat "$SCAN_TMP/_a_error" 2>/dev/null || echo invalid-json)"
+    repo_set "$repo" "audit_status" "error:${audit_error}"
     repo_set "$repo" "audit_critical" "0"
     repo_set "$repo" "audit_high" "0"
     repo_set "$repo" "audit_moderate" "0"
     repo_set "$repo" "audit_low" "0"
     repo_set "$repo" "audit_total" "0"
     repo_set "$repo" "audit_json" "null"
-    echo "  $repo: ERROR (invalid JSON from npm audit)"
+    echo "  $repo: ERROR (unusable npm audit result: ${audit_error})"
     continue
   fi
 
@@ -322,7 +341,7 @@ for repo in $SCAN_COMPONENTS; do
     continue
   fi
 
-  if [[ ! -d "$dir/.git" ]]; then
+  if ! git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     log_verbose "  $repo: not a git repo, skipping secret scan"
     repo_set "$repo" "secret_status" "skipped:no-git"
     repo_set "$repo" "secret_count" "0"
@@ -336,7 +355,13 @@ for repo in $SCAN_COMPONENTS; do
   finding_count=0
 
   # Get list of tracked files
-  tracked_files="$(git -C "$dir" ls-files 2>/dev/null)" || true
+  if ! tracked_files="$(git -C "$dir" ls-files 2>/dev/null)"; then
+    repo_set "$repo" "secret_status" "error:git-ls-files"
+    repo_set "$repo" "secret_count" "0"
+    repo_set "$repo" "secret_findings" "[]"
+    echo "  $repo: ERROR (could not enumerate tracked files)"
+    continue
+  fi
 
   if [[ -z "$tracked_files" ]]; then
     repo_set "$repo" "secret_status" "ok"
@@ -489,22 +514,54 @@ done
 echo ""
 printf "TOTALS: critical=%d  high=%d  moderate=%d  low=%d  secrets=%d\n" \
   "$TOTAL_CRITICAL" "$TOTAL_HIGH" "$TOTAL_MODERATE" "$TOTAL_LOW" "$TOTAL_SECRETS"
+
+TOTAL_INCOMPLETE=0
+INCOMPLETE_REPOS=""
+for repo in $SCAN_COMPONENTS; do
+  audit_status="$(repo_get "$repo" audit_status)"
+  secret_status="$(repo_get "$repo" secret_status)"
+  repo_incomplete=false
+  case "$audit_status" in
+    ok|vulns|skipped:no-lockfile) ;;
+    *) repo_incomplete=true ;;
+  esac
+  case "$secret_status" in
+    ok|found) ;;
+    *) repo_incomplete=true ;;
+  esac
+  if [[ "$repo_incomplete" == "true" ]]; then
+    TOTAL_INCOMPLETE=$((TOTAL_INCOMPLETE + 1))
+    INCOMPLETE_REPOS="${INCOMPLETE_REPOS}${INCOMPLETE_REPOS:+ }${repo}"
+  fi
+done
+if [[ "$TOTAL_INCOMPLETE" -eq 0 ]]; then
+  SCAN_COMPLETE=true
+else
+  SCAN_COMPLETE=false
+fi
+printf "COVERAGE: complete=%s  incomplete_repos=%d%s\n" \
+  "$SCAN_COMPLETE" "$TOTAL_INCOMPLETE" "${INCOMPLETE_REPOS:+ ($INCOMPLETE_REPOS)}"
 echo ""
 
 # ─── Overall status assessment ────────────────────────────────
 
-OVERALL_STATUS="clean"
+FINDING_STATUS="clean"
 if [[ "$TOTAL_CRITICAL" -gt 0 ]] || [[ "$TOTAL_SECRETS" -gt 0 ]]; then
-  OVERALL_STATUS="critical"
+  FINDING_STATUS="critical"
 elif [[ "$TOTAL_HIGH" -gt 0 ]]; then
-  OVERALL_STATUS="high"
+  FINDING_STATUS="high"
 elif [[ "$TOTAL_MODERATE" -gt 0 ]]; then
-  OVERALL_STATUS="moderate"
+  FINDING_STATUS="moderate"
 elif [[ "$TOTAL_LOW" -gt 0 ]]; then
-  OVERALL_STATUS="low"
+  FINDING_STATUS="low"
+fi
+OVERALL_STATUS="$FINDING_STATUS"
+if [[ "$SCAN_COMPLETE" != "true" ]]; then
+  OVERALL_STATUS="incomplete"
 fi
 
 echo "Overall status: $OVERALL_STATUS"
+echo "Finding status: $FINDING_STATUS"
 echo ""
 
 # ─── Delta computation (escalation detection) ─────────────────
@@ -575,9 +632,9 @@ done
 # ─── Telegram alert — high/critical status + at least one escalation ──────
 # Stays silent when overall is clean/low/moderate, or when nothing escalated.
 
-if [[ "$OVERALL_STATUS" == "high" ]] || [[ "$OVERALL_STATUS" == "critical" ]]; then
+if [[ "$FINDING_STATUS" == "high" ]] || [[ "$FINDING_STATUS" == "critical" ]]; then
   if [[ -n "$ESCALATED_REPOS" ]]; then
-    OVERALL_UPPER="$(echo "$OVERALL_STATUS" | tr '[:lower:]' '[:upper:]')"
+    OVERALL_UPPER="$(echo "$FINDING_STATUS" | tr '[:lower:]' '[:upper:]')"
     ALERT_MSG="[Grimnir security] ${OVERALL_UPPER} — escalated findings (${SCAN_DATE}):
 ${ESCALATION_MSG_LINES}"
     if [[ "$DRY_RUN" == "true" ]]; then
@@ -593,16 +650,18 @@ fi
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "(Dry run — skipping Munin writes)"
   echo ""
+  [[ "$SCAN_COMPLETE" == "true" ]] || exit 1
   exit 0
 fi
 
 if [[ -z "$MUNIN_TOKEN" ]]; then
-  echo "(No Munin token — skipping writes)"
+  echo "ERROR: No Munin token — scan result is not durable" >&2
   echo ""
-  exit 0
+  exit 1
 fi
 
 echo "Writing to Munin..."
+WRITE_FAILURES=0
 
 # Build per-repo JSON and aggregate into full scan JSON
 # Each repo object is written as one line to a temp file; assembled into array at end
@@ -640,6 +699,8 @@ done
 OUTDIR="$SCAN_TMP" SCAN_DATE="$SCAN_DATE" TIMESTAMP="$TIMESTAMP" HOST="$HOSTNAME_VAL" \
   TOTAL_C="$TOTAL_CRITICAL" TOTAL_H="$TOTAL_HIGH" TOTAL_M="$TOTAL_MODERATE" \
   TOTAL_L="$TOTAL_LOW" TOTAL_S="$TOTAL_SECRETS" OVERALL="$OVERALL_STATUS" \
+  FINDING_STATUS="$FINDING_STATUS" SCAN_COMPLETE="$SCAN_COMPLETE" \
+  INCOMPLETE_REPOS="$INCOMPLETE_REPOS" \
   SCANNER_VER="$SCANNER_VERSION" \
   node --input-type=commonjs -e '
     var fs = require("fs"), out = process.env.OUTDIR;
@@ -651,6 +712,9 @@ OUTDIR="$SCAN_TMP" SCAN_DATE="$SCAN_DATE" TIMESTAMP="$TIMESTAMP" HOST="$HOSTNAME
       host:            process.env.HOST,
       scanner_version: process.env.SCANNER_VER,
       overall_status:  process.env.OVERALL,
+      finding_status:  process.env.FINDING_STATUS,
+      scan_complete:   process.env.SCAN_COMPLETE === "true",
+      incomplete_repos: process.env.INCOMPLETE_REPOS ? process.env.INCOMPLETE_REPOS.split(" ") : [],
       totals: {
         critical: parseInt(process.env.TOTAL_C),
         high:     parseInt(process.env.TOTAL_H),
@@ -673,6 +737,9 @@ Scan date: ${SCAN_DATE}
 Host: ${HOSTNAME_VAL}
 Scanner version: ${SCANNER_VERSION}
 Overall status: **${OVERALL_STATUS}**
+Finding status: **${FINDING_STATUS}**
+Scan complete: **${SCAN_COMPLETE}**
+Incomplete repositories: ${INCOMPLETE_REPOS:-none}
 
 ### Totals
 
@@ -699,7 +766,10 @@ summary_args="$(NAMESPACE_VAL="security/scans/${SCAN_DATE}" KEY_VAL="summary" \
       tags: ["security", "scan", "automated"]
     }))
 ')"
-munin_tool_call "memory_write" "$summary_args" > /dev/null || echo "  WARNING: Failed to write scan summary to Munin"
+if ! munin_tool_call "memory_write" "$summary_args" > /dev/null; then
+  echo "  WARNING: Failed to write scan summary to Munin"
+  WRITE_FAILURES=$((WRITE_FAILURES + 1))
+fi
 
 # Write 2: Per-repo latest state
 for repo in $SCAN_COMPONENTS; do
@@ -744,12 +814,15 @@ ${repo_detail_json}
         tags: ["security", "repo", process.env.REPO_TAG]
       }))
   ')"
-  munin_tool_call "memory_write" "$repo_args" > /dev/null || echo "  WARNING: Failed to write repo state for $repo"
+  if ! munin_tool_call "memory_write" "$repo_args" > /dev/null; then
+    echo "  WARNING: Failed to write repo state for $repo"
+    WRITE_FAILURES=$((WRITE_FAILURES + 1))
+  fi
 done
 
 # Write 3: Scan event log
 echo "  Logging scan event..."
-log_content="Security scan completed at ${TIMESTAMP} on ${HOSTNAME_VAL}. Overall: ${OVERALL_STATUS}. Totals — critical:${TOTAL_CRITICAL} high:${TOTAL_HIGH} moderate:${TOTAL_MODERATE} low:${TOTAL_LOW} secrets:${TOTAL_SECRETS}. Scanner v${SCANNER_VERSION}."
+log_content="Security scan completed at ${TIMESTAMP} on ${HOSTNAME_VAL}. Overall:${OVERALL_STATUS}; findings:${FINDING_STATUS}; complete:${SCAN_COMPLETE}; incomplete_repos:${INCOMPLETE_REPOS:-none}. Totals — critical:${TOTAL_CRITICAL} high:${TOTAL_HIGH} moderate:${TOTAL_MODERATE} low:${TOTAL_LOW} secrets:${TOTAL_SECRETS}. Scanner v${SCANNER_VERSION}."
 log_args="$(NAMESPACE_VAL="security/" CONTENT_VAL="$log_content" node --input-type=commonjs -e '
   console.log(JSON.stringify({
     namespace: process.env.NAMESPACE_VAL,
@@ -757,7 +830,13 @@ log_args="$(NAMESPACE_VAL="security/" CONTENT_VAL="$log_content" node --input-ty
     tags: ["security", "scan-event"]
   }))
 ')"
-munin_tool_call "memory_log" "$log_args" > /dev/null || echo "  WARNING: Failed to write scan event log to Munin"
+if ! munin_tool_call "memory_log" "$log_args" > /dev/null; then
+  echo "  WARNING: Failed to write scan event log to Munin"
+  WRITE_FAILURES=$((WRITE_FAILURES + 1))
+fi
 
 echo "Done."
 echo ""
+if [[ "$SCAN_COMPLETE" != "true" ]] || [[ "$WRITE_FAILURES" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/tests/deploy-persistent-paths.test.sh
+++ b/scripts/tests/deploy-persistent-paths.test.sh
@@ -67,6 +67,25 @@ else
   pass "POSIX quote does not execute embedded shell syntax"
 fi
 
+# The cleanup command must remove both Git repository directories and worktree
+# pointer files without touching normal release contents.
+REMOTE_FIXTURE="$TMP_DIR/remote alpha"
+mkdir -p "$REMOTE_FIXTURE/.git"
+printf '%s\n' keep > "$REMOTE_FIXTURE/app.js"
+sh -c "$(prepare_rsync_destination_command "$REMOTE_FIXTURE")"
+if [[ ! -e "$REMOTE_FIXTURE/.git" && -f "$REMOTE_FIXTURE/app.js" ]]; then
+  pass "rsync destination cleanup removes .git directory only"
+else
+  fail "rsync destination cleanup must remove .git directory only"
+fi
+printf '%s\n' "gitdir: /Users/example/repo/.git/worktrees/alpha" > "$REMOTE_FIXTURE/.git"
+sh -c "$(prepare_rsync_destination_command "$REMOTE_FIXTURE")"
+if [[ ! -e "$REMOTE_FIXTURE/.git" && -f "$REMOTE_FIXTURE/app.js" ]]; then
+  pass "rsync destination cleanup removes worktree .git file only"
+else
+  fail "rsync destination cleanup must remove worktree .git file only"
+fi
+
 assert_rejected_before_remote() {
   local desc=$1 fixture=$2
   rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
@@ -172,15 +191,26 @@ cat > "$TMP_DIR/safe.json" << 'EOF'
 {
   "components": [
     {
-      "name": "alpha", "repo": "alpha", "host": "h1", "port": null,
+      "name": "alpha", "repo": "alpha", "host": "h1", "port": 3033,
       "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
       "persistent_paths": ["/srv/alpha/data"], "rsync_excludes": ["/data/"],
       "needs_build": false,
-      "systemd_units": [{ "name": "alpha", "type": "service" }]
+      "systemd_units": [
+        { "name": "alpha", "type": "service" },
+        { "name": "heimdall-boot-check", "type": "timer" }
+      ]
     }
   ]
 }
 EOF
+
+# A deploy source must be an addressable, clean commit so its marker and
+# rollback recipe are meaningful.
+printf '%s\n' '{"name":"alpha","lockfileVersion":3,"packages":{}}' > "$TMP_DIR/repos/alpha/package-lock.json"
+git init -q -b main "$TMP_DIR/repos/alpha"
+git -C "$TMP_DIR/repos/alpha" add package-lock.json
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/repos/alpha" commit -q -m seed
 
 rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
 if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
@@ -205,10 +235,93 @@ if grep -Fxq -- "magnus@h1:'/srv/alpha/'" "$RSYNC_CAPTURE"; then
 else
   fail "rsync remote path uses POSIX shell quoting"
 fi
-if grep -Fq -- "mkdir -p '/srv/alpha'" "$SSH_CAPTURE"; then
-  pass "ssh remote deploy path uses POSIX shell quoting"
+if grep -Fq -- "mkdir -p '/srv/alpha' && rm -rf -- '/srv/alpha'/.git" "$SSH_CAPTURE"; then
+  pass "rsync destination is quoted and stale Git metadata is removed"
 else
-  fail "ssh remote deploy path uses POSIX shell quoting"
+  fail "rsync destination must be quoted and remove stale Git metadata"
+fi
+if grep -Fq -- "npm ci --omit=dev" "$SSH_CAPTURE"; then
+  pass "locked runtime dependencies use npm ci"
+else
+  fail "locked runtime dependencies must use npm ci"
+fi
+if grep -Fq -- "heimdall-boot-check.timer" "$SSH_CAPTURE" &&
+   grep -Fq -- "heimdall-boot-check.service" "$SSH_CAPTURE"; then
+  pass "boot-check timer and companion service are refreshed"
+else
+  fail "boot-check timer and companion service must both be refreshed"
+fi
+if grep -Fq -- "enable --now 'heimdall-boot-check.timer'" "$SSH_CAPTURE"; then
+  pass "boot-check timer is enabled and started"
+else
+  fail "boot-check timer must be enabled and started"
+fi
+if grep -Fq -- "is-active --quiet 'heimdall-boot-check.timer'" "$SSH_CAPTURE"; then
+  pass "boot-check timer is health-gated before the marker"
+else
+  fail "boot-check timer must be health-gated"
+fi
+# shellcheck disable=SC2016 # literal remote-shell fragment expected in capture
+if grep -Fq -- 'http://${target}:3033${path}' "$SSH_CAPTURE"; then
+  pass "declared HTTP endpoint is health-gated before the marker"
+else
+  fail "declared HTTP endpoint must be health-gated"
+fi
+final_call="$(grep -F 'DEPLOY_OK' "$SSH_CAPTURE" | tail -1)"
+# shellcheck disable=SC2016 # literal remote-shell fragment expected in capture
+case "$final_call" in
+  *'http://${target}:3033${path}'*"> .deployed-commit"*)
+    pass "health gate precedes deployment marker repair"
+    ;;
+  *)
+    fail "deployment marker must be written only after health succeeds"
+    ;;
+esac
+
+# Dirty content must be rejected before either SSH or rsync can mutate a host.
+echo stray > "$TMP_DIR/repos/alpha/untracked.txt"
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/dirty.out" 2>&1; then
+  fail "dirty source must fail"
+else
+  pass "dirty source fails"
+fi
+if [[ -e "$SSH_CAPTURE" || -e "$RSYNC_CAPTURE" ]]; then
+  fail "dirty source must be rejected before remote mutation"
+else
+  pass "dirty source invokes neither ssh nor rsync"
+fi
+
+# Git-pull mode operates on a real checkout and must never remove its .git.
+cat > "$TMP_DIR/git-pull.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false, "deploy_mode": "git-pull",
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+rm -f "$TMP_DIR/repos/alpha/untracked.txt" "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+if REGISTRY_PATH="$TMP_DIR/git-pull.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/git-pull.out" 2>&1; then
+  pass "git-pull deployment completes with mocked remote"
+else
+  fail "git-pull deployment completes with mocked remote"
+fi
+if grep -Fq -- "rm -rf -- '/srv/alpha'/.git" "$SSH_CAPTURE"; then
+  fail "git-pull deployment must preserve remote Git metadata"
+else
+  pass "git-pull deployment preserves remote Git metadata"
+fi
+if [[ -e "$RSYNC_CAPTURE" ]]; then
+  fail "git-pull deployment must not invoke rsync"
+else
+  pass "git-pull deployment does not invoke rsync"
 fi
 
 echo ""

--- a/scripts/tests/deploy-persistent-paths.test.sh
+++ b/scripts/tests/deploy-persistent-paths.test.sh
@@ -40,7 +40,30 @@ mkdir -p "$TMP_DIR/bin" "$TMP_DIR/repos/alpha"
 cat > "$TMP_DIR/bin/ssh" << 'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$SSH_CAPTURE"
-if [[ "$*" == *"DEPLOY_OK"* ]]; then
+command=${*: -1}
+if [[ "$command" == *"DEPLOY_MARKER_INVALIDATED"* ]]; then
+  printf '%s\n' invalidate >> "$ORDER_CAPTURE"
+  prior=unknown
+  if [[ -f "$REMOTE_MARKER_STATE" ]]; then
+    prior=$(cat "$REMOTE_MARKER_STATE")
+  fi
+  rm -f "$REMOTE_MARKER_STATE"
+  if [[ "${SSH_FAIL_MODE:-}" == "invalidate" ]]; then
+    exit 255
+  fi
+  printf 'DEPLOY_MARKER_INVALIDATED:%s\n' "$prior"
+elif [[ "$command" == *"pull --ff-only"* ]]; then
+  printf '%s\n' pull >> "$ORDER_CAPTURE"
+  [[ "${SSH_FAIL_MODE:-}" == "pull" ]] && exit 1
+elif [[ "$command" == *"npm ci --omit=dev"* ]]; then
+  printf '%s\n' npm >> "$ORDER_CAPTURE"
+  [[ "${SSH_FAIL_MODE:-}" == "npm" ]] && exit 1
+elif [[ "$command" == *"rm -rf --"*"/.git"* ]]; then
+  printf '%s\n' prepare >> "$ORDER_CAPTURE"
+elif [[ "$command" == *"DEPLOY_OK"* ]]; then
+  printf '%s\n' gates >> "$ORDER_CAPTURE"
+  [[ "${SSH_FAIL_MODE:-}" == "gates" ]] && exit 1
+  printf '%s\n' accepted > "$REMOTE_MARKER_STATE"
   echo "DEPLOY_OK"
 fi
 exit 0
@@ -49,6 +72,8 @@ EOF
 cat > "$TMP_DIR/bin/rsync" << 'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$RSYNC_CAPTURE"
+printf '%s\n' rsync >> "$ORDER_CAPTURE"
+[[ "${RSYNC_FAIL_MODE:-}" == "fail" ]] && exit 23
 exit 0
 EOF
 
@@ -56,7 +81,10 @@ chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync"
 
 SSH_CAPTURE="$TMP_DIR/ssh.calls"
 RSYNC_CAPTURE="$TMP_DIR/rsync.args"
-export SSH_CAPTURE RSYNC_CAPTURE
+ORDER_CAPTURE="$TMP_DIR/order.calls"
+REMOTE_MARKER_STATE="$TMP_DIR/remote-marker.state"
+PRIOR_SHA=1111111111111111111111111111111111111111
+export SSH_CAPTURE RSYNC_CAPTURE ORDER_CAPTURE REMOTE_MARKER_STATE
 
 assert_shell_quote_round_trip "POSIX quote round-trips plain text" "alpha"
 assert_shell_quote_round_trip "POSIX quote round-trips apostrophes and shell syntax" \
@@ -84,6 +112,15 @@ if [[ ! -e "$REMOTE_FIXTURE/.git" && -f "$REMOTE_FIXTURE/app.js" ]]; then
   pass "rsync destination cleanup removes worktree .git file only"
 else
   fail "rsync destination cleanup must remove worktree .git file only"
+fi
+
+printf '%s\n' "$PRIOR_SHA" > "$REMOTE_FIXTURE/.deployed-commit"
+marker_receipt=$(sh -c "$(prepare_deploy_marker_invalidation_command "$REMOTE_FIXTURE")")
+if [[ "$marker_receipt" == "DEPLOY_MARKER_INVALIDATED:${PRIOR_SHA}" ]] &&
+   [[ ! -e "$REMOTE_FIXTURE/.deployed-commit" ]]; then
+  pass "marker invalidation captures prior accepted SHA and removes marker"
+else
+  fail "marker invalidation must capture prior accepted SHA and remove marker"
 fi
 
 assert_rejected_before_remote() {
@@ -212,13 +249,28 @@ git -C "$TMP_DIR/repos/alpha" add package-lock.json
 GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
   git -C "$TMP_DIR/repos/alpha" commit -q -m seed
 
-rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
 if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
     PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/safe.out" 2>&1; then
   pass "safe registry completes mocked deploy"
 else
   fail "safe registry completes mocked deploy"
   sed -n '1,160p' "$TMP_DIR/safe.out"
+fi
+invalidate_line=$(grep -n '^invalidate$' "$ORDER_CAPTURE" | head -1 | cut -d: -f1)
+prepare_line=$(grep -n '^prepare$' "$ORDER_CAPTURE" | head -1 | cut -d: -f1)
+rsync_line=$(grep -n '^rsync$' "$ORDER_CAPTURE" | head -1 | cut -d: -f1)
+if [[ -n "$invalidate_line" && -n "$prepare_line" && -n "$rsync_line" ]] &&
+   [[ "$invalidate_line" -lt "$prepare_line" && "$invalidate_line" -lt "$rsync_line" ]]; then
+  pass "accepted marker is invalidated before rsync destination mutation"
+else
+  fail "accepted marker must be invalidated before rsync destination mutation"
+fi
+if grep -Fq "Previous accepted deployment: ${PRIOR_SHA} (marker invalidated)" "$TMP_DIR/safe.out"; then
+  pass "prior accepted SHA is retained in the deploy rollback log"
+else
+  fail "deploy must log the prior accepted SHA for rollback"
 fi
 if grep -Fxq -- '--exclude=/data/' "$RSYNC_CAPTURE"; then
   pass "declared persistent-path exclusion reaches rsync"
@@ -278,9 +330,43 @@ case "$final_call" in
     ;;
 esac
 
+assert_markerless_failure() {
+  local desc=$1 ssh_fail=${2:-} rsync_fail=${3:-}
+  rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+  printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
+  rc=0
+  SSH_FAIL_MODE="$ssh_fail" RSYNC_FAIL_MODE="$rsync_fail" \
+    REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/failure.out" 2>&1 || rc=$?
+  if [[ "$rc" == 1 && ! -e "$REMOTE_MARKER_STATE" ]] &&
+     grep -Fq "markerless/unknown" "$TMP_DIR/failure.out"; then
+    pass "$desc leaves the deployment markerless"
+  else
+    fail "$desc must leave the deployment markerless"
+  fi
+}
+
+assert_markerless_failure "failed rsync" "" fail
+assert_markerless_failure "failed npm install" npm ""
+assert_markerless_failure "failed unit/health gate" gates ""
+
+# If invalidation transport is uncertain, deployment stops before rsync.
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
+rc=0
+SSH_FAIL_MODE=invalidate REGISTRY_PATH="$TMP_DIR/safe.json" \
+  LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$DEPLOY" alpha >"$TMP_DIR/invalidation-fail.out" 2>&1 || rc=$?
+if [[ "$rc" == 1 && ! -e "$RSYNC_CAPTURE" ]] &&
+   [[ "$(tr '\n' ' ' < "$ORDER_CAPTURE")" == "invalidate " ]]; then
+  pass "uncertain marker invalidation stops before code mutation"
+else
+  fail "uncertain marker invalidation must stop before code mutation"
+fi
+
 # Dirty content must be rejected before either SSH or rsync can mutate a host.
 echo stray > "$TMP_DIR/repos/alpha/untracked.txt"
-rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
 if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
     PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/dirty.out" 2>&1; then
   fail "dirty source must fail"
@@ -306,7 +392,8 @@ cat > "$TMP_DIR/git-pull.json" << 'EOF'
   ]
 }
 EOF
-rm -f "$TMP_DIR/repos/alpha/untracked.txt" "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+rm -f "$TMP_DIR/repos/alpha/untracked.txt" "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
 if REGISTRY_PATH="$TMP_DIR/git-pull.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
     PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/git-pull.out" 2>&1; then
   pass "git-pull deployment completes with mocked remote"
@@ -322,6 +409,26 @@ if [[ -e "$RSYNC_CAPTURE" ]]; then
   fail "git-pull deployment must not invoke rsync"
 else
   pass "git-pull deployment does not invoke rsync"
+fi
+invalidate_line=$(grep -n '^invalidate$' "$ORDER_CAPTURE" | head -1 | cut -d: -f1)
+pull_line=$(grep -n '^pull$' "$ORDER_CAPTURE" | head -1 | cut -d: -f1)
+if [[ -n "$invalidate_line" && -n "$pull_line" && "$invalidate_line" -lt "$pull_line" ]]; then
+  pass "accepted marker is invalidated before git pull mutation"
+else
+  fail "accepted marker must be invalidated before git pull mutation"
+fi
+
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
+rc=0
+SSH_FAIL_MODE=pull REGISTRY_PATH="$TMP_DIR/git-pull.json" \
+  LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$DEPLOY" alpha >"$TMP_DIR/pull-fail.out" 2>&1 || rc=$?
+if [[ "$rc" == 1 && ! -e "$REMOTE_MARKER_STATE" ]] &&
+   grep -Fq "markerless/unknown" "$TMP_DIR/pull-fail.out"; then
+  pass "failed git pull leaves the deployment markerless"
+else
+  fail "failed git pull must leave the deployment markerless"
 fi
 
 echo ""

--- a/scripts/tests/munin-rpc.test.sh
+++ b/scripts/tests/munin-rpc.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/munin-rpc.sh
+source "$SCRIPT_DIR/../lib/munin-rpc.sh"
+
+PASS=0
+FAIL=0
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_status() {
+  local desc=$1 expected=$2 mode=$3 rc=0
+  CURL_MODE="$mode" PATH="$TMP_DIR/bin:$PATH" \
+    munin_http_jsonrpc token '{"jsonrpc":"2.0"}' >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — expected $expected, got $rc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+mkdir -p "$TMP_DIR/bin"
+apply_stub="$TMP_DIR/bin/curl"
+# This file is generated only inside the disposable test directory.
+# shellcheck disable=SC2016 # runtime stub expands CURL_MODE, not this test shell
+printf '%s\n' '#!/usr/bin/env bash' \
+  'case "$CURL_MODE" in' \
+  '  ok) printf '\''data: {"jsonrpc":"2.0","result":{"content":[]}}\n\n'\'' ;;' \
+  '  event) printf '\''event: message\ndata:{"jsonrpc":"2.0","result":{"content":[]}}\n\n'\'' ;;' \
+  '  json) printf '\''{"jsonrpc":"2.0","result":{"content":[]}}\n'\'' ;;' \
+  '  rpc-error) printf '\''data: {"jsonrpc":"2.0","error":{"code":-1}}\n\n'\'' ;;' \
+  '  tool-error) printf '\''data: {"jsonrpc":"2.0","result":{"isError":true}}\n\n'\'' ;;' \
+  '  malformed) printf '\''not-json\n'\'' ;;' \
+  '  transport) exit 22 ;;' \
+  'esac' > "$apply_stub"
+chmod +x "$apply_stub"
+
+echo "Munin RPC response tests"
+echo "========================"
+assert_status "valid SSE result succeeds" 0 ok
+assert_status "SSE event and unspaced data result succeeds" 0 event
+assert_status "valid JSON result succeeds" 0 json
+assert_status "JSON-RPC error fails" 1 rpc-error
+assert_status "MCP tool error fails" 1 tool-error
+assert_status "malformed response fails" 1 malformed
+assert_status "HTTP/transport failure fails" 1 transport
+
+rc=0; munin_http_jsonrpc '' '{}' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" == 1 ]]; then
+  echo "  PASS: missing token fails"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: missing token must fail"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/tests/munin-rpc.test.sh
+++ b/scripts/tests/munin-rpc.test.sh
@@ -29,9 +29,14 @@ apply_stub="$TMP_DIR/bin/curl"
 # shellcheck disable=SC2016 # runtime stub expands CURL_MODE, not this test shell
 printf '%s\n' '#!/usr/bin/env bash' \
   'case "$CURL_MODE" in' \
-  '  ok) printf '\''data: {"jsonrpc":"2.0","result":{"content":[]}}\n\n'\'' ;;' \
-  '  event) printf '\''event: message\ndata:{"jsonrpc":"2.0","result":{"content":[]}}\n\n'\'' ;;' \
-  '  json) printf '\''{"jsonrpc":"2.0","result":{"content":[]}}\n'\'' ;;' \
+  '  ok) printf '\''data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}}\n\n'\'' ;;' \
+  '  event) printf '\''event: message\ndata:{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}}\n\n'\'' ;;' \
+  '  json) printf '\''{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}}\n'\'' ;;' \
+  '  read-missing) printf '\''data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"ok\\":true,\\"found\\":false}"}]}}\n\n'\'' ;;' \
+  '  inner-false) printf '\''data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"ok\\":false}"}]}}\n\n'\'' ;;' \
+  '  inner-error) printf '\''data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"error\\":\\"write failed\\"}"}]}}\n\n'\'' ;;' \
+  '  inner-malformed) printf '\''data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"not-json"}]}}\n\n'\'' ;;' \
+  '  empty-content) printf '\''data: {"jsonrpc":"2.0","result":{"content":[]}}\n\n'\'' ;;' \
   '  rpc-error) printf '\''data: {"jsonrpc":"2.0","error":{"code":-1}}\n\n'\'' ;;' \
   '  tool-error) printf '\''data: {"jsonrpc":"2.0","result":{"isError":true}}\n\n'\'' ;;' \
   '  malformed) printf '\''not-json\n'\'' ;;' \
@@ -44,6 +49,11 @@ echo "========================"
 assert_status "valid SSE result succeeds" 0 ok
 assert_status "SSE event and unspaced data result succeeds" 0 event
 assert_status "valid JSON result succeeds" 0 json
+assert_status "memory_read ok=true found=false succeeds" 0 read-missing
+assert_status "inner ok=false fails" 1 inner-false
+assert_status "inner error fails" 1 inner-error
+assert_status "malformed inner text fails" 1 inner-malformed
+assert_status "empty tool content fails" 1 empty-content
 assert_status "JSON-RPC error fails" 1 rpc-error
 assert_status "MCP tool error fails" 1 tool-error
 assert_status "malformed response fails" 1 malformed

--- a/scripts/tests/registry-checkout.test.sh
+++ b/scripts/tests/registry-checkout.test.sh
@@ -82,6 +82,29 @@ assert_eq "no-arg classify_registry_checkout -> alert-no-git" \
 assert_eq "no-arg registry_checkout_is_alert -> yes" \
   "yes" "$(registry_checkout_is_alert)"
 
+# Exact remote-freshness classifier: lookup uncertainty must never become green.
+assert_eq "freshness exact SHA -> current" "current" \
+  "$(classify_registry_freshness 1111111111111111111111111111111111111111 1111111111111111111111111111111111111111 ok)"
+assert_eq "freshness differing SHA -> mismatch" "mismatch" \
+  "$(classify_registry_freshness 1111111111111111111111111111111111111111 2222222222222222222222222222222222222222 ok)"
+assert_eq "freshness failed lookup -> unreachable" "unreachable" \
+  "$(classify_registry_freshness 1111111111111111111111111111111111111111 '' unreachable)"
+assert_eq "freshness malformed SHA -> unreachable" "unreachable" \
+  "$(classify_registry_freshness not-a-sha 2222222222222222222222222222222222222222 ok)"
+assert_eq "no-arg freshness gatherer -> unreachable" "unreachable" \
+  "$(check_registry_freshness)"
+assert_eq "freshness detail mismatch is explicit" \
+  "HEAD differs from live origin (ahead, behind, or diverged)" \
+  "$(registry_freshness_detail mismatch)"
+assert_eq "full SHA deploy marker is valid" "valid" \
+  "$(classify_deploy_marker 1111111111111111111111111111111111111111 regular)"
+assert_eq "truncated deploy marker is invalid" "invalid" \
+  "$(classify_deploy_marker deadbeef regular)"
+assert_eq "text deploy marker is invalid" "invalid" \
+  "$(classify_deploy_marker ok regular)"
+assert_eq "symlink deploy marker is explicit" "symlink" \
+  "$(classify_deploy_marker '' symlink)"
+
 # registry_checkout_detail: verdict + default-branch -> human line. Shared with
 # generate-architecture.sh so the validate wiring's messages are unit-tested and
 # the ok branch is never left referencing an unset detail var.
@@ -163,6 +186,43 @@ assert_eq "fixture: missing path -> alert-no-git" \
 assert_eq "fixture: empty path arg -> alert-no-git" \
   "alert-no-git" "$(check_registry_checkout "" main)"
 
+# Exact comparison against a real local bare origin: no network and no local
+# remote-ref mutation are needed to distinguish current from ahead/behind.
+git init -q --bare "$TMP_DIR/origin.git"
+git clone -q "$TMP_DIR/origin.git" "$TMP_DIR/fresh"
+git -C "$TMP_DIR/fresh" checkout -q -b main
+echo "seed" > "$TMP_DIR/fresh/file.txt"
+git -C "$TMP_DIR/fresh" add file.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t \
+GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/fresh" commit -q -m seed
+git -C "$TMP_DIR/fresh" push -q -u origin main
+assert_eq "freshness fixture: exact origin/main -> current" "current" \
+  "$(check_registry_freshness "$TMP_DIR/fresh" main)"
+
+echo "local ahead" >> "$TMP_DIR/fresh/file.txt"
+git -C "$TMP_DIR/fresh" add file.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t \
+GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/fresh" commit -q -m ahead
+assert_eq "freshness fixture: clean local-ahead main -> mismatch" "mismatch" \
+  "$(check_registry_freshness "$TMP_DIR/fresh" main)"
+
+git clone -q "$TMP_DIR/origin.git" "$TMP_DIR/remote-writer"
+git -C "$TMP_DIR/remote-writer" checkout -q main
+echo "remote ahead" >> "$TMP_DIR/remote-writer/file.txt"
+git -C "$TMP_DIR/remote-writer" add file.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t \
+GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/remote-writer" commit -q -m remote-ahead
+git -C "$TMP_DIR/remote-writer" push -q origin main
+assert_eq "freshness fixture: local differs after remote advances -> mismatch" "mismatch" \
+  "$(check_registry_freshness "$TMP_DIR/fresh" main)"
+
+git -C "$TMP_DIR/fresh" remote set-url origin "$TMP_DIR/missing-origin.git"
+assert_eq "freshness fixture: origin failure -> unreachable" "unreachable" \
+  "$(check_registry_freshness "$TMP_DIR/fresh" main)"
+
 echo ""
 echo "restamp_deploy_marker tests (#33 deploy-marker self-heal)"
 echo "========================================================"
@@ -173,13 +233,13 @@ MARKER_FILE="$TMP_DIR/marker/.deployed-commit"
 
 # ok verdict + existing (stale) marker -> rewritten to HEAD, returns 0.
 printf 'deadbeef\n' > "$MARKER_FILE"
-rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok current || rc=$?
 assert_eq "ok + stale marker -> returns 0" "0" "$rc"
 assert_eq "ok + stale marker -> healed to HEAD" "$MARKER_HEAD" "$(cat "$MARKER_FILE")"
 
 # ok verdict + NO marker -> must not fabricate one (non-deploy checkout), returns 0.
 rm -f "$MARKER_FILE"
-rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok current || rc=$?
 assert_eq "ok + no marker -> returns 0" "0" "$rc"
 assert_eq "ok + no marker -> no marker created" "no" \
   "$([[ -f "$MARKER_FILE" ]] && echo yes || echo no)"
@@ -191,6 +251,11 @@ rc=0; restamp_deploy_marker "$TMP_DIR/marker" alert-dirty || rc=$?
 assert_eq "alert-dirty + marker -> returns 0 (skip)" "0" "$rc"
 assert_eq "alert-dirty + marker -> left untouched" "deadbeef" "$(cat "$MARKER_FILE")"
 
+# Clean main but not equal to live origin must never be certified.
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok mismatch || rc=$?
+assert_eq "clean main + remote mismatch -> returns 0 (skip)" "0" "$rc"
+assert_eq "clean main + remote mismatch -> marker left untouched" "deadbeef" "$(cat "$MARKER_FILE")"
+
 # no-arg call must not crash under set -euo pipefail (strict-mode contract).
 rc=0; restamp_deploy_marker || rc=$?
 assert_eq "no-arg restamp -> returns 0 (skip, no crash)" "0" "$rc"
@@ -201,7 +266,7 @@ assert_eq "no-arg restamp -> returns 0 (skip, no crash)" "0" "$rc"
 if [[ "$(id -u)" != "0" ]]; then
   printf 'deadbeef\n' > "$MARKER_FILE"
   chmod 000 "$MARKER_FILE"
-  rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+  rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok current || rc=$?
   chmod 644 "$MARKER_FILE"
   assert_eq "ok + unwritable marker -> returns 1 (surfaced)" "1" "$rc"
   assert_eq "ok + unwritable marker -> content unchanged" "deadbeef" "$(cat "$MARKER_FILE")"
@@ -213,7 +278,7 @@ fi
 rm -f "$MARKER_FILE"
 echo "target-untouched" > "$TMP_DIR/marker/real-target"
 ln -s "$TMP_DIR/marker/real-target" "$MARKER_FILE"
-rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok || rc=$?
+rc=0; restamp_deploy_marker "$TMP_DIR/marker" ok current || rc=$?
 assert_eq "ok + symlink marker -> returns 1 (refused)" "1" "$rc"
 assert_eq "ok + symlink marker -> target left untouched" \
   "target-untouched" "$(cat "$TMP_DIR/marker/real-target")"

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -198,6 +198,16 @@ cat > "$TMP_DIR/dup-port.json" << 'EOF'
 EOF
 assert_eq "duplicate port -> exit 1" "1" "$(run_validator "$TMP_DIR/dup-port.json")"
 
+cat > "$TMP_DIR/out-of-range-port.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": 70000,
+      "deploy": false, "scan": true, "needs_build": false, "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "out-of-range port -> exit 1" "1" "$(run_validator "$TMP_DIR/out-of-range-port.json")"
+
 # ── deploy=true without deploy_path ─────────────────────────────────────────
 cat > "$TMP_DIR/missing-deploy-path.json" << 'EOF'
 {
@@ -358,6 +368,12 @@ assert_eq "real services.json: hugin deploy scope remains user" "user" \
 assert_eq "real services.json: hugin structured units include appended timer" \
   '[{"name":"hugin","type":"service","scope":"user"},{"name":"hugin-daily-analysis","type":"timer"}]' \
   "$(deploy_field "$REPO_REGISTRY" hugin systemd_units)"
+
+assert_eq "real services.json: Heimdall deploy refreshes boot-check timer companion" \
+  '[{"name":"heimdall","type":"service"},{"name":"heimdall-collect","type":"timer"},{"name":"heimdall-maintain","type":"timer"},{"name":"heimdall-boot-check","type":"timer"}]' \
+  "$(deploy_field "$REPO_REGISTRY" heimdall systemd_units)"
+assert_eq "real services.json: Heimdall deploy carries its health port" \
+  "3033" "$(deploy_field "$REPO_REGISTRY" heimdall port)"
 
 assert_eq "real services.json: skuld timer deploys via user manager" \
   "user" "$(deploy_field "$REPO_REGISTRY" skuld unit_scope)"

--- a/scripts/tests/security-scan-completeness.test.sh
+++ b/scripts/tests/security-scan-completeness.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="$SCRIPT_DIR/../security-scan.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/repos/alpha"
+cat > "$TMP_DIR/bin/npm" << 'EOF'
+#!/usr/bin/env bash
+case "$NPM_AUDIT_FIXTURE" in
+  clean)
+    printf '%s\n' '{"auditReportVersion":2,"vulnerabilities":{},"metadata":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0,"total":0}}}'
+    ;;
+  vulnerable)
+    printf '%s\n' '{"auditReportVersion":2,"vulnerabilities":{"dep":{"severity":"high"}},"metadata":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":1,"critical":0,"total":1}}}'
+    exit 1
+    ;;
+  error-json)
+    printf '%s\n' '{"error":{"code":"ENETUNREACH","summary":"registry unavailable"}}'
+    exit 1
+    ;;
+  no-output) exit 1 ;;
+esac
+EOF
+chmod +x "$TMP_DIR/bin/npm"
+
+cat > "$TMP_DIR/registry.json" << 'EOF'
+{
+  "components": [
+    {"name":"alpha","repo":"alpha","host":null,"port":null,"deploy":false,"scan":true,"needs_build":false,"systemd_units":[]}
+  ]
+}
+EOF
+printf '%s\n' '{"name":"alpha","lockfileVersion":3,"packages":{}}' > "$TMP_DIR/repos/alpha/package-lock.json"
+git init -q -b main "$TMP_DIR/repos/alpha"
+git -C "$TMP_DIR/repos/alpha" add package-lock.json
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/repos/alpha" commit -q -m seed
+
+run_scan() {
+  local mode=$1 output=$2 rc=0
+  NPM_AUDIT_FIXTURE="$mode" REPOS_DIR="$TMP_DIR/repos" REGISTRY_PATH="$TMP_DIR/registry.json" \
+    PATH="$TMP_DIR/bin:$PATH" bash "$SCANNER" --dry-run > "$output" 2>&1 || rc=$?
+  printf '%s\n' "$rc"
+}
+
+assert_run() {
+  local desc=$1 mode=$2 expected_rc=$3 expected_status=$4 expected_complete=$5
+  local output="$TMP_DIR/${mode}.out" rc
+  rc="$(run_scan "$mode" "$output")"
+  if [[ "$rc" == "$expected_rc" ]]; then
+    pass "$desc: exit $expected_rc"
+  else
+    fail "$desc: expected exit $expected_rc, got $rc"
+  fi
+  if grep -Fq "Overall status: $expected_status" "$output"; then
+    pass "$desc: status $expected_status"
+  else
+    fail "$desc: missing status $expected_status"
+  fi
+  if grep -Fq "COVERAGE: complete=$expected_complete" "$output"; then
+    pass "$desc: complete=$expected_complete"
+  else
+    fail "$desc: missing completeness"
+  fi
+}
+
+echo "security scan completeness tests"
+echo "================================"
+assert_run "valid clean audit" clean 0 clean true
+assert_run "valid vulnerability audit" vulnerable 0 high true
+assert_run "npm error JSON" error-json 1 incomplete false
+assert_run "npm no output" no-output 1 incomplete false
+
+rc=0
+NPM_AUDIT_FIXTURE=clean REPOS_DIR="$TMP_DIR/repos" REGISTRY_PATH="$TMP_DIR/registry.json" \
+  PATH="$TMP_DIR/bin:$PATH" bash "$SCANNER" --dry-run --repo not-registered \
+  > "$TMP_DIR/filter.out" 2>&1 || rc=$?
+if [[ "$rc" == 1 ]] && grep -Fq -- '--repo must name a scan-enabled component' "$TMP_DIR/filter.out"; then
+  pass "unknown --repo is rejected before scanning"
+else
+  fail "unknown --repo must be rejected"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/services.json
+++ b/services.json
@@ -42,7 +42,8 @@
       "systemd_units": [
         { "name": "heimdall", "type": "service" },
         { "name": "heimdall-collect", "type": "timer" },
-        { "name": "heimdall-maintain", "type": "timer" }
+        { "name": "heimdall-maintain", "type": "timer" },
+        { "name": "heimdall-boot-check", "type": "timer" }
       ]
     },
     {

--- a/tests/scripts/test-security-scan-skip.sh
+++ b/tests/scripts/test-security-scan-skip.sh
@@ -123,7 +123,7 @@ while IFS= read -r relfile; do
 
   processed_count=$((processed_count+1))
 
-  while IFS='	' read -r pattern category; do
+  while IFS='	' read -r pattern _category; do
     [[ -z "$pattern" ]] && continue
     matched_lines="$(grep -nE "$pattern" "$absfile" 2>/dev/null)" || true
     [[ -z "$matched_lines" ]] && continue


### PR DESCRIPTION
## Summary

This is a hardening-only change: no new service functionality is introduced.

- compare the canonical registry checkout with the exact live `origin/main` SHA and refuse to certify uncertain, ahead, behind, or diverged state
- validate deployment markers as regular full-SHA files
- make npm/security coverage explicit so transport, registry, malformed-output, and Munin persistence failures cannot become zero-findings green
- make Munin persistence require HTTP, JSON-RPC, MCP protocol, and inner `{ok:true}` success; `{ok:true, found:false}` remains a valid read miss
- require clean rsync sources, lockfile-based `npm ci`, declared unit health, and HTTP health before accepting a deployment
- remove stale remote `.git` directories and worktree pointer files for rsync deployments while preserving Git metadata in git-pull mode
- inventory Heimdall's existing post-boot timer and reconcile bounded architecture, authority, recovery, threat-model, and CI truth
- pin GitHub Actions to immutable v4 commit SHAs

## Fallback-review findings resolved

The fallback review found two release-blocking false-green seams:

1. An old `.deployed-commit` marker could survive a partially mutated deployment. Both rsync and git-pull now capture the prior accepted SHA, invalidate the marker in a separately confirmed remote round trip before the first tree mutation, and leave failed deployments markerless/unknown. Uncertain invalidation transport stops before code mutation.
2. JSON-RPC success could conceal an inner Munin `{ok:false}` result. The shared helper now requires parseable successful inner content and rejects inner errors, malformed text, empty content, HTTP failures, and protocol errors.

Regression coverage proves marker invalidation precedes rsync destination cleanup/transfer and git pull; rsync, npm, pull, and unit/health failures never recreate acceptance; and git-pull preserves `.git`.

## Verification

- `make test`: **234/234 assertions passed**
- full ShellCheck over scripts, helpers, and tests: passed
- full Bash syntax check: passed
- `git diff --check`: passed
- full read-only fleet security scan: coverage complete

The fleet scan still reports existing owner-repo dependency debt: critical 3, high 8, moderate 12, low 4. The Heimdall bearer-token placeholder match at `src/panel-ingest.js:168` has been classified as a false positive; its scanner/source correction belongs in the Heimdall owner repo, not this PR.

## Deployment order after approval and merge

Deployment remains manual; this draft PR must not deploy anything.

1. Deploy Grimnir first from merged `main`: `make deploy ARGS="grimnir"`.
2. From clean current component worktrees, selectively deploy Hugin and Mimir to repair missing acceptance markers.
3. Deploy Heimdall from a clean worktree so the existing `heimdall-boot-check.timer` and companion service are refreshed and validated.
4. On huginmunin, run `./scripts/generate-architecture.sh --validate`.
5. Re-run the complete read-only security scan and verify Heimdall's at-a-glance deployment state.

Do not bypass Orin authentication.

## Rollback

- Revert the merged PR commit on `main`, merge that revert, then redeploy Grimnir.
- Every component deployment logs `Previous accepted deployment: <full-sha>` before mutation. If a deployment fails, create a clean worktree at that captured SHA and selectively redeploy it through the registry script.
- Rsync is not transactional: marker absence means live state is unknown and requires inspection, rollback, or a completed verified redeploy.
- Do not restore `.git` metadata to rsync release directories.
- Reverting the registry entry does not itself disable an already active Heimdall boot-check timer; only disable it if an explicit full scheduling rollback is required and its prior state has been verified.

## External actions

No merge, deployment, live marker repair, Munin mutation, or Orin access was performed while preparing this PR.