### PR TITLE
Audit and harden multi-agent worktree and deployment hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,9 @@ Roadmap → tickets → implementation → review, with grimnir as the orchestra
 - `docs/conventions.md` — Naming, GitHub ownership, service patterns
 - `docs/role-separation.md` — Why the canonical grimnir checkout must not double as a deploy target
   or hugin workspace, and the validate check that alarms on drift (issue #47)
+- `docs/worktree-hygiene.md` — Multi-agent worktree/deployment hygiene protocol: stale/dirty/orphaned
+  worktree detection, canonical-checkout and deploy-target role violations, non-destructive
+  remediation recipes, and how to run the audit (`scripts/worktree-hygiene-audit.sh`, issue #87)
 - `docs/observability-and-improvement.md` — How components capture traces, score outputs, and feed the
   self-improving loop
 - `docs/learning-task-contract.md` — Normative Hugin↔M5 learning-evidence seam: field and decision
@@ -122,6 +125,7 @@ Roadmap → tickets → implementation → review, with grimnir as the orchestra
 | `scripts/deploy.sh` | Deploy services to Pi hosts (all or selective) | `make deploy` or `make deploy ARGS="munin-memory"` |
 | `scripts/generate-architecture.sh` | Generate deployment snapshot + full-architecture.md | `make docs` (Pi only) |
 | `scripts/security-scan.sh` | Scan all repos for vulnerabilities and secrets | `make security` |
+| `scripts/worktree-hygiene-audit.sh` | Read-only audit of stale/dirty/orphaned worktrees, canonical-checkout drift, and deploy-target role violations across owned repos | `scripts/worktree-hygiene-audit.sh` (also wired into `scripts/generate-architecture.sh --validate`); tests via `make test-worktree-hygiene` |
 
 > OS patching (`setup-host-patching.sh`) and maintenance reports (`maintenance-report.sh`) have moved
 > to the `brokkr` repo. Use `make patching` / `make maintenance-os` / `make maintenance-deps` from

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -42,7 +42,10 @@ test-registry-checkout: ## Unit tests for the registry-checkout integrity helper
 test-systemd-status: ## Scope-aware local/remote systemd status checks (issue #63)
 	@bash scripts/tests/systemd-status.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status ## Run all test suites
+test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
+	@bash scripts/tests/worktree-hygiene.test.sh
+
+test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/role-separation.md
+++ b/docs/role-separation.md
@@ -5,6 +5,11 @@
 > validation checks branch/cleanliness plus exact equality with live origin and
 > refuses to re-stamp an unproved checkout. The option analysis below is retained
 > as the decision history for issue #47.
+>
+> Issue #87 extends this single-checkout guard to the full multi-agent
+> worktree lifecycle (stale/dirty/orphaned worktrees across every owned repo,
+> plus a deploy-target role check) — see `docs/worktree-hygiene.md` for the
+> protocol and `scripts/worktree-hygiene-audit.sh` for the audit tool.
 
 ## The problem
 

--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -1,0 +1,157 @@
+# Multi-agent worktree and deployment hygiene (issue #87)
+
+> Status: adopted. Extends the canonical-checkout guard from issue #47
+> (`docs/role-separation.md`, `scripts/lib/registry-checkout.sh`) to the full
+> worktree lifecycle, and adds a narrow deploy-target role check. Read-only
+> audit; see `scripts/worktree-hygiene-audit.sh` and
+> `scripts/lib/worktree-hygiene.sh`.
+
+## The problem
+
+Many agents/sessions operate concurrently across the same repos and
+checkouts. Grimnir's own house rule is **one task = one subagent = one
+dedicated worktree** (see `AGENTS.md` § House rules — cross-repo delegation),
+but that discipline is only as good as its follow-through. Left unaudited,
+this class of activity accumulates residue:
+
+- **Stale worktrees** — a task's branch gets merged (or its remote branch is
+  deleted after merge/rebase), but the linked worktree that checked it out is
+  never removed.
+- **Dirty worktrees** — a worktree still holds uncommitted or untracked work,
+  sometimes from a session that ended abruptly.
+- **Orphaned/prunable worktree registrations** — a worktree's directory was
+  removed directly (`rm -rf`) instead of via `git worktree remove`, leaving
+  git's own bookkeeping (`.git/worktrees/<name>`) stranded and pointing at
+  nothing.
+- **A canonical checkout doubling as a deploy target or task workspace** —
+  the exact #47 poisoning class: the single path every registry consumer
+  reads from goes dirty or gets stranded off the default branch.
+- **Deploy drift** — a deployed commit that no longer matches `origin/main`
+  (already guarded for `deploy_mode: git-pull` components by
+  `scripts/lib/registry-checkout.sh`'s freshness check and for rsync
+  components by the `.deployed-commit` marker check), or — the narrower gap
+  this issue closes — an **rsync deploy target that has unexpectedly grown a
+  `.git` directory**, meaning it is quietly doubling as an ad hoc checkout.
+
+An audit (2026-07, grimnir#87) found exactly this kind of residue: dozens of
+worktrees on the Hugin dispatcher host including prunable and dirty stale
+trees, a primary checkout behind `origin/main`, extra worktrees on another
+host including a stale deployment tree, and at least one completed commit
+stranded off `main` on a branch nobody had cleaned up. Current tests were
+green throughout — this is an **operational integrity problem**, not evidence
+of source corruption. The risk is inspecting, editing, or deploying the wrong
+tree and believing cross-repo work landed when only half of it did.
+
+## The protocol
+
+1. **One task = one subagent = one dedicated worktree.** Already the house
+   rule (`AGENTS.md`). A worktree exists for exactly one ticket/task; it is
+   not reused across unrelated work.
+2. **Clean up after merge.** Once a task's PR merges, its worktree is
+   removed (`git worktree remove <path>`) and its branch deleted
+   (`git branch -d <branch>`, or `-D` only after confirming the merge landed
+   under a different SHA, e.g. squash-merge) — by the agent or operator who
+   finished the task, not left for someone else to notice later.
+3. **The canonical checkout stays clean, on the default branch, always.**
+   Per `docs/role-separation.md`: the canonical checkout that registry
+   consumers and validation timers read from is never a scratch workspace and
+   never an rsync deploy target. It only ever advances by
+   `git pull --ff-only origin main`.
+4. **Deploy targets stay in their declared lane.** A `deploy_mode: git-pull`
+   target is *supposed* to be a git checkout. Every other (rsync) target is
+   *not* — if one grows a `.git` directory, that is a role violation worth
+   investigating, not a co-incidence to ignore.
+5. **Run the audit, don't just hope.** `scripts/worktree-hygiene-audit.sh`
+   (standalone) and the `--validate` wiring in
+   `scripts/generate-architecture.sh` (the existing `grimnir-validate` timer,
+   issue #47's harness) both report hygiene state read-only. Findings are
+   evidence for a human/agent to act on, not something the tooling fixes
+   itself.
+
+## Running the audit
+
+Standalone, against the real repo tree on a host:
+
+```bash
+scripts/worktree-hygiene-audit.sh
+# or with overrides:
+GRIMNIR_WORKTREE_AUDIT_ROOT=/path/to/repos \
+GRIMNIR_DEFAULT_BRANCH=main \
+GRIMNIR_SERVICES_JSON=/path/to/services.json \
+  scripts/worktree-hygiene-audit.sh
+```
+
+It scans every git repo directly under the repos root, and for each one
+prints one line per worktree that has a finding, followed by a summary line
+(`Summary: N ok, M issues`) and a non-destructive remediation recipe per
+finding. Exit code is `0` when nothing is flagged, `1` otherwise.
+
+It is also wired into `scripts/generate-architecture.sh --validate` (the
+`grimnir-validate` timer), where its findings fold into the existing
+`PASS`/`FAIL` tally and Munin-persisted validation report alongside the #47
+registry-checkout check and the per-component deployment-freshness checks.
+
+Unit and fixture tests: `make test-worktree-hygiene` (also part of
+`make test`), exercised against constructed fixture git repos — never against
+the real, live repos. See `scripts/tests/worktree-hygiene.test.sh`.
+
+## What the audit reports (and never does)
+
+| Verdict | Meaning | Suggested manual remediation |
+|---|---|---|
+| `ok` | Active/clean; no finding | — |
+| `dirty` | Uncommitted changes present | Inspect (`git status`); commit or `git stash -u`. |
+| `stale` | Branch merged into the default branch, or its upstream is gone, but the worktree remains | After confirming no unique unpushed work: `git worktree remove <path>` then `git branch -d <branch>` — operator-confirmed only. |
+| `dirty,stale` | Both at once — a merged/gone branch with unsaved work sitting in it | Preserve the work first (commit, stash, or cherry-pick it) **before** any removal. |
+| `prunable` | Administrative worktree entry present, but its working directory is gone | Reconcile the registration only: `git worktree prune` (does not touch any other worktree's files). |
+| `alert-branch` / `alert-dirty` / `alert-branch-dirty` (canonical only) | The canonical checkout itself has drifted off the default branch and/or gone dirty — the #47 poisoning class | Reconcile manually to the default branch; see `docs/role-separation.md`. |
+| `violation-unexpected-git` (deploy target) | A non-`git-pull` deploy target unexpectedly contains a `.git` directory | Investigate manually; do not delete `.git` automatically. |
+
+`classify_deploy_target` trusts `services.json`'s declared `deploy_mode` as the
+intended contract, not something it infers from the filesystem. If a
+component is genuinely meant to be a git-pull consumer, its registry entry
+must say `deploy_mode: "git-pull"` — flagging a `.git` directory under a
+component still declared `rsync` is the correct, intended alarm (it surfaces
+a registry/reality mismatch, whichever side is wrong), not a false positive.
+
+The audit is **read-only by construction**: nothing in
+`scripts/lib/worktree-hygiene.sh` or `scripts/worktree-hygiene-audit.sh`
+deletes a worktree, prunes, resets, or checks anything out. Every finding
+maps to a remediation *string* for a human or agent to run — consistent with
+the repo-wide git-safety rule that destroying uncommitted or untracked work
+is never automatic. If a destructive action is ever warranted (e.g. removing
+a confirmed-stale worktree), it is an explicit, opt-in, operator-run command
+— never something this tooling executes on your behalf.
+
+## Known heuristic limit
+
+`stale` is derived from `git merge-base --is-ancestor <branch> <base>`, which
+is also true when a branch's tip is *identical* to the base (a freshly cut
+branch with zero commits yet, or a fast-forward-merged branch that was never
+advanced further). A worktree created moments ago for a task that hasn't
+started committing yet can therefore show up as `stale` on its very first
+audit run. This is treated as an acceptable false-positive class rather than
+a bug: remediation is always manual and requires the operator to confirm
+"no unique unpushed work" before touching anything, so the cost of a
+premature `stale` flag is a no-op glance, never a lost commit. If this proves
+noisy in practice, a future refinement could suppress the flag for worktrees
+younger than some threshold (e.g. via the branch ref's reflog date) — not
+implemented here to keep the classifier pure and deterministic for tests.
+
+## What this does not cover
+
+- **Cross-host worktree state.** The audit inspects the local filesystem of
+  whatever host it runs on. A full cross-host inventory (e.g. auditing Hugin
+  dispatcher worktrees from the laptop) needs either running the audit on
+  each host or extending it with the same SSH pattern
+  `scripts/generate-architecture.sh` already uses for remote git-checkout
+  freshness (`remote_git_checkout_freshness`) — not implemented here to keep
+  this change read-only-and-local, matching how issue #47's checkout guard
+  itself runs from `huginmunin`.
+- **Stranded-but-complete branches with no local worktree at all** (a branch
+  that was pushed, has a completed PR, but was never checked out as a
+  worktree on this host) are outside worktree scope; that class is closer to
+  the "superseded with evidence" cleanup issue #87 also names, and is a
+  candidate for a separate branch-inventory check layered on top of this one.
+- **Force-deleting anything.** Explicitly out of scope per issue #87's
+  non-goals; this audit only ever reports.

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -362,6 +362,53 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     fi
   fi
 
+  # ─── Worktree hygiene audit (#87) ─────────────────────────
+  # Extends the canonical-checkout guard above (#47) to the full worktree
+  # lifecycle across every owned repo under $REPOS_DIR: stale worktrees
+  # (branch merged/gone but the tree remains), dirty worktrees holding
+  # uncommitted work, and orphaned/prunable worktree registrations. Read-only
+  # — see scripts/worktree-hygiene-audit.sh for the standalone CLI (with a
+  # deploy-target role check too) and docs/worktree-hygiene.md for the
+  # protocol and non-destructive remediation recipes.
+  # shellcheck source=scripts/lib/worktree-hygiene.sh
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/worktree-hygiene.sh"
+
+  WT_PASS=0
+  WT_FAIL=0
+  shopt -s nullglob
+  for wt_repo_dir in "$REPOS_DIR"/*/; do
+    wt_repo_dir="${wt_repo_dir%/}"
+    [[ -d "$wt_repo_dir/.git" ]] || continue
+    wt_repo_name="$(basename "$wt_repo_dir")"
+
+    while IFS='|' read -r wt_path wt_role wt_verdict wt_branch; do
+      [[ -n "$wt_path" ]] || continue
+      if [[ "$wt_role" == "canonical" ]]; then
+        if [[ "$(registry_checkout_is_alert "$wt_verdict")" == "yes" ]]; then
+          RESULTS+="❌ worktree:$wt_repo_name (canonical): $(registry_checkout_detail "$wt_verdict" "$REGISTRY_DEFAULT_BRANCH") ($wt_path)\n"
+          WT_FAIL=$((WT_FAIL + 1))
+        else
+          WT_PASS=$((WT_PASS + 1))
+        fi
+      else
+        if [[ "$(worktree_verdict_is_issue "$wt_verdict")" == "yes" ]]; then
+          RESULTS+="❌ worktree:$wt_repo_name (linked, branch=${wt_branch:-<detached>}): $(worktree_verdict_detail "$wt_verdict") ($wt_path)\n"
+          WT_FAIL=$((WT_FAIL + 1))
+        else
+          WT_PASS=$((WT_PASS + 1))
+        fi
+      fi
+    done < <(audit_repo_worktrees "$wt_repo_dir" "$REGISTRY_DEFAULT_BRANCH")
+  done
+  shopt -u nullglob
+
+  PASS=$((PASS + WT_PASS))
+  FAIL=$((FAIL + WT_FAIL))
+  if [[ "$WT_FAIL" -eq 0 ]]; then
+    RESULTS+="✅ worktree-hygiene: $WT_PASS worktree(s) clean across $REPOS_DIR\n"
+  fi
+
   # Print results
   echo -e "$RESULTS"
   echo ""

--- a/scripts/lib/worktree-hygiene.sh
+++ b/scripts/lib/worktree-hygiene.sh
@@ -1,0 +1,301 @@
+# shellcheck shell=bash
+# worktree-hygiene.sh — audit helpers for multi-agent worktree/deployment
+# hygiene (issue #87).
+#
+# Motivation: many agents/sessions operate concurrently across the same
+# repos/checkouts (grimnir's own house rule is one task = one subagent = one
+# dedicated worktree — see AGENTS.md). Left unaudited this leaves stale
+# worktrees (branch merged/gone but the tree remains), dirty worktrees holding
+# uncommitted work, orphaned/prunable worktree registrations, and deploy
+# targets that quietly become ad hoc git checkouts. This extends the
+# canonical-checkout guard from issue #47 (scripts/lib/registry-checkout.sh,
+# docs/role-separation.md) to the full worktree lifecycle across every owned
+# repo, and to a narrow deploy-target role check.
+#
+# Read-only. Nothing in this file mutates git state, deletes a worktree,
+# prunes, resets, or checks anything out. Every verdict maps to a suggested
+# remediation STRING for a human/agent to run manually — see
+# worktree_remediation(). Destructive actions are never automatic.
+#
+# ── Pure classifiers (no git, no filesystem) ──────────────────────────────
+#
+# classify_linked_worktree <dirty> <merged> <upstream_gone> <prunable>
+#   Verdict for a linked (non-canonical) worktree entry. Inputs are all
+#   "yes"/"no". Echoes one of: "prunable", "ok", "dirty", "stale",
+#   "dirty,stale". `prunable` short-circuits (a missing working directory
+#   can't be dirty-checked, so its presence alone is the whole verdict).
+#
+# worktree_verdict_is_issue <verdict>
+#   "no" for "ok", "yes" for everything else.
+#
+# worktree_verdict_detail <verdict>
+#   One-line human description of a linked-worktree verdict.
+#
+# worktree_remediation <verdict>
+#   Suggested NON-destructive, manual remediation recipe string for a
+#   verdict. Empty string for "ok". Never suggests an unconditional delete;
+#   `stale` and `prunable` recipes are still phrased as operator-run commands,
+#   not anything this code executes.
+#
+# classify_deploy_target <deploy_mode> <has_git_dir>
+#   A deploy target that is unexpectedly a git checkout is a role violation
+#   (docs/role-separation.md): an rsync deploy target should never itself
+#   contain a `.git` directory. Echoes "ok" or "violation-unexpected-git".
+#   git-pull deploy targets are SUPPOSED to be git checkouts, so `deploy_mode
+#   == "git-pull"` is always "ok" regardless of has_git_dir.
+#
+# deploy_target_is_alert <verdict>
+# deploy_target_detail <verdict>
+#   Same shape as the worktree helpers above, for classify_deploy_target.
+#
+# ── Gatherers (impure — read git/filesystem state, never mutate it) ───────
+#
+# list_repo_worktrees <repo_path>
+#   Parses `git worktree list --porcelain`. Emits one line per worktree:
+#   "<path>|<branch>|<prunable>" (branch is empty for a detached HEAD;
+#   prunable is "yes"/"no"). The FIRST line is always the repo's main
+#   worktree (git's own listing order), which callers treat as canonical.
+#
+# worktree_is_dirty <path>
+#   "yes"/"no"/"unknown" (path missing or not a readable git work tree).
+#
+# worktree_branch_merged <repo_path> <branch> <base_ref>
+# worktree_upstream_gone <repo_path> <branch>
+#   "yes"/"no" staleness signals for a linked worktree's branch.
+#
+# check_deploy_target_git_dir <path>
+#   "yes" if <path>/.git exists, else "no".
+#
+# audit_repo_worktrees <repo_path> <default_branch> [<base_ref>]
+#   Orchestrates the above across every worktree of one repo. Emits one line
+#   per worktree: "<path>|<role>|<verdict>|<branch>" where role is
+#   "canonical" (verdict from the shared registry-checkout classifier,
+#   scripts/lib/registry-checkout.sh — reused, not duplicated) or "linked"
+#   (verdict from classify_linked_worktree). base_ref defaults to
+#   default_branch; pass e.g. "origin/main" when it exists to catch
+#   merged-but-not-yet-pulled branches.
+#
+# Sourced by scripts/worktree-hygiene-audit.sh (standalone CLI),
+# scripts/generate-architecture.sh (--validate wiring), and
+# scripts/tests/worktree-hygiene.test.sh. bash 3.2+.
+
+WORKTREE_HYGIENE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/registry-checkout.sh
+# shellcheck disable=SC1091
+source "$WORKTREE_HYGIENE_LIB_DIR/registry-checkout.sh"
+
+classify_linked_worktree() {
+  local dirty="${1:-no}" merged="${2:-no}" upstream_gone="${3:-no}" prunable="${4:-no}"
+
+  if [[ "$prunable" == "yes" ]]; then
+    echo "prunable"
+    return 0
+  fi
+
+  local tags=""
+  [[ "$dirty" == "yes" ]] && tags+="dirty,"
+  if [[ "$merged" == "yes" || "$upstream_gone" == "yes" ]]; then
+    tags+="stale,"
+  fi
+  tags="${tags%,}"
+
+  if [[ -z "$tags" ]]; then
+    echo "ok"
+  else
+    echo "$tags"
+  fi
+}
+
+worktree_verdict_is_issue() {
+  if [[ "${1:-ok}" == "ok" ]]; then
+    echo "no"
+  else
+    echo "yes"
+  fi
+}
+
+worktree_verdict_detail() {
+  case "${1:-ok}" in
+    ok)          echo "active, clean" ;;
+    dirty)       echo "uncommitted changes present" ;;
+    stale)       echo "branch merged into base or its upstream is gone; worktree was not cleaned up" ;;
+    dirty,stale) echo "branch merged/gone AND uncommitted changes present — inspect before touching" ;;
+    prunable)    echo "administrative worktree entry present but its working directory is missing" ;;
+    *)           echo "unknown verdict: ${1:-}" ;;
+  esac
+}
+
+worktree_remediation() {
+  case "${1:-ok}" in
+    ok) echo "" ;;
+    dirty)
+      echo "Inspect first: git -C <path> status. Commit or 'git stash -u' the work, then re-run the audit. Never delete a dirty worktree automatically."
+      ;;
+    stale)
+      echo "After confirming there is no unique unpushed work: 'git worktree remove <path>' then 'git branch -d <branch>' — manual, operator-confirmed only."
+      ;;
+    dirty,stale)
+      echo "Branch is merged/gone but the tree is dirty. Preserve the work first (commit, 'git stash -u', or cherry-pick it), THEN 'git worktree remove <path>'. Never auto-delete."
+      ;;
+    prunable)
+      echo "Working directory is already gone; only the registration is stale. Safe to reconcile: 'git worktree prune' (does not touch any other worktree's files)."
+      ;;
+    *)
+      echo "Manual review required — unrecognized verdict."
+      ;;
+  esac
+}
+
+classify_deploy_target() {
+  local deploy_mode="${1:-rsync}" has_git_dir="${2:-no}"
+
+  if [[ "$deploy_mode" == "git-pull" ]]; then
+    echo "ok"
+  elif [[ "$has_git_dir" == "yes" ]]; then
+    echo "violation-unexpected-git"
+  else
+    echo "ok"
+  fi
+}
+
+deploy_target_is_alert() {
+  if [[ "${1:-ok}" == "ok" ]]; then
+    echo "no"
+  else
+    echo "yes"
+  fi
+}
+
+deploy_target_detail() {
+  case "${1:-ok}" in
+    ok)                        echo "deploy target matches its declared deploy_mode" ;;
+    violation-unexpected-git)  echo "deploy target unexpectedly contains a .git directory — it may be doubling as an ad hoc checkout (role violation, see docs/role-separation.md)" ;;
+    *)                         echo "unknown verdict: ${1:-}" ;;
+  esac
+}
+
+list_repo_worktrees() {
+  local repo_path="${1:-}"
+  [[ -n "$repo_path" ]] || return 0
+  # `|| true` on the git leg is deliberate: callers source this under
+  # `set -euo pipefail`, and a nonexistent/unreadable repo_path makes `git -C`
+  # exit non-zero. Under pipefail that becomes THIS function's return code,
+  # which would abort a caller that invokes it as a plain statement (not
+  # masked inside a `$(...)`/`<(...)` context). The contract for every
+  # gatherer in this file is "report an empty/absent finding, never abort the
+  # caller" (matching check_registry_checkout's documented behaviour in
+  # registry-checkout.sh) — a missing repo simply yields zero worktree rows.
+  { git -C "$repo_path" worktree list --porcelain 2>/dev/null || true; } | awk '
+    BEGIN { path = ""; branch = ""; prunable = "no" }
+    /^worktree / {
+      if (path != "") { print path "|" branch "|" prunable }
+      path = substr($0, 10)
+      branch = ""
+      prunable = "no"
+      next
+    }
+    /^branch / {
+      b = substr($0, 8)
+      sub(/^refs\/heads\//, "", b)
+      branch = b
+      next
+    }
+    /^detached/ { branch = ""; next }
+    /^prunable/ { prunable = "yes"; next }
+    END { if (path != "") print path "|" branch "|" prunable }
+  '
+}
+
+worktree_is_dirty() {
+  local path="${1:-}"
+  if [[ -z "$path" || ! -d "$path" ]]; then
+    echo "unknown"
+    return 0
+  fi
+  if ! git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "unknown"
+    return 0
+  fi
+  if [[ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+worktree_branch_merged() {
+  local repo_path="${1:-}" branch="${2:-}" base_ref="${3:-main}"
+  if [[ -z "$repo_path" || -z "$branch" ]]; then
+    echo "no"
+    return 0
+  fi
+  if git -C "$repo_path" merge-base --is-ancestor "$branch" "$base_ref" 2>/dev/null; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+worktree_upstream_gone() {
+  local repo_path="${1:-}" branch="${2:-}"
+  if [[ -z "$repo_path" || -z "$branch" ]]; then
+    echo "no"
+    return 0
+  fi
+  local track
+  track="$(git -C "$repo_path" for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null || true)"
+  if [[ "$track" == *"[gone]"* ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+check_deploy_target_git_dir() {
+  local path="${1:-}"
+  if [[ -n "$path" && -d "$path/.git" ]]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+
+audit_repo_worktrees() {
+  local repo_path="${1:-}" default_branch="${2:-main}" base_ref="${3:-}"
+  [[ -n "$base_ref" ]] || base_ref="$default_branch"
+  [[ -n "$repo_path" ]] || return 0
+
+  local rows
+  rows="$(list_repo_worktrees "$repo_path")"
+  [[ -n "$rows" ]] || return 0
+
+  local first=true
+  local w_path w_branch w_prunable
+  while IFS='|' read -r w_path w_branch w_prunable; do
+    [[ -n "$w_path" ]] || continue
+    if [[ "$first" == "true" ]]; then
+      first=false
+      local co_verdict
+      co_verdict="$(check_registry_checkout "$w_path" "$default_branch")"
+      echo "${w_path}|canonical|${co_verdict}|${w_branch}"
+    else
+      local verdict dirty merged gone
+      if [[ "$w_prunable" == "yes" ]]; then
+        verdict="prunable"
+      else
+        dirty="$(worktree_is_dirty "$w_path")"
+        if [[ "$dirty" == "unknown" ]]; then
+          # Directory vanished without git flagging the entry prunable yet
+          # (e.g. a race, or a manual rm). Never claim "ok" on unverifiable
+          # state — surface it the same way as a git-confirmed prunable entry.
+          verdict="prunable"
+        else
+          merged="$(worktree_branch_merged "$repo_path" "$w_branch" "$base_ref")"
+          gone="$(worktree_upstream_gone "$repo_path" "$w_branch")"
+          verdict="$(classify_linked_worktree "$dirty" "$merged" "$gone" no)"
+        fi
+      fi
+      echo "${w_path}|linked|${verdict}|${w_branch}"
+    fi
+  done <<< "$rows"
+}

--- a/scripts/tests/worktree-hygiene.test.sh
+++ b/scripts/tests/worktree-hygiene.test.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# worktree-hygiene.test.sh — unit + fixture tests for the worktree-hygiene
+# audit helpers (issue #87: audit and harden multi-agent worktree and
+# deployment hygiene).
+#
+# Mirrors the layered approach of registry-checkout.test.sh:
+#   1. Pure classifiers — exhaustive truth table, no git/filesystem.
+#   2. Gatherers — exercised against real fixture git repos (mktemp), so the
+#      git-plumbing wiring (worktree list --porcelain parsing, merge-base,
+#      upstream tracking) is proven end to end, never against live repos.
+#   3. The standalone CLI (scripts/worktree-hygiene-audit.sh) run against a
+#      constructed repos-root fixture, asserting it flags every seeded
+#      problem (stale, dirty, canonical-violation, deploy-drift), reports
+#      clean when clean, and never emits an auto-executed destructive action.
+#
+# Usage: bash scripts/tests/worktree-hygiene.test.sh
+# Exit codes: 0 = all assertions passed, 1 = at least one failed.
+# Compatible with bash 3.2+ (macOS default).
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(dirname "$TEST_DIR")"
+
+# shellcheck source=scripts/lib/worktree-hygiene.sh
+# shellcheck disable=SC1091
+source "$SCRIPTS_DIR/lib/worktree-hygiene.sh"
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — expected '$expected', got '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — expected to find '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — unexpectedly found '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "worktree-hygiene classify tests"
+echo "==============================="
+
+# ── classify_linked_worktree truth table ──────────────────────────────────
+assert_eq "clean, not merged, upstream ok, not prunable -> ok" \
+  "ok" "$(classify_linked_worktree no no no no)"
+assert_eq "dirty only -> dirty" \
+  "dirty" "$(classify_linked_worktree yes no no no)"
+assert_eq "merged only -> stale" \
+  "stale" "$(classify_linked_worktree no yes no no)"
+assert_eq "upstream gone only -> stale" \
+  "stale" "$(classify_linked_worktree no no yes no)"
+assert_eq "merged AND upstream gone -> stale (no duplicate tag)" \
+  "stale" "$(classify_linked_worktree no yes yes no)"
+assert_eq "dirty AND merged -> dirty,stale" \
+  "dirty,stale" "$(classify_linked_worktree yes yes no no)"
+assert_eq "prunable wins over dirty/merged inputs" \
+  "prunable" "$(classify_linked_worktree yes yes yes yes)"
+assert_eq "no-arg classify_linked_worktree -> ok (defensive default)" \
+  "ok" "$(classify_linked_worktree)"
+
+assert_eq "is_issue ok -> no"          "no"  "$(worktree_verdict_is_issue ok)"
+assert_eq "is_issue dirty -> yes"      "yes" "$(worktree_verdict_is_issue dirty)"
+assert_eq "is_issue stale -> yes"      "yes" "$(worktree_verdict_is_issue stale)"
+assert_eq "is_issue dirty,stale -> yes" "yes" "$(worktree_verdict_is_issue dirty,stale)"
+assert_eq "is_issue prunable -> yes"   "yes" "$(worktree_verdict_is_issue prunable)"
+assert_eq "no-arg is_issue -> no (defensive default 'ok')" \
+  "no" "$(worktree_verdict_is_issue)"
+
+assert_eq "detail ok"          "active, clean" "$(worktree_verdict_detail ok)"
+assert_eq "detail unknown verdict is explicit" \
+  "unknown verdict: weird" "$(worktree_verdict_detail weird)"
+
+# ── Remediation recipes must never suggest an unconditional/automatic delete ──
+for v in ok dirty stale dirty,stale prunable; do
+  recipe="$(worktree_remediation "$v")"
+  assert_not_contains "remediation($v) never says 'rm -rf'" "$recipe" "rm -rf"
+done
+assert_eq "remediation(ok) is empty" "" "$(worktree_remediation ok)"
+assert_contains "remediation(dirty) tells you to inspect, not delete" \
+  "$(worktree_remediation dirty)" "Never delete"
+assert_contains "remediation(stale) requires manual confirmation" \
+  "$(worktree_remediation stale)" "manual, operator-confirmed only"
+assert_contains "remediation(dirty,stale) says never auto-delete" \
+  "$(worktree_remediation dirty,stale)" "Never auto-delete"
+assert_contains "remediation(prunable) only touches the prunable entry" \
+  "$(worktree_remediation prunable)" "git worktree prune"
+
+# ── classify_deploy_target ────────────────────────────────────────────────
+assert_eq "git-pull mode + git dir present -> ok (expected)" \
+  "ok" "$(classify_deploy_target git-pull yes)"
+assert_eq "git-pull mode + no git dir -> ok" \
+  "ok" "$(classify_deploy_target git-pull no)"
+assert_eq "rsync mode + no git dir -> ok" \
+  "ok" "$(classify_deploy_target rsync no)"
+assert_eq "rsync mode + git dir present -> violation" \
+  "violation-unexpected-git" "$(classify_deploy_target rsync yes)"
+assert_eq "no-arg classify_deploy_target -> ok (defensive default)" \
+  "ok" "$(classify_deploy_target)"
+
+assert_eq "deploy_target_is_alert ok -> no" "no" "$(deploy_target_is_alert ok)"
+assert_eq "deploy_target_is_alert violation -> yes" \
+  "yes" "$(deploy_target_is_alert violation-unexpected-git)"
+assert_contains "deploy_target_detail violation references role-separation doc" \
+  "$(deploy_target_detail violation-unexpected-git)" "role-separation.md"
+
+echo ""
+echo "worktree-hygiene gatherer tests (real fixture repos)"
+echo "====================================================="
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mk_repo() {  # $1 = dir, $2 = branch
+  local dir="$1" branch="$2"
+  git init -q -b "$branch" "$dir"
+  echo "seed" > "$dir/file.txt"
+  git -C "$dir" add file.txt
+  GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t \
+  GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+    git -C "$dir" commit -q -m "seed"
+}
+
+# ── list_repo_worktrees ────────────────────────────────────────────────────
+mk_repo "$TMP_DIR/wt-repo" main
+git -C "$TMP_DIR/wt-repo" branch feature/done
+git -C "$TMP_DIR/wt-repo" worktree add -q "$TMP_DIR/wt-repo-linked" feature/done
+rows="$(list_repo_worktrees "$TMP_DIR/wt-repo")"
+assert_eq "list_repo_worktrees returns 2 rows" "2" "$(echo "$rows" | grep -c '.')"
+assert_contains "first row is the main worktree" "$(echo "$rows" | head -1)" "$TMP_DIR/wt-repo|main|no"
+assert_contains "second row is the linked worktree on feature/done" "$(echo "$rows" | tail -1)" "$TMP_DIR/wt-repo-linked|feature/done|no"
+assert_eq "list_repo_worktrees on non-repo path -> empty" "" "$(list_repo_worktrees "$TMP_DIR/does-not-exist")"
+assert_eq "list_repo_worktrees on empty path -> empty" "" "$(list_repo_worktrees "")"
+
+# Regression: list_repo_worktrees must never abort a `set -euo pipefail`
+# caller that invokes it as a PLAIN top-level statement (not masked inside a
+# `$(...)`/`<(...)` argument context, which swallows the subshell's own exit
+# code). `git -C <missing-path> worktree list` exits non-zero; under
+# pipefail that used to become this function's own return code and could
+# kill a caller like scripts/generate-architecture.sh's validate wiring.
+set +e
+plain_call_out="$(
+  set -euo pipefail
+  # shellcheck disable=SC1091
+  source "$SCRIPTS_DIR/lib/worktree-hygiene.sh"
+  list_repo_worktrees "$TMP_DIR/does-not-exist"
+  echo "survived"
+)"
+plain_call_rc=$?
+set -e
+assert_eq "list_repo_worktrees as a plain statement under set -euo pipefail does not abort" "0" "$plain_call_rc"
+assert_contains "plain-statement caller reaches the line after the call" "$plain_call_out" "survived"
+
+# ── worktree_is_dirty ──────────────────────────────────────────────────────
+assert_eq "clean linked worktree -> no" "no" "$(worktree_is_dirty "$TMP_DIR/wt-repo-linked")"
+echo "stray" > "$TMP_DIR/wt-repo-linked/leftover.tmp"
+assert_eq "dirty linked worktree -> yes" "yes" "$(worktree_is_dirty "$TMP_DIR/wt-repo-linked")"
+rm -f "$TMP_DIR/wt-repo-linked/leftover.tmp"
+assert_eq "missing path -> unknown" "unknown" "$(worktree_is_dirty "$TMP_DIR/nope")"
+assert_eq "no-arg worktree_is_dirty -> unknown" "unknown" "$(worktree_is_dirty)"
+
+# ── worktree_branch_merged / worktree_upstream_gone ───────────────────────
+git -C "$TMP_DIR/wt-repo" checkout -q main
+git -C "$TMP_DIR/wt-repo" merge -q --no-ff -m "merge feature/done" feature/done
+assert_eq "merged branch -> yes" "yes" \
+  "$(worktree_branch_merged "$TMP_DIR/wt-repo" feature/done main)"
+
+git -C "$TMP_DIR/wt-repo" branch feature/unmerged
+git -C "$TMP_DIR/wt-repo" worktree add -q "$TMP_DIR/wt-repo-unmerged" feature/unmerged
+echo "unique work" > "$TMP_DIR/wt-repo-unmerged/unique.txt"
+git -C "$TMP_DIR/wt-repo-unmerged" add unique.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/wt-repo-unmerged" commit -q -m "unique work"
+assert_eq "unmerged branch with unique commit -> no" "no" \
+  "$(worktree_branch_merged "$TMP_DIR/wt-repo" feature/unmerged main)"
+assert_eq "no-arg worktree_branch_merged -> no" "no" "$(worktree_branch_merged)"
+assert_eq "empty-branch worktree_branch_merged -> no" "no" \
+  "$(worktree_branch_merged "$TMP_DIR/wt-repo" "" main)"
+
+# upstream-gone: bare origin, clone, push a branch, delete it remotely, fetch --prune.
+git init -q --bare "$TMP_DIR/origin.git"
+git -C "$TMP_DIR/wt-repo" remote add origin "$TMP_DIR/origin.git"
+git -C "$TMP_DIR/wt-repo" push -q origin main
+git -C "$TMP_DIR/wt-repo" checkout -q -b feature/upstream-gone
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/wt-repo" commit -q --allow-empty -m "gone-branch commit"
+git -C "$TMP_DIR/wt-repo" push -q -u origin feature/upstream-gone
+git -C "$TMP_DIR/wt-repo" push -q origin --delete feature/upstream-gone
+git -C "$TMP_DIR/wt-repo" fetch -q --prune origin
+assert_eq "deleted-upstream branch -> yes (gone)" "yes" \
+  "$(worktree_upstream_gone "$TMP_DIR/wt-repo" feature/upstream-gone)"
+assert_eq "branch with no upstream at all -> no" "no" \
+  "$(worktree_upstream_gone "$TMP_DIR/wt-repo" feature/unmerged)"
+assert_eq "no-arg worktree_upstream_gone -> no" "no" "$(worktree_upstream_gone)"
+git -C "$TMP_DIR/wt-repo" checkout -q main
+
+# ── check_deploy_target_git_dir ────────────────────────────────────────────
+mkdir -p "$TMP_DIR/deploy-plain" "$TMP_DIR/deploy-git/.git"
+assert_eq "plain deploy dir -> no" "no" "$(check_deploy_target_git_dir "$TMP_DIR/deploy-plain")"
+assert_eq "deploy dir with .git -> yes" "yes" "$(check_deploy_target_git_dir "$TMP_DIR/deploy-git")"
+assert_eq "no-arg check_deploy_target_git_dir -> no" "no" "$(check_deploy_target_git_dir)"
+
+echo ""
+echo "audit_repo_worktrees end-to-end tests"
+echo "======================================"
+
+# Clean canonical + clean linked worktree -> both ok. The linked branch needs
+# a unique commit beyond main's tip: a branch cut but never advanced is
+# trivially "an ancestor of main" (merge-base --is-ancestor is true even when
+# branch == base), which the classifier correctly treats as safe-to-clean
+# ("stale") — see docs/worktree-hygiene.md's noted heuristic limit. This
+# fixture instead models the common "actively worked, not yet merged" case.
+mk_repo "$TMP_DIR/clean-repo" main
+git -C "$TMP_DIR/clean-repo" branch other
+git -C "$TMP_DIR/clean-repo" worktree add -q "$TMP_DIR/clean-repo-linked" other
+echo "in progress" > "$TMP_DIR/clean-repo-linked/wip.txt"
+git -C "$TMP_DIR/clean-repo-linked" add wip.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/clean-repo-linked" commit -q -m "unique in-progress work"
+audit_out="$(audit_repo_worktrees "$TMP_DIR/clean-repo" main)"
+assert_contains "clean repo: canonical row is ok" "$audit_out" "|canonical|ok|main"
+assert_contains "clean repo: linked row is ok" "$audit_out" "|linked|ok|other"
+
+# Canonical checkout dirty-on-nondefault-branch (role violation per #47).
+mk_repo "$TMP_DIR/violating-repo" main
+git -C "$TMP_DIR/violating-repo" checkout -q -b task/some-hugin-job
+echo "stray" > "$TMP_DIR/violating-repo/leftover.tmp"
+audit_out="$(audit_repo_worktrees "$TMP_DIR/violating-repo" main)"
+assert_contains "canonical dirty-on-nondefault -> alert-branch-dirty" "$audit_out" "|canonical|alert-branch-dirty|task/some-hugin-job"
+
+# Stale linked worktree: branch merged into main, worktree left behind, clean.
+mk_repo "$TMP_DIR/stale-repo" main
+git -C "$TMP_DIR/stale-repo" branch feature/merged
+git -C "$TMP_DIR/stale-repo" worktree add -q "$TMP_DIR/stale-repo-linked" feature/merged
+git -C "$TMP_DIR/stale-repo" merge -q --no-ff -m "merge" feature/merged
+audit_out="$(audit_repo_worktrees "$TMP_DIR/stale-repo" main)"
+assert_contains "merged-branch worktree flagged stale" "$audit_out" "|linked|stale|feature/merged"
+
+# Dirty linked worktree: unique committed work (so it's genuinely unmerged,
+# not the branch==base trivial-ancestor case) PLUS uncommitted scratch work.
+mk_repo "$TMP_DIR/dirty-repo" main
+git -C "$TMP_DIR/dirty-repo" branch feature/wip
+git -C "$TMP_DIR/dirty-repo" worktree add -q "$TMP_DIR/dirty-repo-linked" feature/wip
+echo "unique work" > "$TMP_DIR/dirty-repo-linked/committed.txt"
+git -C "$TMP_DIR/dirty-repo-linked" add committed.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/dirty-repo-linked" commit -q -m "unique work"
+echo "uncommitted" > "$TMP_DIR/dirty-repo-linked/scratch.txt"
+audit_out="$(audit_repo_worktrees "$TMP_DIR/dirty-repo" main)"
+assert_contains "uncommitted-work worktree flagged dirty" "$audit_out" "|linked|dirty|feature/wip"
+
+# Orphaned/prunable worktree registration: administrative entry survives after
+# the working directory itself is removed out from under git (never via
+# `git worktree remove` — this simulates the exact "orphaned" class in #87).
+mk_repo "$TMP_DIR/prunable-repo" main
+git -C "$TMP_DIR/prunable-repo" branch feature/gone-dir
+git -C "$TMP_DIR/prunable-repo" worktree add -q "$TMP_DIR/prunable-repo-linked" feature/gone-dir
+rm -rf "$TMP_DIR/prunable-repo-linked"
+audit_out="$(audit_repo_worktrees "$TMP_DIR/prunable-repo" main)"
+assert_contains "removed working dir flagged prunable" "$audit_out" "|linked|prunable|feature/gone-dir"
+
+# Non-repo path and empty path must not crash the orchestrator.
+assert_eq "audit_repo_worktrees on non-repo path -> empty" "" \
+  "$(audit_repo_worktrees "$TMP_DIR/does-not-exist" main)"
+assert_eq "audit_repo_worktrees with no args -> empty" "" \
+  "$(audit_repo_worktrees)"
+
+echo ""
+echo "worktree-hygiene-audit.sh CLI tests (fixture repos-root)"
+echo "========================================================="
+
+FIXTURE_ROOT="$TMP_DIR/repos-root"
+mkdir -p "$FIXTURE_ROOT"
+
+# Repo A: fully clean (canonical only, on main).
+mk_repo "$FIXTURE_ROOT/repo-a" main
+
+# Repo B: seeds a stale merged worktree AND a dirty worktree, canonical clean.
+mk_repo "$FIXTURE_ROOT/repo-b" main
+git -C "$FIXTURE_ROOT/repo-b" branch feature/merged-b
+git -C "$FIXTURE_ROOT/repo-b" worktree add -q "$TMP_DIR/repo-b-stale" feature/merged-b
+git -C "$FIXTURE_ROOT/repo-b" merge -q --no-ff -m "merge" feature/merged-b
+git -C "$FIXTURE_ROOT/repo-b" branch feature/wip-b
+git -C "$FIXTURE_ROOT/repo-b" worktree add -q "$TMP_DIR/repo-b-dirty" feature/wip-b
+echo "uncommitted" > "$TMP_DIR/repo-b-dirty/scratch.txt"
+
+# Repo C: canonical checkout itself is dirty AND off the default branch.
+mk_repo "$FIXTURE_ROOT/repo-c" main
+git -C "$FIXTURE_ROOT/repo-c" checkout -q -b task/stray-session
+echo "stray" > "$FIXTURE_ROOT/repo-c/leftover.tmp"
+
+# Deploy-target drift fixture: an rsync-mode component whose deploy path has
+# unexpectedly grown a .git directory.
+mkdir -p "$TMP_DIR/deploy-drift-target/.git"
+FIXTURE_SERVICES_JSON="$TMP_DIR/services.json"
+cat > "$FIXTURE_SERVICES_JSON" << EOF
+{
+  "components": [
+    {
+      "name": "fixture-component",
+      "repo": "fixture-component",
+      "host": null,
+      "port": null,
+      "deploy": true,
+      "scan": false,
+      "deploy_path": "$TMP_DIR/deploy-drift-target",
+      "deploy_mode": "rsync",
+      "needs_build": false,
+      "systemd_units": []
+    }
+  ]
+}
+EOF
+
+set +e
+dirty_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$FIXTURE_ROOT" GRIMNIR_SERVICES_JSON="$FIXTURE_SERVICES_JSON" \
+  "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
+dirty_rc=$?
+set -e
+
+assert_eq "CLI exits 1 when fixture has issues" "1" "$dirty_rc"
+assert_contains "CLI flags repo-b stale worktree" "$dirty_output" "repo-b"
+assert_contains "CLI flags repo-b dirty worktree" "$dirty_output" "dirty"
+assert_contains "CLI flags repo-c canonical violation" "$dirty_output" "repo-c"
+assert_contains "CLI flags the deploy-target .git drift" "$dirty_output" "fixture-component"
+assert_contains "CLI flags deploy-target role-separation reference" "$dirty_output" "role-separation.md"
+assert_not_contains "CLI output never instructs an unconditional delete" "$dirty_output" "rm -rf"
+assert_contains "CLI prints a summary line" "$dirty_output" "Summary:"
+
+# Clean-only fixture root: must report clean and exit 0.
+CLEAN_ROOT="$TMP_DIR/repos-root-clean"
+mkdir -p "$CLEAN_ROOT"
+mk_repo "$CLEAN_ROOT/repo-clean" main
+
+set +e
+clean_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$CLEAN_ROOT" GRIMNIR_SERVICES_JSON="$TMP_DIR/no-such-services.json" \
+  "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
+clean_rc=$?
+set -e
+
+assert_eq "CLI exits 0 on a fully clean fixture root" "0" "$clean_rc"
+assert_contains "CLI reports 0 issues on the clean fixture" "$clean_output" "0 issues"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/worktree-hygiene-audit.sh
+++ b/scripts/worktree-hygiene-audit.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# worktree-hygiene-audit.sh — Read-only audit of multi-agent worktree and
+# deployment hygiene across owned repos (issue #87).
+#
+# Extends the canonical-checkout guard from issue #47
+# (scripts/lib/registry-checkout.sh, docs/role-separation.md) to the full
+# worktree lifecycle. For every git repo directly under the scanned root it
+# reports:
+#   - a canonical checkout that is dirty or off its default branch (role
+#     violation per #47)
+#   - stale linked worktrees (branch merged into the default branch, or its
+#     upstream is gone) that were never cleaned up
+#   - dirty linked worktrees holding uncommitted work
+#   - orphaned/prunable worktree registrations (administrative entry present,
+#     working directory gone)
+# and, when a services registry is available, whether any declared rsync
+# deploy target has unexpectedly grown a `.git` directory (a deploy target
+# doubling as an ad hoc checkout).
+#
+# Read-only by design: this script NEVER deletes a worktree, prunes, resets,
+# or checks anything out. Every finding is reported with a specific,
+# non-destructive, operator-confirmed remediation recipe (see
+# scripts/lib/worktree-hygiene.sh: worktree_remediation()); nothing here is
+# applied automatically. See docs/worktree-hygiene.md for the protocol.
+#
+# Usage:
+#   scripts/worktree-hygiene-audit.sh [--repos-root DIR] [--default-branch BRANCH] [--services-json PATH]
+#
+# Env overrides (mirrors scripts/lib/registry-checkout.sh conventions):
+#   GRIMNIR_WORKTREE_AUDIT_ROOT   repos root to scan (default: $HOME/repos)
+#   GRIMNIR_DEFAULT_BRANCH        default branch name (default: main)
+#   GRIMNIR_SERVICES_JSON         services.json path for the deploy-target
+#                                 check (default: <this repo>/services.json)
+#
+# Exit code: 0 when nothing is flagged, 1 when at least one repo/worktree/
+# deploy target is an issue. A single unreadable repo is reported as a
+# finding, not a crash (set -euo pipefail is scoped to script-level errors,
+# never to a single repo's git state).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/worktree-hygiene.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/worktree-hygiene.sh"
+
+REPOS_ROOT="${GRIMNIR_WORKTREE_AUDIT_ROOT:-$HOME/repos}"
+DEFAULT_BRANCH="${GRIMNIR_DEFAULT_BRANCH:-main}"
+SERVICES_JSON="${GRIMNIR_SERVICES_JSON:-$SCRIPT_DIR/../services.json}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repos-root) REPOS_ROOT="$2"; shift 2 ;;
+    --default-branch) DEFAULT_BRANCH="$2"; shift 2 ;;
+    --services-json) SERVICES_JSON="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+PASS=0
+ISSUES=0
+OFFENDERS=""
+RECIPES=""
+
+echo "Worktree Hygiene Audit — root: $REPOS_ROOT (default branch: $DEFAULT_BRANCH)"
+echo "=============================================================="
+echo ""
+
+if [[ ! -d "$REPOS_ROOT" ]]; then
+  echo "❌ repos root not found: $REPOS_ROOT"
+  echo ""
+  echo "Summary: 0 ok, 1 issues"
+  exit 1
+fi
+
+shopt -s nullglob
+for repo_dir in "$REPOS_ROOT"/*/; do
+  repo_dir="${repo_dir%/}"
+  [[ -d "$repo_dir/.git" ]] || continue
+  repo_name="$(basename "$repo_dir")"
+
+  while IFS='|' read -r w_path w_role w_verdict w_branch; do
+    [[ -n "$w_path" ]] || continue
+    if [[ "$w_role" == "canonical" ]]; then
+      if [[ "$(registry_checkout_is_alert "$w_verdict")" == "yes" ]]; then
+        detail="$(registry_checkout_detail "$w_verdict" "$DEFAULT_BRANCH")"
+        OFFENDERS+="❌ $repo_name (canonical checkout, $w_path): $detail\n"
+        RECIPES+="  - $repo_name canonical checkout ($w_path): reconcile manually to $DEFAULT_BRANCH — 'git status' / 'git checkout $DEFAULT_BRANCH' / commit or stash, as appropriate. Never auto-fixed. See docs/role-separation.md.\n"
+        ISSUES=$((ISSUES + 1))
+      else
+        PASS=$((PASS + 1))
+      fi
+    else
+      if [[ "$(worktree_verdict_is_issue "$w_verdict")" == "yes" ]]; then
+        detail="$(worktree_verdict_detail "$w_verdict")"
+        branch_label="${w_branch:-<detached>}"
+        OFFENDERS+="❌ $repo_name (linked worktree, branch=$branch_label, $w_path): $detail\n"
+        recipe="$(worktree_remediation "$w_verdict")"
+        RECIPES+="  - $repo_name $w_path: $recipe\n"
+        ISSUES=$((ISSUES + 1))
+      else
+        PASS=$((PASS + 1))
+      fi
+    fi
+  done < <(audit_repo_worktrees "$repo_dir" "$DEFAULT_BRANCH")
+done
+shopt -u nullglob
+
+# Deploy-target role check (#47/#87): an rsync deploy target that has grown a
+# .git directory may be doubling as an ad hoc checkout. Only meaningful on the
+# host that actually owns the deploy path locally (a laptop checking a Pi's
+# /home/magnus/... path simply won't find the directory — reported as "not
+# found here", never as a false "clean").
+if [[ -f "$SERVICES_JSON" ]]; then
+  REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
+  while IFS='|' read -r v_name _v_host _v_port _v_repo v_deploy_path v_deploy_mode _v_units_json; do
+    [[ -n "$v_name" && -n "$v_deploy_path" ]] || continue
+    if [[ ! -d "$v_deploy_path" ]]; then
+      continue
+    fi
+    dt_git_dir="$(check_deploy_target_git_dir "$v_deploy_path")"
+    dt_verdict="$(classify_deploy_target "$v_deploy_mode" "$dt_git_dir")"
+    if [[ "$(deploy_target_is_alert "$dt_verdict")" == "yes" ]]; then
+      OFFENDERS+="❌ $v_name deploy target ($v_deploy_path): $(deploy_target_detail "$dt_verdict")\n"
+      RECIPES+="  - $v_name deploy target ($v_deploy_path): investigate manually why a .git directory exists on a $v_deploy_mode target; do not delete .git automatically. See docs/role-separation.md.\n"
+      ISSUES=$((ISSUES + 1))
+    else
+      PASS=$((PASS + 1))
+    fi
+  done < <(REGISTRY_PATH="$SERVICES_JSON" QUERY=validate node --input-type=commonjs "$REGISTRY_JS")
+fi
+
+if [[ -n "$OFFENDERS" ]]; then
+  echo "Offenders:"
+  echo -e "$OFFENDERS"
+  echo "Remediation recipes (manual, non-destructive — nothing here is auto-applied):"
+  echo -e "$RECIPES"
+fi
+
+echo "Summary: $PASS ok, $ISSUES issues"
+
+if [[ "$ISSUES" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Refs #87

## What

Extends the canonical-checkout guard from issue #47
(`scripts/lib/registry-checkout.sh`, `docs/role-separation.md`) to the full
worktree lifecycle across every owned repo, and adds a narrow deploy-target
role check:

- **`scripts/lib/worktree-hygiene.sh`** — pure classifiers (linked-worktree
  `ok`/`dirty`/`stale`/`dirty,stale`/`prunable`; deploy-target
  `ok`/`violation-unexpected-git`) plus read-only gatherers: a
  `git worktree list --porcelain` parser, a dirty check, merge/upstream-gone
  staleness signals, and a `.git`-directory check for deploy targets.
  Reuses `check_registry_checkout` from `registry-checkout.sh` for the
  canonical (main) worktree rather than duplicating that logic.
- **`scripts/worktree-hygiene-audit.sh`** — standalone CLI. Scans a repos
  root and reports: stale linked worktrees (branch merged into the default
  branch, or its upstream is gone), dirty worktrees holding uncommitted
  work, orphaned/prunable worktree registrations, a canonical checkout that
  is dirty or off its default branch, and (via `services.json`) an rsync
  deploy target that has unexpectedly grown a `.git` directory.
- **Wired into `scripts/generate-architecture.sh --validate`** (the existing
  `grimnir-validate` timer / harness from #47), folding into the same
  `PASS`/`FAIL` tally and Munin-persisted validation report.
- **`docs/worktree-hygiene.md`** — the hygiene protocol (one task = one
  worktree per the existing house rules, clean up after merge, canonical
  checkout stays clean on the default branch), how to run the audit, a
  verdict→remediation table, and a documented heuristic limitation.
- **`scripts/tests/worktree-hygiene.test.sh`** — 73 assertions, wired into
  `make test`.

## Design decisions

- **Read-only by construction, always.** Nothing in either script deletes a
  worktree, prunes, resets, or checks anything out. Every finding maps to a
  specific, non-destructive, operator-confirmed remediation *string*
  (`worktree_remediation()`); a stale/prunable/dirty finding is always
  reported, never auto-cleaned. This matches the repo-wide git-safety rule
  that destroying uncommitted/untracked work is never automatic.
- **Reuse over duplication.** The canonical-checkout verdict for the main
  worktree of every scanned repo is produced by the *existing*, already
  unit-tested `check_registry_checkout`/`registry_checkout_is_alert`/
  `registry_checkout_detail` from #47 — this PR only adds the *linked*
  worktree and deploy-target classifiers, and the orchestration that walks
  every repo's full worktree list.
- **Deterministic, fixture-driven tests.** Every assertion runs against
  constructed `mktemp -d` git repos (including a genuine "upstream branch
  deleted" case via a real bare origin + `fetch --prune`), never the real
  live repos — per the task's testability requirement.
- **Deploy-target check trusts the registry's declared intent.** A
  `deploy_mode: git-pull` component is *supposed* to be a git checkout, so
  it's always `ok` regardless of a `.git` directory; a non-`git-pull`
  target that has one is flagged as a role-separation violation to
  investigate, on the assumption `services.json`'s declared mode is the
  contract (a mismatch surfaces either a stale registry entry or an actual
  role violation — either way, worth a look).
- **Known accepted heuristic limit** (documented in
  `docs/worktree-hygiene.md`): `git merge-base --is-ancestor <branch>
  <base>` is trivially true when a branch's tip equals the base's tip (a
  freshly cut worktree with zero commits yet), so a brand-new worktree can
  transiently read `stale` on its first audit. Accepted rather than
  suppressed, because remediation is always manual — the cost of a
  premature flag is a no-op glance, never a lost commit.

## M5 dogfooding

Used `mcp__m5__ask` (qwen3-30b-instruct, `delegator_model_id:
anthropic/claude-sonnet-5`) for a bounded review of false-positive/
false-negative edge cases and shell safety in the two new scripts.

Verdict: **net useful, with real fabrication mixed in — verified every
claim before acting.**

- 2 of 6 findings were **fabricated**: it claimed `"$path"` and `"$branch"`
  were unquoted in `git -C`/`git merge-base` calls that are, on inspection,
  already correctly quoted.
- 1 finding was **real and fixed**: `list_repo_worktrees`'s
  `git ... | awk ...` pipeline could return git's non-zero exit status
  (e.g. missing `repo_path`) under `set -o pipefail`, which — while
  currently masked in this codebase's actual call sites by `$(...)`/`<(...)`
  argument contexts — would abort a `set -euo pipefail` caller if ever
  invoked as a plain top-level statement. Fixed with a defensive
  `|| true` on the git leg. Proved with a red/green regression test: it
  fails without the fix (rc 128, output missing) and passes with it.
- The remaining 3 findings were speculative/non-actionable (symlinked
  worktree paths, a hypothetical `check_registry_checkout`-on-symlink case,
  a "dual-purpose deploy target" scenario that turned out to be correct
  intended behavior, not a bug) — addressed with a short doc clarification
  rather than code changes.

## Verification

- `make test` — all suites green, exit 0 (`Results: 73 passed, 0 failed`
  for the new suite; no regressions elsewhere).
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh` — clean, no
  output.
- Ran `scripts/worktree-hygiene-audit.sh` against a constructed fixture
  seeding all four required categories (stale worktree, dirty worktree,
  canonical checkout dirty-on-nondefault-branch, deploy-target `.git`
  drift) — correctly flagged all four with `Summary: 2 ok, 4 issues` and
  exit code 1; ran again against a clean-only fixture — `Summary: 1 ok, 0
  issues`, exit code 0. Confirmed no remediation text ever suggests an
  unconditional/automatic delete (`rm -rf`, unconditional
  `git worktree remove`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)