### PR TITLE
fix: require install-ready service units before deploy

### DIFF
--- a/docs/authority.md
+++ b/docs/authority.md
@@ -10,6 +10,7 @@
 | **Port assignments** | `services.json` | `generate-architecture.sh`, `deploy.sh`, `security-scan.sh`, `docs/architecture.md` |
 | **Hostnames / hosts** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
 | **Deploy paths, targets, systemd units & timer semantics** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
+| **Install-ready systemd unit contents** | Owning component repo | `deploy.sh` installs selected `systemd/{unit}` or root `{unit}` bytes without rendering |
 | **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
 | **Global rsync safety exclusions** (`.env`, `.git`, dependencies, tests, deploy marker) | `scripts/deploy.sh` | deploy persistence tests |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |
@@ -50,6 +51,12 @@
    restart every declared timer. Timers default to recurring and must expose a concrete next trigger
    before acceptance. A timer whose only trigger is legitimately single-fire, such as a lone
    `OnBootSec`, must be declared with `timer_semantics: "one-shot"` in `services.json`.
+
+9. **Declared unit sources are install-ready artifacts, not templates.** The owning component repo
+   owns unit contents. Central deploy selects `systemd/{unit}` before root `{unit}` and installs the
+   selected bytes without component-specific rendering. Unresolved angle-bracket identifiers on
+   active unit lines fail preflight; template files must use a different name or live outside those
+   selected paths. Placeholder prose in comments is allowed.
 
 ## Validation
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,7 +24,7 @@ All components are named after figures from Norse mythology, reflecting their ro
 
 Remote install paths live in `services.json` as `deploy_path`. Most services live under `~/repos/<service-name>/`, but a few have intentional exceptions such as `munin-memory` (`~/munin-memory`) and `mimir` (`~/mimir-server`).
 
-Deploy all services from the laptop with `make deploy` (from the grimnir repo), or selectively with `make deploy ARGS="munin-memory hugin"`. The centralized script deploys the local working tree via rsync, runs a local build when `needs_build: true`, installs production dependencies on the target host, and restarts primary service units. For worktree-based deploys, pass an explicit source override such as `make deploy ARGS="munin-memory=/tmp/munin-memory-awesome"`.
+Deploy all services from the laptop with `make deploy` (from the grimnir repo), or selectively with `make deploy ARGS="munin-memory hugin"`. The centralized script deploys the local working tree via rsync, runs a local build when `needs_build: true`, installs production dependencies on the target host, and restarts primary service units. Declared unit files must be install-ready: the deployer installs the selected `systemd/{unit}` or root `{unit}` bytes without rendering component-specific templates. For worktree-based deploys, pass an explicit source override such as `make deploy ARGS="munin-memory=/tmp/munin-memory-awesome"`.
 
 ## GitHub ownership
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -151,6 +151,26 @@ unit_rows() {
     '
 }
 
+preflight_local_unit_sources() {
+  local local_path=$1 units_json=$2 fallback_name=$3 fallback_type=$4 fallback_scope=$5
+  local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file
+
+  rows="$(unit_rows "$units_json" "$fallback_name" "$fallback_type" "$fallback_scope")"
+  while IFS='|' read -r unit_name unit_kind unit_actual_scope unit_timer_semantics; do
+    [[ -n "$unit_name" ]] || continue
+    unit_file="${unit_name}.${unit_kind}"
+    if ! preflight_local_install_ready_unit_source "$local_path" "$unit_file" true; then
+      return 1
+    fi
+    if [[ "$unit_kind" == "timer" ]]; then
+      companion_file="${unit_name}.service"
+      if ! preflight_local_install_ready_unit_source "$local_path" "$companion_file" false; then
+        return 1
+      fi
+    fi
+  done <<< "$rows"
+}
+
 rsync_exclude_rows() {
   local excludes_json=$1
   RSYNC_EXCLUDES_JSON="$excludes_json" node --input-type=commonjs -e '
@@ -239,6 +259,15 @@ deploy_service() {
     fi
     dirty_state="clean"
     echo "Source: ${local_path} (${branch} @ ${commit}, ${dirty_state})"
+
+    # Central deploy installs declared units byte-for-byte. Reject a missing
+    # source or a component-owned template before build, marker invalidation,
+    # host resolution, or any remote mutation.
+    if ! preflight_local_unit_sources "$local_path" "$units_json" "$name" "$unit_type" "$unit_scope"; then
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+      return
+    fi
   fi
 
   if ! remote_host=$(resolve_host "$host"); then
@@ -342,7 +371,7 @@ deploy_service() {
   local cmd="cd ${q_deploy_path} && "
   local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file
   local timer_entry timer_name timer_semantics timer_next_check
-  local q_unit_src q_unit_root q_user_dest q_system_dest q_unit_label
+  local q_unit_src q_unit_root q_user_dest q_system_dest q_unit_label unit_guard companion_guard
   local user_needs_reload=false system_needs_reload=false
   local user_services=() system_services=() user_timers=() system_timers=()
 
@@ -359,6 +388,8 @@ deploy_service() {
     if [[ "$unit_actual_scope" == "user" ]]; then
       cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
       cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
+      unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
+      cmd+="${unit_guard} && "
       cmd+="install -D -m644 \"\$unit_src\" \"\$HOME\"/${q_user_dest} && "
       user_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
@@ -369,12 +400,15 @@ deploy_service() {
         q_unit_root=$(posix_shell_quote "$companion_file")
         q_user_dest=$(posix_shell_quote ".config/systemd/user/${companion_file}")
         cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
-        cmd+="if [ -n \"\$companion_src\" ]; then install -D -m644 \"\$companion_src\" \"\$HOME\"/${q_user_dest}; fi && "
+        companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
+        cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && install -D -m644 \"\$companion_src\" \"\$HOME\"/${q_user_dest}; fi && "
         user_timers+=("${unit_name}|${unit_timer_semantics}")
       fi
     else
       cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
       cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
+      unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
+      cmd+="${unit_guard} && "
       cmd+="sudo install -D -m644 \"\$unit_src\" ${q_system_dest} && "
       system_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
@@ -385,7 +419,8 @@ deploy_service() {
         q_unit_root=$(posix_shell_quote "$companion_file")
         q_system_dest=$(posix_shell_quote "/etc/systemd/system/${companion_file}")
         cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
-        cmd+="if [ -n \"\$companion_src\" ]; then sudo install -D -m644 \"\$companion_src\" ${q_system_dest}; fi && "
+        companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
+        cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && sudo install -D -m644 \"\$companion_src\" ${q_system_dest}; fi && "
         system_timers+=("${unit_name}|${unit_timer_semantics}")
       fi
     fi

--- a/scripts/lib/deploy-safety.sh
+++ b/scripts/lib/deploy-safety.sh
@@ -11,6 +11,65 @@ posix_shell_quote() {
   printf "%s%s'" "$quoted" "$value"
 }
 
+# Registry-declared unit sources are installed byte-for-byte. Angle-bracket
+# identifiers have no rendering semantics in Grimnir and indicate that a
+# component-owned template was selected instead of an install-ready unit.
+# Comments may document placeholders without making the unit unsafe.
+unit_template_token_awk() {
+  # shellcheck disable=SC2016 # emitted for awk, not expanded by this shell
+  printf '%s' '/^[[:space:]]*[#;]/ { next } match($0, /<[A-Za-z][A-Za-z0-9_-]*>/) { print substr($0, RSTART, RLENGTH); exit }'
+}
+
+resolve_local_unit_source() {
+  local repo_path=$1 unit_file=$2 candidate
+  for candidate in "$repo_path/systemd/$unit_file" "$repo_path/$unit_file"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+preflight_local_install_ready_unit_source() {
+  local repo_path=$1 unit_file=$2 required=${3:-true}
+  local source token
+
+  if ! source=$(resolve_local_unit_source "$repo_path" "$unit_file"); then
+    if [[ "$required" == "true" ]]; then
+      printf 'ERROR: install-ready unit source missing: %s (looked in %s/systemd and %s)\n' \
+        "$unit_file" "$repo_path" "$repo_path" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  token=$(awk "$(unit_template_token_awk)" "$source")
+  if [[ -n "$token" ]]; then
+    printf 'ERROR: unit source is not install-ready: %s (unit %s contains unresolved placeholder %s)\n' \
+      "$source" "$unit_file" "$token" >&2
+    return 1
+  fi
+}
+
+# Emit the equivalent guard for the source selected on the remote host. This
+# covers git-pull deployments and prevents a source change between local
+# preflight and install from bypassing the byte-for-byte unit contract.
+prepare_remote_install_ready_unit_check_command() {
+  local source_var=$1 unit_file=$2 quoted_awk quoted_label
+  case "$source_var" in
+    unit_src|companion_src) ;;
+    *) return 1 ;;
+  esac
+  quoted_awk=$(posix_shell_quote "$(unit_template_token_awk)")
+  quoted_label=$(posix_shell_quote "$unit_file")
+
+  # shellcheck disable=SC2016 # command substitution and source variable expand remotely
+  printf '%s_placeholder=$(awk %s "$%s"); ' "$source_var" "$quoted_awk" "$source_var"
+  printf '[ -z "$%s_placeholder" ] || { printf '\''ERROR: unit source is not install-ready: %%s (unit %%s contains unresolved placeholder %%s)\\n'\'' "$%s" %s "$%s_placeholder" >&2; exit 1; }' \
+    "$source_var" "$source_var" "$quoted_label" "$source_var"
+}
+
 # Rsync deployments are release directories, never Git checkouts. Remove any
 # stale repository metadata before syncing: `.git` can be either a directory or
 # a worktree pointer file, and leaving the latter can point the Pi at a path

--- a/scripts/tests/deploy-persistent-paths.test.sh
+++ b/scripts/tests/deploy-persistent-paths.test.sh
@@ -109,14 +109,22 @@ cat > "$TMP_DIR/bin/sleep" << 'EOF'
 [[ "$#" -eq 1 && "$1" == "1" ]]
 EOF
 
-chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/systemctl" "$TMP_DIR/bin/sleep"
+cat > "$TMP_DIR/bin/npm" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$BUILD_CAPTURE"
+exit 0
+EOF
+
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/systemctl" \
+  "$TMP_DIR/bin/sleep" "$TMP_DIR/bin/npm"
 
 SSH_CAPTURE="$TMP_DIR/ssh.calls"
 RSYNC_CAPTURE="$TMP_DIR/rsync.args"
 ORDER_CAPTURE="$TMP_DIR/order.calls"
 REMOTE_MARKER_STATE="$TMP_DIR/remote-marker.state"
+BUILD_CAPTURE="$TMP_DIR/build.calls"
 PRIOR_SHA=1111111111111111111111111111111111111111
-export SSH_CAPTURE RSYNC_CAPTURE ORDER_CAPTURE REMOTE_MARKER_STATE
+export SSH_CAPTURE RSYNC_CAPTURE ORDER_CAPTURE REMOTE_MARKER_STATE BUILD_CAPTURE
 
 assert_shell_quote_round_trip "POSIX quote round-trips plain text" "alpha"
 assert_shell_quote_round_trip "POSIX quote round-trips apostrophes and shell syntax" \
@@ -202,9 +210,63 @@ else
   fail "recurring timer poll must report the failing timer"
 fi
 
+UNIT_FIXTURE="$TMP_DIR/unit-fixture"
+mkdir -p "$UNIT_FIXTURE/systemd"
+cat > "$UNIT_FIXTURE/systemd/alpha.service" << 'EOF'
+# Template prose such as <user> is allowed in comments.
+[Service]
+ExecStart=/bin/true
+EOF
+cat > "$UNIT_FIXTURE/alpha.service" << 'EOF'
+[Service]
+User=<user>
+EOF
+if [[ "$(resolve_local_unit_source "$UNIT_FIXTURE" alpha.service)" == \
+      "$UNIT_FIXTURE/systemd/alpha.service" ]] &&
+   preflight_local_install_ready_unit_source "$UNIT_FIXTURE" alpha.service true; then
+  pass "install-ready systemd unit is preferred and comment placeholders are allowed"
+else
+  fail "preferred systemd unit must win over the root fallback"
+fi
+remote_unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src alpha.service)
+if sh -c "unit_src=$(posix_shell_quote "$UNIT_FIXTURE/systemd/alpha.service"); $remote_unit_guard"; then
+  pass "remote install-ready guard allows comment-only placeholders"
+else
+  fail "remote install-ready guard must allow comment-only placeholders"
+fi
+rm "$UNIT_FIXTURE/systemd/alpha.service"
+if preflight_local_install_ready_unit_source "$UNIT_FIXTURE" alpha.service true \
+    >"$TMP_DIR/root-template.out" 2>&1; then
+  fail "root fallback template must be rejected"
+elif grep -Fq -- "$UNIT_FIXTURE/alpha.service" "$TMP_DIR/root-template.out" &&
+     grep -Fq -- "unit alpha.service" "$TMP_DIR/root-template.out" &&
+     grep -Fq -- "<user>" "$TMP_DIR/root-template.out"; then
+  pass "root fallback template failure names its file, unit, and placeholder"
+else
+  fail "root fallback template failure must identify its source"
+fi
+if sh -c "unit_src=$(posix_shell_quote "$UNIT_FIXTURE/alpha.service"); $remote_unit_guard" \
+    >"$TMP_DIR/remote-template.out" 2>&1; then
+  fail "remote install-ready guard must reject active placeholders"
+elif grep -Fq -- "$UNIT_FIXTURE/alpha.service" "$TMP_DIR/remote-template.out" &&
+     grep -Fq -- "unit alpha.service" "$TMP_DIR/remote-template.out" &&
+     grep -Fq -- "<user>" "$TMP_DIR/remote-template.out"; then
+  pass "remote template failure names its file, unit, and placeholder"
+else
+  fail "remote template failure must identify its source"
+fi
+
+commit_fixture_repo() {
+  local repo_path=$1
+  git init -q -b main "$repo_path"
+  git -C "$repo_path" add .
+  GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+    git -C "$repo_path" commit -q -m seed
+}
+
 assert_rejected_before_remote() {
-  local desc=$1 fixture=$2
-  rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+  local desc=$1 fixture=$2 expected_error=${3:-}
+  rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$BUILD_CAPTURE"
   if REGISTRY_PATH="$fixture" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
       PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/rejected.out" 2>&1; then
     fail "$desc: deploy must fail"
@@ -215,6 +277,18 @@ assert_rejected_before_remote() {
     fail "$desc: must invoke neither ssh nor rsync"
   else
     pass "$desc: invokes neither ssh nor rsync"
+  fi
+  if [[ -e "$BUILD_CAPTURE" ]]; then
+    fail "$desc: must not build"
+  else
+    pass "$desc: does not build"
+  fi
+  if [[ -n "$expected_error" ]]; then
+    if grep -Fq -- "$expected_error" "$TMP_DIR/rejected.out"; then
+      pass "$desc: reports the selected source"
+    else
+      fail "$desc: must report $expected_error"
+    fi
   fi
 }
 
@@ -303,6 +377,99 @@ cat > "$TMP_DIR/injected-path.json" << 'EOF'
 EOF
 assert_rejected_before_remote "shell-bearing deploy path" "$TMP_DIR/injected-path.json"
 
+mkdir -p "$TMP_DIR/repos/missing-unit"
+printf '%s\n' '{"name":"missing-unit"}' > "$TMP_DIR/repos/missing-unit/package.json"
+commit_fixture_repo "$TMP_DIR/repos/missing-unit"
+cat > "$TMP_DIR/missing-unit.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "missing-unit", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": true,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "missing primary unit" "$TMP_DIR/missing-unit.json" \
+  "install-ready unit source missing: alpha.service"
+
+mkdir -p "$TMP_DIR/repos/systemd-template/systemd"
+cat > "$TMP_DIR/repos/systemd-template/systemd/alpha.service" << 'EOF'
+# This is the preferred path, but active placeholders are never rendered.
+[Service]
+User=<user>
+EOF
+cat > "$TMP_DIR/repos/systemd-template/alpha.service" << 'EOF'
+[Service]
+ExecStart=/bin/true
+EOF
+commit_fixture_repo "$TMP_DIR/repos/systemd-template"
+cat > "$TMP_DIR/systemd-template.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "systemd-template", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": true,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "preferred systemd template" "$TMP_DIR/systemd-template.json" \
+  "systemd/alpha.service (unit alpha.service contains unresolved placeholder <user>)"
+
+mkdir -p "$TMP_DIR/repos/munin-template"
+cat > "$TMP_DIR/repos/munin-template/munin-memory.service" << 'EOF'
+# NOTE: Replace <user> and <install-dir> before installing this template.
+[Service]
+User=<user>
+WorkingDirectory=/home/<user>/<install-dir>
+EnvironmentFile=/home/<user>/<install-dir>/.env
+EOF
+commit_fixture_repo "$TMP_DIR/repos/munin-template"
+cat > "$TMP_DIR/munin-template.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "munin-template", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": true,
+      "systemd_units": [{ "name": "munin-memory", "type": "service" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "Munin-shaped root template" "$TMP_DIR/munin-template.json" \
+  "munin-memory.service (unit munin-memory.service contains unresolved placeholder <user>)"
+
+mkdir -p "$TMP_DIR/repos/companion-template/systemd"
+cat > "$TMP_DIR/repos/companion-template/systemd/alpha.timer" << 'EOF'
+[Timer]
+OnCalendar=daily
+EOF
+cat > "$TMP_DIR/repos/companion-template/systemd/alpha.service" << 'EOF'
+[Service]
+WorkingDirectory=/home/<user>/alpha
+EOF
+commit_fixture_repo "$TMP_DIR/repos/companion-template"
+cat > "$TMP_DIR/companion-template.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "companion-template", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": true,
+      "systemd_units": [{ "name": "alpha", "type": "timer" }]
+    }
+  ]
+}
+EOF
+assert_rejected_before_remote "present timer companion template" "$TMP_DIR/companion-template.json" \
+  "systemd/alpha.service (unit alpha.service contains unresolved placeholder <user>)"
+
 cat > "$TMP_DIR/safe.json" << 'EOF'
 {
   "components": [
@@ -326,10 +493,27 @@ EOF
 # A deploy source must be an addressable, clean commit so its marker and
 # rollback recipe are meaningful.
 printf '%s\n' '{"name":"alpha","lockfileVersion":3,"packages":{}}' > "$TMP_DIR/repos/alpha/package-lock.json"
-git init -q -b main "$TMP_DIR/repos/alpha"
-git -C "$TMP_DIR/repos/alpha" add package-lock.json
-GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
-  git -C "$TMP_DIR/repos/alpha" commit -q -m seed
+mkdir -p "$TMP_DIR/repos/alpha/systemd"
+cat > "$TMP_DIR/repos/alpha/systemd/alpha.service" << 'EOF'
+# Install-ready unit; illustrative <user> prose in comments is allowed.
+[Service]
+ExecStart=/bin/true
+EOF
+cat > "$TMP_DIR/repos/alpha/alpha.service" << 'EOF'
+[Service]
+User=<ignored-root-template>
+EOF
+for timer in heimdall-boot-check alpha-once alpha-recurring alpha-user-recurring; do
+  cat > "$TMP_DIR/repos/alpha/${timer}.timer" << EOF
+[Timer]
+OnCalendar=daily
+EOF
+done
+cat > "$TMP_DIR/repos/alpha/alpha-recurring.service" << 'EOF'
+[Service]
+ExecStart=/bin/true
+EOF
+commit_fixture_repo "$TMP_DIR/repos/alpha"
 
 rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
 printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
@@ -384,6 +568,14 @@ if grep -Fq -- "heimdall-boot-check.timer" "$SSH_CAPTURE" &&
   pass "boot-check timer and companion service are refreshed"
 else
   fail "boot-check timer and companion service must both be refreshed"
+fi
+# shellcheck disable=SC2016 # literal remote-shell fragments expected in capture
+if grep -Fq -- "for f in 'systemd/alpha.service' 'alpha.service'" "$SSH_CAPTURE" &&
+   grep -Fq -- 'unit_src_placeholder=$(awk' "$SSH_CAPTURE" &&
+   grep -Fq -- 'companion_src_placeholder=$(awk' "$SSH_CAPTURE"; then
+  pass "remote unit selection rechecks primary and present companion sources"
+else
+  fail "remote install must retain the install-ready source guard"
 fi
 if grep -Fq -- "sudo systemctl enable 'heimdall-boot-check.timer'" "$SSH_CAPTURE" &&
    grep -Fq -- "sudo systemctl restart 'heimdall-boot-check.timer'" "$SSH_CAPTURE"; then
@@ -531,6 +723,15 @@ if REGISTRY_PATH="$TMP_DIR/git-pull.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
 else
   fail "git-pull deployment completes with mocked remote"
 fi
+git_pull_final_call="$(grep -F 'DEPLOY_OK' "$SSH_CAPTURE" | tail -1)"
+case "$git_pull_final_call" in
+  *"unit_src_placeholder="*"unit source is not install-ready"*"sudo install -D -m644"*)
+    pass "git-pull source is guarded immediately before unit install"
+    ;;
+  *)
+    fail "git-pull source must be guarded immediately before unit install"
+    ;;
+esac
 if grep -Fq -- "rm -rf -- '/srv/alpha'/.git" "$SSH_CAPTURE"; then
   fail "git-pull deployment must preserve remote Git metadata"
 else


### PR DESCRIPTION
## Summary
- select component-owned `systemd/<unit>` artifacts before root fallbacks
- reject missing primary units and active-line template placeholders before build or remote mutation
- repeat the guard immediately before installation, including present timer companions
- document the generic byte-for-byte unit authority boundary

## Validation
- `make test` — 277 assertions passed
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `git diff --check origin/main...HEAD`

## Review
Claude Opus was unavailable in this environment. Codex independently reviewed the complete diff and reran the full repository gate; no findings remain.

No new functionality; this closes the deployment acceptance gap exposed during the hardening rollout.