### PR TITLE
docs(contract): bounded cross-host clock skew tolerance (v1 clarification)

### DIFF
--- a/docs/learning-task-contract.md
+++ b/docs/learning-task-contract.md
@@ -172,6 +172,20 @@ preflight may predate the attempt but must remain fresh at stamp time. Direct an
 and model clocks without inventing gateway admission. Exposure and review/rating clocks are bounded
 by source acceptance and their relevant attempt outcome or experiment observation; equality at a
 boundary is permitted.
+
+**Cross-host clock skew tolerance (v1 clarification, 2026-07-20).** Timestamps in one record are
+stamped by two hosts: Hugin-host clocks (source creation/acceptance, attempt start/end, request
+stamp, `recorded_at`) and gateway-host clocks (preflight advertisement/expiry, gateway admission,
+model start/end). Orderings that compare clocks from *different* hosts carry a bounded skew
+tolerance of exactly **2000 ms**: a conforming implementation MUST accept an otherwise-valid
+cross-host ordering violated by at most the tolerance and MUST reject one violated by more.
+Same-host orderings remain exact with no tolerance. Every freshness/expiry upper bound is
+TIGHTENED by the tolerance (e.g. a stamp is fresh only while `stamped_at` <
+`expires_at` − 2000 ms), so the tolerance can never extend an advertisement's validity window.
+Rationale: the first live joint smokes (2026-07-20) proved zero-tolerance cross-host orderings
+require inter-host clock agreement tighter than one-way network latency, which NTP does not
+provide; both producer and gateway implementations must apply the same bound or the stricter side
+rejects handshakes the other accepts.
 Every dispatched M5 request stamp, including a non-admitted attempt, is also bounded above by the
 known attempt end and record creation; the missing gateway echo never permits a post-hoc stamp.
 

--- a/tests/fixtures/learning-task-contract/negative.json
+++ b/tests/fixtures/learning-task-contract/negative.json
@@ -1193,7 +1193,7 @@
       {
         "op": "set",
         "path": "/transport/gateway_echo/admitted_at",
-        "value": "2026-07-19T10:00:00.900Z"
+        "value": "2026-07-19T09:59:58.900Z"
       }
     ],
     "expected_error": "gateway admission clock is outside stamp/model-start interval"

--- a/tests/scripts/validate-learning-task-contract.mjs
+++ b/tests/scripts/validate-learning-task-contract.mjs
@@ -6,6 +6,11 @@ import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, "../..");
+// Contract v1 clarification (2026-07-20): bounded cross-host clock skew tolerance. Applied ONLY
+// to orderings comparing a Hugin-host clock with a gateway-host clock; same-host orderings stay
+// exact and freshness/expiry edges are tightened by the tolerance, never extended. See
+// docs/learning-task-contract.md, "Cross-host clock skew tolerance".
+const CLOCK_SKEW_TOLERANCE_MS = 2_000;
 const schema = JSON.parse(fs.readFileSync(path.join(root, "docs/learning-task-contract-v1.schema.json"), "utf8"));
 const positive = JSON.parse(fs.readFileSync(path.join(root, "tests/fixtures/learning-task-contract/positive.json"), "utf8"));
 const positiveDerivedDefinitions = JSON.parse(fs.readFileSync(path.join(root, "tests/fixtures/learning-task-contract/positive-derived.json"), "utf8"));
@@ -638,9 +643,11 @@ function validateTransport(record, errors) {
   if (canonical(preflight.request.requested_capabilities) !== canonical(request.contract_request)
     || canonical(preflight.response.capabilities) !== canonical(request.contract_request)) errors.push("preflight advertisement/request does not bind exact requested revision and features");
   if (preflight.response.authenticated_principal_id !== "service:gille-inference") errors.push("preflight response is not authenticated as gille-inference");
-  if (!(Date.parse(preflight.request.requested_at) <= Date.parse(preflight.response.advertised_at)
-    && Date.parse(preflight.response.advertised_at) <= Date.parse(request.stamped_at)
-    && Date.parse(request.stamped_at) < Date.parse(preflight.response.expires_at))) errors.push("preflight freshness window does not cover request stamp");
+  // Cross-host orderings (Hugin-host requested/stamped vs gateway-host advertised/expires) carry
+  // the contract's bounded skew tolerance; the expiry edge is tightened, never extended.
+  if (!(Date.parse(preflight.request.requested_at) - CLOCK_SKEW_TOLERANCE_MS <= Date.parse(preflight.response.advertised_at)
+    && Date.parse(preflight.response.advertised_at) <= Date.parse(request.stamped_at) + CLOCK_SKEW_TOLERANCE_MS
+    && Date.parse(request.stamped_at) < Date.parse(preflight.response.expires_at) - CLOCK_SKEW_TOLERANCE_MS)) errors.push("preflight freshness window does not cover request stamp");
   if (Date.parse(preflight.response.expires_at) - Date.parse(preflight.response.advertised_at) > 15 * 60 * 1000) errors.push("preflight advertisement cache TTL exceeds 15 minutes");
   if (state === "m5-not-admitted") {
     for (const [name, value] of [
@@ -667,7 +674,9 @@ function validateTransport(record, errors) {
   if (echo.authenticated_principal_id !== request.expected_transport_principal_id) errors.push("gateway authenticated principal does not match expected transport principal");
   const principalBindingSource = { authenticated_principal_id: echo.authenticated_principal_id, request_stamp: request };
   if (echo.principal_binding_digest.digest !== digestCanonical(principalBindingSource)) errors.push("gateway principal binding digest does not bind principal/request identity");
-  if (Date.parse(echo.admitted_at) < Date.parse(request.stamped_at)
+  // stamped_at is a Hugin-host clock and admitted_at a gateway-host clock (cross-host: tolerance);
+  // admitted_at and model_started_at are both gateway-host clocks (same-host: exact).
+  if (Date.parse(echo.admitted_at) < Date.parse(request.stamped_at) - CLOCK_SKEW_TOLERANCE_MS
     || isUnknown(record.execution.model_started_at)
     || Date.parse(echo.admitted_at) > Date.parse(record.execution.model_started_at)) errors.push("gateway admission clock is outside stamp/model-start interval");
 }


### PR DESCRIPTION
The strict admitted-M5 clock ordering compares clocks stamped on two different hosts with zero tolerance — proven unsatisfiable by the first seven live joint-smoke runs (see Magnus-Gille/hugin#253). This clarification specifies a 2000ms cross-host tolerance (same-host stays exact; expiry edges tightened, never extended), implements it in the reference validator, and deepens the admission-precedes negative vector beyond the tolerance.

Verification: `validate-learning-task-contract.mjs` — 14 positives, 2 immutable multi-review, **102 adversarial** all passing; doc test 150/150; `make test` 23/23.

Consumers to re-vendor after merge: gille-inference (negative.json + PROVENANCE pin — in flight in the same session), hugin (vendors only fingerprint/serializer fixtures — unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)