### PR TITLE
chore: adopt 2026-07-13/-09 session artifacts left in the working tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@ Roadmap → tickets → implementation → review, with grimnir as the orchestra
 - `docs/roadmap-now-decision-brief.md` — Index of the adopted "now" decisions: succession (#65),
   GDPR/data lifecycle (#66), system ROI/off-ramp (#67), Skuld revive-or-cut (#69), interactive-session
   trust posture (#70), and the #58 Verdandi blocker
+- `docs/verdandi-purpose-reset-2026-07-13.md` — 2026-07-13 purpose-reset evidence note feeding
+  verdandi#21 and draft PR verdandi#22; not authorization to restart Verdandi
+- `docs/verdandi-user-stories-and-product-fit-2026-07-13.md` — 2026-07-13 user-stories and
+  product-fit evidence note feeding verdandi#21 and draft PR verdandi#22; not authorization to restart Verdandi
 - `docs/succession-checklist.md` — Public, non-secret export-and-shutdown checklist for the emergency
   delegate; private-envelope contents stay out of git
 - `docs/data-lifecycle.md` — Store-by-store retention, correction, erasure, and backup-expiry map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ Roadmap → tickets → implementation → review, with grimnir as the orchestra
 |--------|---------|----------|
 | `scripts/deploy.sh` | Deploy services to Pi hosts (all or selective) | `make deploy` or `make deploy ARGS="munin-memory"` |
 | `scripts/generate-architecture.sh` | Generate deployment snapshot + full-architecture.md | `make docs` (Pi only) |
+| `scripts/output-audit.py` | Audit owner+AI repository output over a date window | `python3 scripts/output-audit.py` (reads an untracked local identities config; see `scripts/output-audit-identities.example.json`) |
 | `scripts/security-scan.sh` | Scan all repos for vulnerabilities and secrets | `make security` |
 | `scripts/worktree-hygiene-audit.sh` | Read-only audit of stale/dirty/orphaned worktrees, canonical-checkout drift, and deploy-target role violations across owned repos | `scripts/worktree-hygiene-audit.sh` (also wired into `scripts/generate-architecture.sh --validate`); tests via `make test-worktree-hygiene` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,8 @@ Roadmap → tickets → implementation → review, with grimnir as the orchestra
 - `docs/autonomous-improvement-design.md` — Design v0.1 for removing the human approval step from
   the operating loop (owner decision 2026-07-20): reversibility axiom, mechanical promotion
   predicates, verifier-anchored auto-calibration, watchdog/auto-revert, protected lanes, tier ladder
+- `docs/vision-review-fable-2026-07-09.md` and `docs/vision-review-sol-2026-07-09.md` — Independent
+  Fable + Sol vision/priority reviews from 2026-07-09 that preceded the roadmap-now decisions
 - `docs/roadmap-now-decision-brief.md` — Index of the adopted "now" decisions: succession (#65),
   GDPR/data lifecycle (#66), system ROI/off-ramp (#67), Skuld revive-or-cut (#69), interactive-session
   trust posture (#70), and the #58 Verdandi blocker

--- a/debate/INDEX.md
+++ b/debate/INDEX.md
@@ -1,18 +1,19 @@
 # Debate Index
 
-| Date | Topic | Rounds | Key decision | Critique points | Self-review catch rate |
-|------|-------|--------|--------------|----------------|-----------------------|
-| 2026-03-28 | [Doc Architecture](doc-architecture-summary.md) | 2 | Fix authority map before adding layers; reduce 5 layers to evidence-driven approach | 13 | 2/13 (15%) |
-| 2026-03-28 | [Generator Refactor](generator-refactor-summary.md) | 2 | Reject sections/ dir; use existing architecture.md + snapshot.md concatenation | 10 | 2/10 (20%) |
-| 2026-03-28 | [Hugin Signals](hugin-signals-summary.md) | 2 | Reject Hugin-side analytics; add timeout calibration to Heimdall instead | 12 | 2/12 (17%) |
-| 2026-03-29 | [Syn Guardian](syn-guardian-summary.md) | 2 | Don't build a service; start with deterministic scan script in grimnir/scripts/ | 13 | 3/13 (23%) |
-| 2026-03-30 | [Seidr Architecture](seidr-architecture-summary.md) | 2 | Don't build Seidr yet; build one non-Claude worker first, then decide on abstraction | 12 | 3/12 (25%) |
-| 2026-03-30 | [Ollama Runtime](ollama-runtime-summary.md) | 2 | Extend Hugin with ollama executor; infra-only fallback; lazy host resolution; stream output | 13 | 3/13 (23%) |
-| 2026-03-31 | [Revenue Radar](revenue-radar-summary.md) | 2 | Reframe from market scanner to commercial follow-through layer; narrow v1 to Fortnox pulse + follow-up nudges | 15 | 3/15 (20%) |
-| 2026-03-31 | [Multi-User Grimnir](multi-user-grimnir-summary.md) | 2 | Narrow to "multi-principal Munin"; AccessContext in every tool; full cutover before onboarding Sara | 20 | 4/20 (20%) |
-| 2026-03-31 | [Scion vs Hugin](scion-vs-hugin-summary.md) | 2 | Run Scion Solo spike before building Hugin worker mode; "order of magnitude" complexity claim withdrawn | 9 | 3/9 (33%) |
-| 2026-03-31 | [Hugin Worker Mode](hugin-worker-summary.md) | 2 | Defer worker mode; optimize remote Ollama + make Hugin portable first; capability routing over machine names | 11 | 2/11 (18%) |
-| 2026-04-01 | [Service Registry](service-registry-summary.md) | 2 | Adopt services.json as sole machine authority; all components included; proper JS helper; conventions.md references registry | 8 | 2/8 (25%) |
-| 2026-04-01 | [Auto Ops](auto-ops-summary.md) | 2 | Drop hourly sync + standalone validator; add read-only host-aware --validate to generator; measure staleness before choosing cadence | 9 | 3/9 (33%) |
-| 2026-04-02 | [Hugin v2 Orchestrator](hugin-v2-orchestrator-summary.md) | 2 | Narrow to sequential bets; markdown compiles to typed IR; monotonic sensitivity; router opt-in only; defer templates/OpenRouter/eval routing | 15 | 5/15 (33%) |
-| 2026-04-09 | [Ecosystem Review](ecosystem-review-summary.md) | 2 | Write contract spec first; collapse 5 phases to 2+1; kill workspaces/knip/shared tooling; 3 contract tests not 1; heimdall adapter not translation; own the contracts explicitly | 15 | 5/15 (33%) |
+| Date | Topic | Reviewer | Rounds | Key decision | Critique points | Self-review catch rate |
+|------|-------|----------|--------|--------------|----------------|-----------------------|
+| 2026-03-28 | [Doc Architecture](doc-architecture-summary.md) | codex | 2 | Fix authority map before adding layers; reduce 5 layers to evidence-driven approach | 13 | 2/13 (15%) |
+| 2026-03-28 | [Generator Refactor](generator-refactor-summary.md) | codex | 2 | Reject sections/ dir; use existing architecture.md + snapshot.md concatenation | 10 | 2/10 (20%) |
+| 2026-03-28 | [Hugin Signals](hugin-signals-summary.md) | codex | 2 | Reject Hugin-side analytics; add timeout calibration to Heimdall instead | 12 | 2/12 (17%) |
+| 2026-03-29 | [Syn Guardian](syn-guardian-summary.md) | codex | 2 | Don't build a service; start with deterministic scan script in grimnir/scripts/ | 13 | 3/13 (23%) |
+| 2026-03-30 | [Seidr Architecture](seidr-architecture-summary.md) | codex | 2 | Don't build Seidr yet; build one non-Claude worker first, then decide on abstraction | 12 | 3/12 (25%) |
+| 2026-03-30 | [Ollama Runtime](ollama-runtime-summary.md) | codex | 2 | Extend Hugin with ollama executor; infra-only fallback; lazy host resolution; stream output | 13 | 3/13 (23%) |
+| 2026-03-31 | [Revenue Radar](revenue-radar-summary.md) | codex | 2 | Reframe from market scanner to commercial follow-through layer; narrow v1 to Fortnox pulse + follow-up nudges | 15 | 3/15 (20%) |
+| 2026-03-31 | [Multi-User Grimnir](multi-user-grimnir-summary.md) | codex | 2 | Narrow to "multi-principal Munin"; AccessContext in every tool; full cutover before onboarding Sara | 20 | 4/20 (20%) |
+| 2026-03-31 | [Scion vs Hugin](scion-vs-hugin-summary.md) | codex | 2 | Run Scion Solo spike before building Hugin worker mode; "order of magnitude" complexity claim withdrawn | 9 | 3/9 (33%) |
+| 2026-03-31 | [Hugin Worker Mode](hugin-worker-summary.md) | codex | 2 | Defer worker mode; optimize remote Ollama + make Hugin portable first; capability routing over machine names | 11 | 2/11 (18%) |
+| 2026-04-01 | [Service Registry](service-registry-summary.md) | codex | 2 | Adopt services.json as sole machine authority; all components included; proper JS helper; conventions.md references registry | 8 | 2/8 (25%) |
+| 2026-04-01 | [Auto Ops](auto-ops-summary.md) | codex | 2 | Drop hourly sync + standalone validator; add read-only host-aware --validate to generator; measure staleness before choosing cadence | 9 | 3/9 (33%) |
+| 2026-04-02 | [Hugin v2 Orchestrator](hugin-v2-orchestrator-summary.md) | codex | 2 | Narrow to sequential bets; markdown compiles to typed IR; monotonic sensitivity; router opt-in only; defer templates/OpenRouter/eval routing | 15 | 5/15 (33%) |
+| 2026-04-09 | [Ecosystem Review](ecosystem-review-summary.md) | codex | 2 | Write contract spec first; collapse 5 phases to 2+1; kill workspaces/knip/shared tooling; 3 contract tests not 1; heimdall adapter not translation; own the contracts explicitly | 15 | 5/15 (33%) |
+| 2026-07-13 | [Team Equivalent (6mo)](team-equivalent-6mo-summary.md) | codex | 2 | ~6 productive FTE (6–10 hired) to reproduce 6 months of output; scenario band 3–12; corpus frozen & reproducible, effort table still uncalibrated | 19 | 6/19 (32%) |

--- a/debate/team-equivalent-6mo-critique-log.json
+++ b/debate/team-equivalent-6mo-critique-log.json
@@ -1,0 +1,190 @@
+[
+  {
+    "id": "team-equivalent-6mo-C01",
+    "source": "codex-round-1",
+    "text": "The counterfactual is not well-posed. The draft oscillates between 'nobody would have built this' (asserting an invented 80% figure) and pricing full functional reproduction. Different readings change the answer by multiples.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "team-equivalent-6mo-C02",
+    "source": "codex-round-1",
+    "text": "'TantRagnar' is another human, so the 'Magnus+AI authored only' heading is invalidated and any component estimate anchored to those counts is void.",
+    "classification": "invalid",
+    "impact": "rejected",
+    "severity": "critical",
+    "caught_by_self_review": false,
+    "note": "REFUTED. 'TantRagnar' is Magnus's own former git identity (a personal address under a previous surname): 59/63 commits carry Co-Authored-By: Claude, repos are github.com/Magnus-Gille/*, identity switches to 'Magnus Gille' in Feb 2026 with the global git config, and the owner confirmed it in-session. Codex inferred a third party from a surname in an email without verifying, then called it decisive. It retracted fully in round 2. Measured non-Magnus contamination: 6 of 2,634 commits (0.2%)."
+  },
+  {
+    "id": "team-equivalent-6mo-C03",
+    "source": "codex-round-1",
+    "text": "The commit counts were never author-filtered: repos with zero Magnus commits were excluded, but every commit inside surviving repos was counted regardless of author.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "The underlying methodological point beneath the false C02. Real error; corrected via explicit identity-set classification. Aggregate impact turned out to be 0.2%."
+  },
+  {
+    "id": "team-equivalent-6mo-C04",
+    "source": "codex-round-1",
+    "text": "The '300-500k real code + docs' figure is a discretionary discount presented as a measurement, with no file-type rules or manifest.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "Measured instead of guessed. Final-state standing artifact: 670,879 lines (526,233 src + 144,646 docs). The original guess was ~40% low."
+  },
+  {
+    "id": "team-equivalent-6mo-C05",
+    "source": "codex-round-1",
+    "text": "The 8-FTE headline does not reconcile with the 29-45 PM table: 37 PM / 6 months = 6.2 FTE, and 8 FTE would supply 48 PM, above the table's own upper bound.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true,
+    "note": "The single change that actually moved the headline (8 -> 6). Conflated 'FTE of productive output' with 'heads you would hire'. Now stated with the utilization step shown."
+  },
+  {
+    "id": "team-equivalent-6mo-C06",
+    "source": "codex-round-1",
+    "text": "The 10-20x multiplier's denominator (Magnus's 0.3-0.5 FTE) is admitted to be unmeasured; the numeric claim should be removed.",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": true,
+    "note": "Diagnosis accepted, remedy rejected. Measured via commit-session clustering: 556h (512-608h) = ~0.5 FTE = 3.2 PM -> ~12x. Downgraded from 'measured' to 'hypothesis, likely conservative' after C13."
+  },
+  {
+    "id": "team-equivalent-6mo-C07",
+    "source": "codex-round-1",
+    "text": "There is no deliverable/deployment/acceptance ledger. Components are priced by what was built, not by what actually runs. Verdandi is dead (97k+ restarts) while other services are live with passing suites.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "critical",
+    "caught_by_self_review": false,
+    "note": "THE open gap. Not closed in this debate. Both sides agree it is the highest-value next step and that it likely moves the estimate DOWN."
+  },
+  {
+    "id": "team-equivalent-6mo-C08",
+    "source": "codex-round-1",
+    "text": "The 'honesty caveats' are performative: each names a real risk and then changes nothing. The headline and the narrow range survive them untouched.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "The sharpest meta-point in the debate. Became the standard the revision was held to: a caveat that does not move the number is decoration."
+  },
+  {
+    "id": "team-equivalent-6mo-C09",
+    "source": "codex-round-1",
+    "text": "The bottom-up PM table is activity-shaped judgment, not bottom-up estimation: no WBS, acceptance criteria, reference class, or independent estimator. Rejecting bad alternatives (LOC, COCOMO) is not evidence for the chosen numbers.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": true,
+    "note": "Stands unresolved. The 37 PM numerator never moved during the debate; only its conversion to FTE was corrected."
+  },
+  {
+    "id": "team-equivalent-6mo-C10",
+    "source": "codex-round-1",
+    "text": "Do not publish 8-FTE or 10-20x as findings; they are at most pre-audit priors pending a frozen dataset, completion ledger, WBS, blind two-estimator calibration, and prospective time-tracking.",
+    "classification": "partially_valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": true,
+    "note": "Codex softened in round 2 ('my round-1 wording was too categorical for the conversational stakes'). Cheap audit performed; full WBS rejected as disproportionate to a conversational question. Both sides converged on: quote the number, stamp it low-confidence, name the scenario."
+  },
+  {
+    "id": "team-equivalent-6mo-C11",
+    "source": "codex-round-2",
+    "text": "The LOC reverse cross-check is arithmetically wrong: at its own stated rates, 120-180k lines implies 60-180 person-months, not the 6-16 developer-months claimed. Off by an order of magnitude.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false,
+    "note": "The best catch of the debate. Verified: 120k/100 = 1,200 dev-days = 60 PM; 180k/50 = 3,600 dev-days = 180 PM. This was Claude's flagship self-criticism (the argument offered AGAINST its own headline) and it was broken. Withdrawn entirely. Correcting it removes the strongest support for the low-end scenario."
+  },
+  {
+    "id": "team-equivalent-6mo-C12",
+    "source": "codex-round-2",
+    "text": "The audit did not move the 37-PM numerator. The 8-to-6 change was the arithmetic correction demanded in round 1, not empirical calibration. Claiming 'the audit did that, not the argument' is misleading.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "Conceded outright. The audit validated the CORPUS (provenance, volume, authorship); it did not validate the EFFORT TABLE. Claude blurred the two and took credit for the reviewer's argument."
+  },
+  {
+    "id": "team-equivalent-6mo-C13",
+    "source": "codex-round-2",
+    "text": "'Active hours at keyboard' is an unsupported relabeling of commit-span time. In an agentic workflow, inter-commit gaps may be agent runtime, not human attention. The claimed 'roughly a wash' between over- and under-counting is asserted without evidence.",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "Accepted; 0.54 FTE downgraded from 'measured' to 'bounded activity estimate, factor-of-two uncertainty'. Claude's counter (the dominant bias - charging agent runtime to Magnus - makes the multiplier CONSERVATIVE, not merely uncertain) was not rebutted."
+  },
+  {
+    "id": "team-equivalent-6mo-C14",
+    "source": "codex-round-2",
+    "text": "Final-state LOC is temporally mismatched: 'current HEAD today' may include pre-window code and post-window changes, so it is not a six-month delta.",
+    "classification": "invalid",
+    "impact": "rejected",
+    "severity": "minor",
+    "caught_by_self_review": false,
+    "note": "REFUTED by measurement: all 44 repos in the corpus had their FIRST commit inside the window. There is no pre-window baseline to subtract; standing code is six-month output."
+  },
+  {
+    "id": "team-equivalent-6mo-C15",
+    "source": "codex-round-2",
+    "text": "Commit dedup does not imply tree dedup. Divergent duplicate checkouts (gille-inference/home-server-inference-evaluation, hugin/hugin-orchestrator) mean much of the standing artifact may be double-counted.",
+    "classification": "invalid",
+    "impact": "rejected",
+    "severity": "minor",
+    "caught_by_self_review": false,
+    "note": "REFUTED by measurement: blob-hashing every source/doc file across all 44 repos found 1,008 cross-repo duplicate lines (0.1%), not 'much'. hugin-orchestrator is a git WORKTREE (.git is a file) and was already excluded by construction. Real pair, already handled."
+  },
+  {
+    "id": "team-equivalent-6mo-C16",
+    "source": "codex-round-2",
+    "text": "The 'frozen evidence base' is not frozen: no per-repo HEAD SHAs, no identity set, no commands, no classification rules. And the Magnus commit total is internally inconsistent (2,477 in the corpus section vs 2,481 in the session analysis).",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "Fixed. Wrote one canonical script (scripts/output-audit.py) emitting debate/team-equivalent-6mo-manifest.json with every repo's HEAD SHA, identity sets, and dedup rules. Reconciled total: 2,481 Magnus commits."
+  },
+  {
+    "id": "team-equivalent-6mo-C17",
+    "source": "codex-round-2",
+    "text": "The hire range discards its own endpoints: 4.8-7.5 productive FTE at 75-80% utilization is 6-10 heads, not 7-9.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "team-equivalent-6mo-C18",
+    "source": "codex-round-2",
+    "text": "The session sensitivity endpoints (416-755h) do not follow the stated algorithm; holding lead-in fixed and varying only the gap yields ~512-608h.",
+    "classification": "partially_valid",
+    "impact": "changed",
+    "severity": "minor",
+    "caught_by_self_review": false,
+    "note": "Both computations are correct but measure different things: Claude co-varied gap AND lead-in (labeled as such); Codex varied only the gap. Codex's is the more honest single-parameter sensitivity - co-varying manufactures a wider band. Adopted 512-608h."
+  },
+  {
+    "id": "team-equivalent-6mo-C19",
+    "source": "codex-round-2",
+    "text": "Scenarios A/B/C are better separated but still not well-posed as estimands: each equivocates over what is supplied on day one, what may be substituted (OSS/SaaS), and what counts as done.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false,
+    "note": "Accepted as framing rather than calibrated intervals. Blocked on the same missing artifact as C07 (the acceptance ledger)."
+  }
+]

--- a/debate/team-equivalent-6mo-summary.md
+++ b/debate/team-equivalent-6mo-summary.md
@@ -1,0 +1,134 @@
+# Debate summary: How many humans would the last 6 months of output have taken?
+
+**Date:** 2026-07-13
+**Participants:** Claude (Fable 5) vs. Codex (`gpt-5.6-sol`, reasoning effort: high)
+**Rounds:** 2
+**Question:** For everything built 2026-01-12 → 2026-07-12, how many developers and other roles
+would be needed to produce the same output without AI?
+
+---
+
+## Final answer
+
+> **~6 full-time engineers' worth of productive output over six months** — which in practice means
+> **hiring 6–10 people**, because nobody runs at 100% utilization.
+>
+> Against a **measured ~0.5 FTE** of Magnus's own time. Order-of-magnitude labor multiplier
+> (~12×, treated as a hypothesis, not a measurement).
+>
+> This is a **low-confidence Scenario-B estimate**: reproduce the artifacts that exist, at
+> personal-project quality, with requirements handed over on day one. It is not a measurement.
+
+**The number depends on the question, and the honest band is 3–12:**
+
+| Scenario | The team is asked to… | FTE |
+|---|---|---|
+| **A — Outcome equivalence** | Deliver the same *useful outcomes* to one user: consolidate services, buy/reuse OSS, drop the dead experiments | **3–4** |
+| **B — Artifact reproduction** *(the literal question)* | Rebuild what actually exists, personal-grade, spec supplied free on day one | **~6** (6–10 hired) |
+| **C — Historical replay** | Start from January with no spec: discover, take the wrong turns, and *operate the fleet live* for 6 months | **10–12** |
+
+Composition at Scenario B: 4–5 engineers (one staff-level, one LLM-infra, one or two
+backend/full-stack, one embedded/DSP generalist), 1 DevOps/SRE, ~0.5 security, ~0.5 technical
+writer, ~0.5 PM, ~0.25–0.5 QA/eval, plus fractional research-analyst and ops/EA capacity for the
+non-repo output.
+
+## Measured corpus (frozen, reproducible)
+
+Re-derive with `scripts/output-audit.py`; every repo's HEAD SHA is pinned in
+`team-equivalent-6mo-manifest.json`.
+
+| | |
+|---|---|
+| Repos | **44** (all created *inside* the window) |
+| Commits | **2,634** — Magnus 2,481 · agents 137 · CI 10 · other humans 6 |
+| **Magnus+AI share** | **99.4%** |
+| Standing artifact | **670,879 lines** (526,233 source + 144,646 docs), vendored excluded, blob-deduped |
+| Magnus's own input | **~556 h** (512–608 h) ≈ **0.5 FTE** ≈ 3.2 person-months; 332 sessions, 145 active days of 182 |
+
+## What each side got wrong
+
+**Codex's decisive round-1 finding was false.** It claimed "TantRagnar" was a second human whose
+commits invalidated the Magnus+AI attribution — inferring a third party from a surname in an email
+address, without checking. Verification (Claude co-author trailers on 59/63 commits, repo
+ownership, the Feb 2026 git-config switch, and the owner's direct confirmation) established
+TantRagnar as Magnus's own former identity. Real non-Magnus contamination: **6 commits of 2,634
+(0.2%)**. Codex retracted in full in round 2 and named the failure precisely: *"I treated author
+metadata as conclusive while arguing that author metadata needed auditing."*
+
+**Claude's flagship self-criticism was arithmetically broken.** The LOC cross-check — offered as
+the strongest evidence *against* its own headline — was wrong by a factor of ten (120–180k lines at
+50–100 LOC/day is 60–180 person-months, not the "6–16 developer-months" claimed). Corrected, it
+doesn't support the low end at all; it points *above* the 37-PM table. Withdrawn entirely. The
+awkward consequence: removing Claude's best objection to its own number made that number **more**
+robust.
+
+**Claude also took credit for Codex's work.** The headline moved from 8 FTE to 6 because of
+Codex's arithmetic criticism (37 PM ÷ 6 months = 6.2), not because of Claude's git forensics. The
+line "the audit did that, not the argument" was self-flattering and false. The audit validated the
+*corpus*; it never validated the *effort table*.
+
+## Concessions accepted by both sides
+
+- The counterfactual was never fixed; the draft asserted "80% wouldn't have been built" (an
+  invented figure, withdrawn) and then priced full reproduction anyway. Now split into A/B/C.
+- The original counts were never author-filtered — repos were filtered, commits were not.
+- "300–500k real lines" was a guess. Measured: 670,879 (the guess was ~40% low).
+- 8 FTE never reconciled with a 37-PM table. It doesn't. It's 6.2.
+- The "Brooks's law" appeal was lazy — this portfolio is 44 near-independent repos, so coordination
+  overhead is *lower* than a normal 8-person team, an argument that cut against Claude's own number.
+- **Caveats that don't move the estimate are decoration.** Codex's sharpest point, and the standard
+  the revision was held to.
+
+## Unresolved (and where both sides agree the work is)
+
+**There is no deliverable/acceptance ledger.** Components are priced by what was *built*, not by
+what actually *runs*. Live state cuts both ways: Grimnir/Hugin/Heimdall have passing suites and
+verified deployments, while Verdandi is dead after a data-path failure and 97,000+ restarts. Until
+each of the 44 repos is tagged deployed / exercised / prototype / abandoned, the 37-PM numerator
+stays uncalibrated expert judgment. **Both sides expect that ledger to move the estimate down.**
+
+Also unresolved: the 37-PM table itself has no work-breakdown structure, no reference class, and no
+independent estimator. It never moved during the debate.
+
+## Verdict
+
+Both models converged on the same number and the same confidence level. Codex: *"About 6 productive
+FTE for six months to reconstruct the frozen, personal-grade functionality from supplied
+requirements — explicitly a low-confidence Scenario-B midpoint, not a measurement."* Claude agrees.
+
+**Do not quote "6 FTE" or "12×" stripped of the scenario label.** Round numbers become anchors and
+caveats get dropped in retelling.
+
+## Action items
+
+| # | Action | Owner |
+|---|---|---|
+| 1 | Build the deliverable/acceptance ledger: tag all 44 repos deployed / exercised / prototype / abandoned, then re-estimate the 37-PM numerator against it | grimnir |
+| 2 | Keep `scripts/output-audit.py` as the single source of truth for output-volume claims | grimnir |
+| 3 | Fix Verdandi (dead, 97k+ restarts) — it is both an operational bug and the clearest datapoint that "built" ≠ "works" | verdandi |
+
+## Files
+
+- `team-equivalent-6mo-claude-draft.md`
+- `team-equivalent-6mo-claude-self-review.md`
+- `team-equivalent-6mo-codex-critique.md` (round 1)
+- `team-equivalent-6mo-claude-response-1.md`
+- `team-equivalent-6mo-codex-rebuttal-1.md` (round 2)
+- `team-equivalent-6mo-claude-response-2.md` (final)
+- `team-equivalent-6mo-critique-log.json` (19 points)
+- `team-equivalent-6mo-manifest.json` (frozen corpus)
+- `scripts/output-audit.py` (canonical, reproducible)
+
+## Costs
+
+| Invocation | Wall-clock | Model |
+|---|---|---|
+| Codex R1 | ~6 min | gpt-5.6-sol (high effort) |
+| Codex R2 | ~7 min | gpt-5.6-sol (high effort) |
+
+## Scorecard
+
+19 critique points. **14 valid, 2 partially valid, 3 invalid.** Self-review caught 6 of 19 (32%) —
+its worst miss was the LOC arithmetic error, which it *originated*. Codex's two round-1 criticals
+included its single worst error (TantRagnar) and its single best (the FTE arithmetic). The
+cross-model gap paid for itself: neither model would have caught its own flagship mistake.

--- a/docs/verdandi-purpose-reset-2026-07-13.md
+++ b/docs/verdandi-purpose-reset-2026-07-13.md
@@ -1,0 +1,432 @@
+# Verdandi Purpose Reset — Landscape Research and Proposed ADR
+
+> **Status:** Proposed for owner review; not accepted and not an authorization to restart Verdandi.
+> **Date:** 2026-07-13
+> **Tracks:** [verdandi#21](https://github.com/Magnus-Gille/verdandi/issues/21)
+> **Decision boundary:** research and definition only. No deployment, new genesis, or integration is
+> authorized by this document.
+
+## Executive recommendation
+
+Retire Verdandi v1's purpose as a general log of agent activity, human decisions, tool calls, and
+reasoning. Do **not** replace it with an LLM-observability platform, SIEM, workflow engine, or generic
+audit-log product.
+
+Keep the Verdandi name and repo only for a schema-breaking, narrowly continued v2:
+
+> **Verdandi is Grimnir's append-only ledger of consequential action receipts. It binds an
+> authenticated actor and authority-bearing intent to an independently observed outcome, an
+> authoritative-system reference, and reversal evidence. Its purpose is to make autonomous changes
+> attributable, reviewable, and recoverable—not to record everything an agent did.**
+
+This is a conditional continuation, not a vote for another permanent service. A new genesis is
+warranted only after the minimum contract, two real mutation adapters, one consumer, independent
+anchoring, restore evidence, and owner acceptance all exist. If that proof is not worth building—or
+if the receipts are not used in an operating decision within two monthly reviews—retire Verdandi
+and remove it from the protected-pillar description.
+
+## Why the reset changes the answer
+
+The original system accumulated approximately 67,000 events, predominantly from one laptop Claude
+Code hook. The database is now lost by accepted owner decision. More important than the loss itself,
+the history had no material consumer, no external integrity anchor, incomplete actor identity, and
+classification gaps. It was high-volume evidence of collection, not evidence of accountability.
+
+The old design began with the question “how do we capture agent activity?” The useful question is:
+
+> **Which future decision becomes safer or possible because this record exists?**
+
+If no gate, alert, rollback, incident review, or trust decision consumes an entry, the entry should
+not exist. This follows Grimnir's current strategy directly:
+
+- **Sovereign Memory:** accountability evidence is worth owning when it protects the ability to let
+  replaceable tenants act on personal systems.
+- **Self-Knowing Inference:** execution quality and model competence belong in traces and the M5
+  capability ledger, not in Verdandi.
+- **Minimal surface:** a component earns its place only where it provides a non-replicable pillar
+  capability and has measured use.
+- **Instrument first, then decide:** a ledger that has no concrete consumer cannot show value merely
+  by growing.
+
+## First-principles requirements
+
+### Primary user and job
+
+The primary user is Magnus in two modes:
+
+1. **Before an autonomous mutation:** the substrate must know that a named tenant is authorized to
+   perform a bounded action and that a reversal/mitigation path exists.
+2. **After the mutation:** Magnus or an automated consumer must be able to establish what actually
+   changed, whether it matched the authorized intent, how the result was verified, and how to undo
+   or contain it.
+
+Secondary consumers are Hugin's mutation gate, Heimdall's exception view, rollback tooling, and a
+periodic autonomy/trust review. They consume structured receipts or exceptions, not raw sessions.
+
+### Authoritative role
+
+Verdandi is authoritative for one relationship:
+
+```text
+authority + intended effect -> observed effect + source reference + reversal evidence
+```
+
+It is **not** authoritative for the changed object itself. Git remains authoritative for code;
+Fortnox for accounting records; calendar/email providers for their objects; the filesystem/Mimir
+for files; Munin for current memory and project state; Hugin for task execution; OpenTelemetry-style
+traces for execution detail.
+
+Verdandi records a minimal cross-system receipt pointing to those authorities. It must not become a
+second copy of their content.
+
+### Unique value relative to existing records
+
+| Existing record | What it proves | What it does not prove |
+|---|---|---|
+| Munin state/log | Current remembered truth and chronological project decisions | Tamper-evident action receipts, external outcome, or pre-action authority |
+| Git/PR history | Exact code result, review, and merge metadata | Non-code actions or one cross-system identity/rollback contract |
+| Hugin task record | What work was dispatched and how execution ended | That an external mutation happened as claimed or remains in place |
+| Service logs / OTel traces | Execution path, errors, latency, model/tool behavior | Authorization, durable accountability, or authoritative result |
+| Provider audit/history | Domain-specific result | Why Grimnir acted, under whose delegated authority, or how to reverse it |
+
+Verdandi is justified only if it joins these otherwise separate facts without duplicating their
+payloads.
+
+## Current software landscape
+
+No current product provides the whole Grimnir requirement. The market has mature parts, but they
+solve different problems.
+
+| Category / examples | What is reusable | Why it is not the Verdandi answer |
+|---|---|---|
+| **AI observability:** [Arize Phoenix](https://arize.com/docs/phoenix/), [Langfuse](https://langfuse.com/pricing-self-host) | Self-hosted traces, sessions, evaluations, OTel ingestion, UIs | Optimizes and debugs model execution; does not establish authority, authoritative outcome, reversal, or tamper evidence. It overlaps Munin traces and the M5 ledger. |
+| **Telemetry standard:** [OpenTelemetry logs/events](https://opentelemetry.io/docs/specs/otel/logs/data-model/) | Stable log model, trace/span correlation, event naming; Collector ecosystem | Transport/schema interoperability, not an accountability or integrity system. Use `trace_id` correlation but do not store OTel traffic in Verdandi. |
+| **Application audit products:** [WorkOS Audit Logs](https://workos.com/docs/audit-logs), [Retraced](https://github.com/retracedhq/retraced) | Useful actor/action/target vocabulary, validation, search/export patterns | WorkOS is cloud-hosted; Retraced is a comparatively heavy application/Kubernetes/search stack. Both trust emitters and lack the intent→verified-outcome→reversal contract. |
+| **Managed tamper-proof audit:** [Pangea Secure Audit Log](https://pangea.cloud/docs/audit/overview/about) | Merkle membership/consistency proof and redaction patterns | Managed cloud conflicts with sovereignty and still does not decide selection, authority, or outcome semantics. |
+| **Authorization decision logs:** [OPA](https://www.openpolicyagent.org/docs/management-decision-logs), [Cerbos](https://docs.cerbos.dev/cerbos/latest/configuration/audit.html) | Decision IDs, server-side masking/drop rules, policy version and allow/deny lineage | Proves what a policy engine decided, not what the caller subsequently changed. Useful at Hugin's gate, insufficient as the action ledger. |
+| **Durable workflow:** [Temporal](https://docs.temporal.io/) | Ordered execution history, crash recovery, deterministic replay | Requires moving execution into its workflow runtime, duplicates Hugin/harness concerns, and does not cover direct tenants or external source truth. |
+| **Code intent/provenance:** [happi/warrant](https://github.com/happi/warrant) | Strong pattern: bind intent, exact code, and authorization when code becomes real; content digests and verification | Code/Git-specific, very young, and not a solution for files, messages, finance, keys, or arbitrary tenants. Adopt the semantic pattern, not the product as Grimnir's audit layer. |
+| **Signed supply-chain attestations:** [in-toto](https://in-toto.io/), DSSE/Sigstore | Standard signed statements about who performed which ordered software-supply-chain steps | Excellent envelope/signature ideas but supply-chain scoped; does not supply action selection, runtime identity, retention, or consumers. A custom DSSE predicate is an optional future envelope, not an MVP dependency. |
+| **Cryptographic data store:** [immudb](https://docs.immudb.io/master/immudb.html) | Append-only data, client verification, signed database states, external auditor model | Replaces storage but not semantics. Another database/service would add operational surface while existing SQLite append primitives are adequate at Grimnir volume. |
+| **Transparency log:** [Sigstore Rekor](https://docs.sigstore.dev/logging/overview/) | Inclusion/consistency proofs and independent witnesses | Optimized for public software-signing metadata. Public use leaks metadata; private operation is excessive for one owner. Borrow the independent-witness principle. |
+| **Workload identity:** [SPIFFE/SPIRE](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/), [step-ca](https://smallstep.com/docs/step-ca/) | Cryptographically verifiable workload credentials and rotation | Correct at larger scale but too much PKI/control-plane surface for the current fleet. Verdandi still needs a minimal tenant mint/revoke path even if a federation arrives later. |
+| **Tailnet ingress:** [Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve) | Keeps the service loopback-only while exposing HTTPS on the tailnet; adds user identity headers for user-originated requests | Solves reachability and some human identity, not process/tenant identity—tagged-device traffic does not get user headers. It is a candidate transport for the rewritten #15, not the identity model. |
+
+### Corrections to the April 2026 research
+
+The earlier 40+ framework survey remains useful, especially its findings on W3C PROV, data
+minimization, same-host trust, and external anchoring. Three assumptions should not carry forward:
+
+1. **Comprehensive chat/tool capture is not a unique requirement.** It proved to be the main source
+   of volume and privacy risk, while providing no material consumer value.
+2. **HumanLayer is no longer the open-source HITL building block described in April.** Its current
+   product is an AI coding platform; on-prem and audit logs are enterprise features, and the site
+   says the product itself is not yet open source.
+3. **A local hash chain is not an external anchor.** Verdandi's daily checkpoint currently writes a
+   local file and explicitly disclaims RFC 3161 backing. It detects accidental/local discontinuity
+   while the checkpoint survives; it does not defeat a Pi-1 compromise that can rewrite the database
+   and its local checkpoint. The Grimnir threat model correctly still calls this out.
+
+## Proposed v2 contract
+
+### Event-selection rule
+
+An action is ledger-worthy only when all three are true:
+
+1. It changes authoritative state, sends something externally, changes identity/security posture,
+   spends or commits money, deletes/restores data, or deploys/publishes executable behavior.
+2. It is performed by an agent/service under delegated authority, or it changes the Grimnir
+   substrate's own trust/continuity controls.
+3. A named consumer can block, alert, reverse, investigate, or update a trust decision from the
+   receipt.
+
+Human work performed directly in an authoritative system is not duplicated merely for completeness.
+If a human authorizes a tenant through Grimnir, the authorization is part of the receipt.
+
+### Must log
+
+| Example | Required evidence |
+|---|---|
+| Agent opens/pushes/merges a PR or deploys a revision | Intent/authority ref, repo + immutable commit/PR/deploy marker, observed result, `git_revert` recipe |
+| Agent changes production config, systemd state, ACL, credential, or key | Bounded target, pre-state snapshot/ref, observed post-state, rollback/ref or mitigation |
+| Agent creates/updates/deletes a calendar, ticket, file, memory entry, or external record | Stable source-system ref/digest, operation, observed result, reversal/snapshot |
+| Agent sends an email/message or performs another irreversible external action | Pre-action intent receipt, recipient/target pseudonymous ref, provider result ref, mitigation |
+| Agent performs a Fortnox write or other financially consequential mutation | Owner/policy authority, operation class, authoritative Fortnox ref, readback result, supported reversal/mitigation; never full financial payload |
+| Autonomous rollback, restore, or erasure | Original action ref, authority, stores affected, verified result, residual gaps |
+| Break-glass action while the ledger is impaired | Durable local gap receipt, named human authority, reason, later reconciliation outcome |
+
+### Must not log
+
+| Example | Correct home |
+|---|---|
+| LLM prompts, responses, chain-of-thought, chats, and every tool call | Ephemeral harness history or scoped OTel trace when needed |
+| Reads, searches, health checks, polling, model calls, token/cost detail | Service logs, Munin traces, M5 ledger, Heimdall metrics |
+| Hugin task start/complete with no consequential side effect | Hugin/Munin task record |
+| Draft documents/code before publication or authoritative commit | Workspace/git branch; no action receipt yet |
+| Full diffs, messages, invoices, calendar bodies, credentials, personal data payloads | Authoritative system only; Verdandi stores ref/digest/minimal summary |
+| Post-session “decision extraction” inferred by an LLM | Munin memory if useful, explicitly labeled as interpretation—not audit evidence |
+| Human actions performed directly in GitHub/Fortnox/etc. with no Grimnir delegation | The source system's own history unless a specific substrate-security rule requires a receipt |
+
+### Record shape
+
+The minimum model is two append-only records plus an exception record:
+
+- `action.intent` — accepted **before** a consequential autonomous mutation.
+- `action.outcome` — appended after independent readback from the authoritative system.
+- `action.gap` — appended/reconciled when an intent has no timely authoritative outcome, the receipt
+  path failed, or break-glass was used.
+
+Representative shape (names are illustrative; the accepted ADR should freeze the schema):
+
+```jsonc
+{
+  "schema": "grimnir.action-receipt.v1",
+  "kind": "action.intent",
+  "action_id": "019...",                // stable correlation id, not the content digest
+  "generation_id": "verdandi-receipts-1",
+  "actor_id": "tenant:codex-cli",       // server-derived from credential
+  "principal_id": "person:magnus",      // or named policy/grant
+  "authority_ref": "hugin:grant/...",
+  "action_class": "deployment.apply",
+  "target_ref": "service:hugin",
+  "expected_effect": "deploy commit <sha>",
+  "risk": "consequential",
+  "reversal": { "kind": "git_revert", "ref": "<sha-or-pr>" },
+  "trace_id": "...",                    // correlation only; trace is stored elsewhere
+  "privacy_class": "internal",
+  "retention_policy_ref": "grimnir:data-lifecycle/v1"
+}
+```
+
+```jsonc
+{
+  "schema": "grimnir.action-receipt.v1",
+  "kind": "action.outcome",
+  "action_id": "019...",
+  "observer_id": "adapter:grimnir-deploy", // not merely the acting tenant
+  "status": "succeeded",
+  "actual_effect": "production marker equals <sha>",
+  "authority_object_ref": "deploy:hugin/<sha>",
+  "authority_object_digest": "sha256:...",
+  "evidence": "authority_readback",
+  "intent_drift": "none",
+  "reversal_verified": true
+}
+```
+
+Key rules:
+
+- `actor_id` says which tenant attempted the action; `principal_id` says whose authority it used;
+  `observer_id` says who verified the outcome. Do not collapse them into `component`.
+- UUID/ULID-style `action_id` provides stable pre-action correlation. Each canonical record also has
+  a content digest, but content-addressing is not the business identifier.
+- An actor's self-reported success is `declared`, never `authority_readback`. It cannot improve the
+  tenant's trust score until an independent adapter observes the authoritative system.
+- Intent and outcome are separate immutable records. Corrections and reversals append new records;
+  no historical row is edited to make intent and reality agree.
+- Reversal evidence follows [`failure-recovery.md`](failure-recovery.md): `git_revert`, `snapshot`,
+  or `irreversible` with mitigation.
+
+### Consumers and actions
+
+| Consumer | Input | Concrete action |
+|---|---|---|
+| Hugin / mutation adapter | Accepted intent receipt | Permit mutation; deny an autonomous mutation lacking required receipt/reversal fields |
+| Outcome adapter | Provider/git/readback result | Append authoritative outcome; flag intent drift |
+| Heimdall | Open intent past TTL, failed/drifted outcome, gap, checkpoint/restore failure | One exception alert; no generic event dashboard |
+| Rollback tooling / operator CLI | Action + reversal records | Show or execute the named recovery recipe under separate authority |
+| Monthly trust/ROI review | Aggregates of authority-readback success, drift, rollback, and gaps | Keep/fix/cut tenant autonomy scopes; self-reports do not count |
+| Incident review | Selected receipt chain + authoritative refs | Reconstruct who authorized what, what changed, and containment status |
+
+Skuld should not receive every receipt. It may summarize unresolved exceptions only after Heimdall's
+consumer proves useful.
+
+### Identity
+
+The immediate minimum is one revocable, scoped credential per tenant with `mint`, `list`, `rotate`,
+and `revoke`; the server derives `actor_id` from the credential. Tailscale Serve is a good candidate
+for tailnet-only HTTPS reachability while the backend stays on localhost, but its user headers do not
+replace tenant identity.
+
+At this scale, bearer credentials provide authenticated attribution, not strong non-repudiation.
+The accepted design must say so. SPIFFE/SPIRE or a private CA should be adopted only if the broader
+Grimnir identity spine chooses them; Verdandi should not create a fleet PKI by itself.
+
+### Failure semantics
+
+The old blanket “fail-open for operations, fail-loud for audit” rule is too weak for autonomous
+mutations. It contradicts the thesis that any tenant can **safely** act through the substrate.
+
+- **Autonomous consequential mutation:** fail closed before mutation if an intent receipt cannot be
+  durably accepted or no reversal/mitigation is present.
+- **Outcome write after an already executed mutation:** persist to a durable local outbox, mark the
+  task incomplete/degraded, and alert until authoritative readback is reconciled. Do not pretend the
+  action failed merely because the receipt path failed.
+- **Read-only, draft, telemetry, or diagnostic work:** Verdandi is not on the path and cannot block it.
+- **Human break-glass/recovery:** may proceed when delay is riskier, but must create a durable local
+  gap receipt and an alert for later reconciliation.
+
+This makes audit availability part of the autonomy safety boundary without making it a dependency
+for ordinary work.
+
+### Privacy, retention, erasure, and continuity
+
+- **Minimize by schema, not regex alone.** Free-form payloads are rejected. Receipts contain stable
+  internal refs, small controlled summaries, and digests; secrets and source content never enter the
+  ledger.
+- **Retention follows the explained action.** Keep a receipt at least as long as the authoritative
+  object/action it explains, using `docs/data-lifecycle.md`. Non-domain operational telemetry remains
+  outside Verdandi and follows the six-month default. No event-type prefix silently creates a legal
+  retention claim.
+- **Erasure remains honest.** Corrections are appended. If a minimal identifier must be erased, keep
+  only the non-identifying commitment and an erasure receipt, and narrow subsequent integrity claims;
+  never say an erased semantic record is still fully verifiable.
+- **Hash-chain verification is necessary but insufficient.** The chain head must be witnessed outside
+  Verdandi's host and outside the writer's rewrite authority. A one-way append-only target on a second
+  Grimnir host preserves sovereignty; a public TSA/transparency service is optional only after an
+  explicit metadata-leakage decision.
+- **Recovery must be tested.** A regular export plus restore verification is a new-genesis gate, not
+  a post-launch backlog item.
+
+## Build, reuse, or retire
+
+### Option A — retire Verdandi and rely on existing authorities
+
+**Advantages:** smallest surface; no new privacy store; source histories already prove many outcomes.
+
+**Failure:** no uniform pre-action authority, tenant identity, independent outcome, and reversal link
+across code, files, communications, finance, and infrastructure. The tenant contract and Phase 3/4
+autonomy would lose a checkable accountability seam.
+
+**Verdict:** viable if Grimnir declines consequential autonomy. Not the current strategy's best fit.
+
+### Option B — replace Verdandi with an off-the-shelf product
+
+**Advantages:** mature storage, search, UIs, or cryptographic proofs depending on product.
+
+**Failure:** every candidate solves a lower layer or adjacent job. The cloud products violate
+sovereignty; the self-hosted audit/search stacks are too heavy; cryptographic stores do not supply
+selection/identity/outcome semantics; AI observability duplicates existing systems.
+
+**Verdict:** reject a whole-product replacement. Reuse standards and patterns selectively.
+
+### Option C — narrow continuation in the existing repo
+
+Keep the useful primitives: Fastify/SQLite scale, server-side identity derivation, canonicalization,
+single-writer atomic append, idempotency, authenticated reads, generation manifests, verification,
+and checkpoint machinery. Replace the v1 schema and delete the generic capture surfaces:
+
+- Claude Code hook and universal tool telemetry;
+- session details and encrypted raw/debug layers;
+- generic accounting/email/calendar/file/memory/task/Telegram taxonomy;
+- automatic severity→retention assumptions;
+- rubber-stamp/dwell-time analysis;
+- post-session decision extraction and generic dashboard ambitions.
+
+Add only the action-receipt schema, tenant lifecycle, authoritative outcome adapters, independent
+anchor, durable outbox, restore proof, and exception query.
+
+**Verdict: recommended**, subject to the stop conditions below.
+
+## New-genesis decision and activation gates
+
+### Decision
+
+**No new genesis now.** A new genesis is conditionally warranted after owner acceptance and the
+activation gates pass. It would be a new product generation, not restoration or continuation.
+
+The generation manifest must permanently disclose:
+
+- predecessor: legacy Verdandi v1;
+- predecessor continuity: `none`;
+- incident: legacy database deleted 2026-07-13; physical recovery declined;
+- approximate lost history: 67,000 events, never represented as an exact verified count;
+- schema/purpose discontinuity: generic activity events replaced by action receipts;
+- first v2 chain head and independently witnessed checkpoint.
+
+### Gates before activation
+
+1. Owner explicitly accepts the purpose, scope, non-goals, and failure semantics.
+2. The schema has fixtures proving every `must log` class and rejecting every `must not log` class.
+3. Tenant identity has mint/list/rotate/revoke and server-derived actor tests.
+4. Tailnet-only off-Pi intake works without exposing the service publicly.
+5. Two real adapters pass end to end, one of them a non-Claude tenant and one independently reading
+   an authoritative outcome. Dry-run/sandbox fixtures may be used for financial paths.
+6. Hugin or another mutation gate demonstrably fails closed before an unaudited autonomous mutation.
+7. Heimdall or an operator CLI consumes stale/failed/drifted receipts and causes a concrete action.
+8. A checkpoint is witnessed across an independent trust boundary; a full export/restore test passes.
+9. Retention and erasure behavior is tested on the v2 schema.
+10. `services.json`, the architecture, tenant contract, failure-recovery convention, threat model,
+    and data-lifecycle map are updated together before deployment.
+
+### Stop conditions after activation
+
+Retire Verdandi if any of these remains true for two consecutive monthly reviews:
+
+- no operating decision, rollback, denied mutation, or incident review consumed a receipt;
+- most outcomes remain actor-declared rather than independently observed;
+- integrations drift back to tool/session telemetry;
+- the service costs more operator time than the autonomous actions it protects;
+- source-system records plus Hugin provenance answer every real query without the cross-system link.
+
+## Existing issue disposition
+
+| Issue | Disposition | Rationale / replacement scope |
+|---|---|---|
+| [#1 Phase 2 integrations and rubber-stamp detection](https://github.com/Magnus-Gille/verdandi/issues/1) | **Supersede and close** | Drop rubber-stamp scoring, generic Hugin lifecycle and Telegram receipt telemetry. Refile narrow adapters for consequential Hugin/noxctl/Ratatoskr mutations, durable outbox, and scoped read/write identity only after ADR acceptance. |
+| [#2 Phase 3 GDPR compliance](https://github.com/Magnus-Gille/verdandi/issues/2) | **Rewrite** | Retain data minimization, tested retention/erasure, and independent anchoring. Drop the preselected pseudonym-key DB and RFC 3161 implementation as foregone conclusions. Schema-level exclusion is the first privacy control. |
+| [#3 Phase 4 dashboard and analysis integrations](https://github.com/Magnus-Gille/verdandi/issues/3) | **Supersede and close** | No generic widget, cross-session analysis, or post-session extraction. Create only an exception consumer for stale/failed/drifted/gap receipts after v2 evidence exists. |
+| [#5 warrant-inspired rebuild](https://github.com/Magnus-Gille/verdandi/issues/5) | **Supersede and close** | Adopt intent/outcome separation, final-state evidence, and content digests. Reject universal intent refs, content hash as the action identifier, `.verdandi/` per-repo stores, leases, and a code-only model as Verdandi's architecture. |
+| [#15 off-Pi intake and per-tenant identity](https://github.com/Magnus-Gille/verdandi/issues/15) | **Retain but rewrite** | Still a real blocker. Narrow it to tailnet-only receipt intake plus mint/list/rotate/revoke or federated identity, and update tenant-contract language from “every consequential action event” to the accepted receipt contract. Tailscale Serve is a candidate transport, not the identity solution. |
+
+One extra finding should be carried into #21 even though it is not in the requested disposition list:
+issue #16 was closed after local recurring checkpoints landed, but the current implementation and
+threat model both show that **independent** anchoring is still absent. Treat an off-host witness as an
+unresolved activation requirement; do not reopen or edit the closed issue without owner direction.
+
+## Explicit non-goals
+
+- Full chat, reasoning, prompt, tool-call, or session capture.
+- A replacement for Munin, Mimir, Git, Hugin history, service logs, OTel, or provider records.
+- A general SIEM, event bus, workflow engine, policy engine, or LLM-evaluation platform.
+- Proving that a client statement is true merely because it was authenticated and hash-chained.
+- Storing source payloads “for later analysis.”
+- A dashboard before a real exception consumer exists.
+- A Grimnir-specific PKI when the ecosystem identity spine has not selected one.
+- Restarting v1 or backfilling the lost chain.
+
+## Proposed owner decision
+
+Accept **Option C: narrow continuation**, with the definition and gates above. In the same decision:
+
+1. retire the v1 generic audit/telemetry purpose permanently;
+2. approve “consequential action receipt ledger” as Verdandi's sole purpose;
+3. require fail-closed pre-action receipts for autonomous consequential mutations;
+4. authorize contract/fixture work only—still no deployment or new genesis;
+5. apply the issue dispositions above;
+6. require a second owner review after the gates are evidenced and before genesis.
+
+If Magnus does not want audit availability on the autonomous-mutation critical path, select Option A
+and retire Verdandi. A fail-open generic log is not valuable enough to justify resurrection.
+
+## Primary sources consulted
+
+- [OpenTelemetry Logs Data Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/)
+- [Arize Phoenix documentation](https://arize.com/docs/phoenix/)
+- [Langfuse self-hosted feature matrix](https://langfuse.com/pricing-self-host)
+- [OPA Decision Logs](https://www.openpolicyagent.org/docs/management-decision-logs)
+- [Cerbos audit configuration](https://docs.cerbos.dev/cerbos/latest/configuration/audit.html)
+- [Temporal documentation](https://docs.temporal.io/)
+- [happi/warrant](https://github.com/happi/warrant)
+- [in-toto](https://in-toto.io/)
+- [immudb](https://docs.immudb.io/master/immudb.html)
+- [Sigstore Rekor](https://docs.sigstore.dev/logging/overview/)
+- [WorkOS Audit Logs](https://workos.com/docs/audit-logs)
+- [Retraced](https://github.com/retracedhq/retraced)
+- [Pangea Secure Audit Log](https://pangea.cloud/docs/audit/overview/about)
+- [SPIFFE concepts](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/)
+- [step-ca](https://smallstep.com/docs/step-ca/)
+- [Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve)
+
+The April 2026 internal landscape survey, architecture proposal, ingest/trust specification, and
+adversarial review in Mimir were also read. They remain historical inputs, not current authority.

--- a/docs/verdandi-user-stories-and-product-fit-2026-07-13.md
+++ b/docs/verdandi-user-stories-and-product-fit-2026-07-13.md
@@ -1,0 +1,385 @@
+# Verdandi Action Receipts — User Stories and Product Fit
+
+> **Status:** Candidate product brief for owner review; not an accepted backlog and not an
+> authorization to restart Verdandi.
+> **Date:** 2026-07-13
+> **Companion to:** [Verdandi Purpose Reset](verdandi-purpose-reset-2026-07-13.md)
+> **Tracks:** [verdandi#21](https://github.com/Magnus-Gille/verdandi/issues/21)
+
+## Product conclusion
+
+The reusable product should not primarily be “the Verdandi server.” It should be a small **Action
+Receipt Protocol** with SDK/middleware and authoritative-system adapters. Verdandi can be Grimnir's
+self-hosted reference ledger and verification service.
+
+That separation makes the idea fit naturally inside Hugin, noxctl, deployment tooling, SaaS admin
+planes, agent SDKs, and physical control systems without forcing each product to adopt Grimnir's
+database or UI:
+
+```text
+actor/agent
+    |
+    v
+product mutation boundary -- durable action.intent --> receipt ledger
+    |                                                    |
+    v                                                    v
+authoritative system ------- independent readback --> action.outcome
+    |                                                    |
+    +---------------- reversal / mitigation <------------+
+```
+
+The product's distinctive promise is:
+
+> Before an autonomous consequential action, record who is acting, under whose authority, what
+> effect is permitted, and how failure will be contained. Afterward, independently establish what
+> the authoritative system says happened and preserve enough evidence to investigate or reverse it.
+
+This is narrower than observability and stronger than an emitter-authored audit log. The mutation
+boundary—not the model loop—is the correct integration point.
+
+## Story conventions
+
+These are candidate stories, not implementation commitments.
+
+- **P0 — proof/activation:** required before a Verdandi v2 genesis or real autonomous mutation.
+- **P1 — operational value:** required before the system can justify remaining a permanent service.
+- **P2 — conditional expansion:** build only after observed usage establishes the need.
+
+“Authoritative readback” means a query to the source of truth after the attempted action. A success
+response from the acting tool is not, by itself, sufficient evidence. “Independent” means the
+outcome is emitted by a constrained adapter/observer rather than asserted by the LLM or tenant that
+requested the change.
+
+## Personas
+
+| Persona | Job |
+|---|---|
+| **Owner/operator** | Delegate useful autonomy without losing control, attribution, or recovery. |
+| **Acting tenant** | Know whether a mutation is allowed and leave a valid receipt without learning ledger internals. |
+| **Mutation-boundary integrator** | Add the control once around a product's write path rather than to every agent. |
+| **Outcome-adapter author** | Convert source-system readback into minimal, trustworthy outcome evidence. |
+| **Reviewer/incident responder** | See exceptions and reconstruct one consequential action quickly. |
+| **Privacy/data steward** | Minimize sensitive duplication and apply retention or erasure policy demonstrably. |
+
+## Candidate story bank — 64 stories
+
+### 1. Selection, authority, and pre-action control
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-SEL-01 | P0 | As a mutation-boundary integrator, I want a deterministic rule for whether an operation is consequential so that reads and harmless drafts bypass the ledger. | Shared fixtures classify representative operations consistently; ordinary reads work while Verdandi is unavailable. |
+| AR-SEL-02 | P0 | As an acting tenant, I want the gate to durably accept `action.intent` before execution so that the authorization record cannot be invented afterward. | A test proves no provider write occurs when intent persistence fails. |
+| AR-SEL-03 | P0 | As an owner, I want every intent bounded by action class, target, and expected effect so that a vague approval cannot authorize an arbitrary change. | The schema rejects missing or wildcard bounds outside explicit policy. |
+| AR-SEL-04 | P0 | As an owner, I want the receipt to name both actor and principal/authority so that “which agent acted?” and “on whose authority?” have separate answers. | Both identities appear in the stored intent and are server-derived or grant-backed. |
+| AR-SEL-05 | P0 | As an owner, I want a reversal recipe or explicit irreversible-action mitigation before execution so that “undo” is considered before risk is taken. | Consequential actions lacking either are rejected; irreversible examples require a named mitigation. |
+| AR-SEL-06 | P1 | As an owner, I want human approval references attached to the exact bounded intent so that approval for one object cannot be replayed for another. | Changing the target/effect invalidates the approval digest or grant. |
+| AR-SEL-07 | P1 | As a product integrator, I want policy to distinguish human-directed, policy-preapproved, and fully autonomous actions so that control strength matches delegated authority. | Fixtures demonstrate distinct authority modes and review requirements. |
+| AR-SEL-08 | P2 | As a product integrator, I want domain risk hints to assist selection so that well-described tools need less hand configuration. | Hints affect classification only after local policy validation and never serve as authorization or proof. |
+
+### 2. Authoritative outcome and drift
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-OUT-01 | P0 | As an owner, I want an observer distinct from the acting tenant to read back the result so that a tenant cannot certify its own claim. | Outcome identity is adapter-scoped and a tenant credential cannot emit it. |
+| AR-OUT-02 | P0 | As a reviewer, I want the receipt to point to the stable source-system object or revision so that I can inspect the authority rather than trust copied prose. | The outcome contains a resolvable immutable reference or a documented stable identifier. |
+| AR-OUT-03 | P0 | As a reviewer, I want expected and actual effects compared into a small drift vocabulary so that mismatches are machine-actionable. | At least `none`, `partial`, `unexpected`, `unverifiable`, and `missing` are covered by fixtures. |
+| AR-OUT-04 | P0 | As an operator, I want intents without timely outcomes to become gaps so that silence cannot look like success. | A deterministic timeout creates an alertable `action.gap`. |
+| AR-OUT-05 | P0 | As an integrator, I want idempotent correlation across retries so that network retries do not create multiple authorized actions. | Reusing an idempotency key returns the same action; conflicting payloads are rejected. |
+| AR-OUT-06 | P1 | As an adapter author, I want to attach a digest of the authoritative post-state without copying it so that later drift can be checked privately. | Canonicalization and digest fixtures pass across equivalent provider responses. |
+| AR-OUT-07 | P1 | As an operator, I want asynchronous providers reconciled later so that queued writes are neither prematurely successful nor permanently ambiguous. | A pending outcome can become succeeded/failed only through adapter readback, with history preserved. |
+| AR-OUT-08 | P2 | As a reviewer, I want multi-target actions decomposed into per-target effects so that partial batch success is visible and recoverable. | A batch fixture reports exact successful, failed, and unknown targets without duplicating payloads. |
+
+### 3. Reversal, mitigation, and incident recovery
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-REC-01 | P0 | As an incident responder, I want the intent, outcome, authority, and reversal evidence for one action in one view so that reconstruction takes minutes, not log archaeology. | An action-ID query returns the linked receipt chain and source references. |
+| AR-REC-02 | P0 | As an owner, I want reversal recipes to use a small validated vocabulary so that free-text “undo this” is not mistaken for executable recovery. | `git_revert`, `snapshot_restore`, provider inverse, and `irreversible+mitigation` fixtures validate. |
+| AR-REC-03 | P0 | As an acting tenant, I want rollback itself to be a new consequential action linked to the original so that recovery remains attributable and reviewable. | A rollback produces its own intent/outcome pair and `reverses_action_id`. |
+| AR-REC-04 | P0 | As an operator, I want rollback success verified from the source of truth so that an executed command is not confused with restored state. | The original adapter confirms the restored revision/object state. |
+| AR-REC-05 | P1 | As an incident responder, I want irreversible actions to expose the promised mitigation so that I know the next containment step immediately. | A sent-message fixture shows provider reference plus correction/notification procedure, not a fake undo. |
+| AR-REC-06 | P1 | As a data steward, I want restore and erasure actions to report every affected store and any residual gap so that partial completion is explicit. | A multi-store test cannot report success while one required store remains unknown. |
+| AR-REC-07 | P1 | As an operator, I want to ask what consequential changes occurred since a trusted checkpoint so that incident scope can be bounded. | Query output is derived from verified receipt order and flags unanchored intervals. |
+| AR-REC-08 | P2 | As an incident responder, I want a portable evidence pack with verification instructions so that I can investigate while the live service is impaired. | Export verifies offline without exposing source payloads or credentials. |
+
+### 4. Tenant identity and delegated authority
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-ID-01 | P0 | As an owner, I want one credential per tenant so that Codex, Claude, Hugin, and a domain service cannot be conflated. | Mint/list/rotate/revoke works and two tenants produce distinct actor IDs. |
+| AR-ID-02 | P0 | As a reviewer, I want actor identity derived by the server from authentication so that callers cannot self-label as another tenant. | A spoofed `actor_id` is ignored or rejected. |
+| AR-ID-03 | P0 | As an owner, I want a tenant's credential scoped to allowed action classes and roles so that receipt access does not grant universal mutation authority. | Cross-scope intent and outcome attempts are denied. |
+| AR-ID-04 | P0 | As an owner, I want immediate revocation so that a compromised tenant cannot create new valid intents. | Revoked credentials fail while historical receipt verification remains intact. |
+| AR-ID-05 | P1 | As a reviewer, I want historical identity immutable across key rotation so that old receipts retain a stable actor while keys change safely. | Rotated keys map to the same tenant record with distinct validity intervals. |
+| AR-ID-06 | P1 | As an owner, I want principal authority separated from workload identity so that a service can act for Magnus, a policy, or another bounded grant without ambiguity. | Receipt fixtures distinguish `actor_id`, `principal_id`, and `authority_ref`. |
+| AR-ID-07 | P1 | As an adapter author, I want observer-only credentials so that readback components cannot authorize or perform mutations. | Observer credentials can append outcomes for allowed domains but cannot create intents. |
+| AR-ID-08 | P2 | As an operator, I want short-lived workload credentials when the fleet warrants them so that static-key exposure is bounded without changing receipt semantics. | A credential-provider conformance test works without requiring Verdandi to become a PKI. |
+
+### 5. Review, exception handling, and autonomy governance
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-REV-01 | P0 | As an operator, I want Heimdall to show only unresolved gaps, failures, drift, and integrity problems so that Verdandi creates decisions rather than another feed. | Normal successful receipts create no dashboard alert. |
+| AR-REV-02 | P0 | As an operator, I want stale intents ranked by risk and age so that the most dangerous ambiguity is handled first. | A deterministic view orders seeded gaps correctly. |
+| AR-REV-03 | P1 | As an owner, I want to inspect all evidence for one exception without searching raw service logs so that review is fast but source-linked. | One view links intent, outcome/gap, task/trace, authority object, and reversal. |
+| AR-REV-04 | P1 | As an owner, I want an exception resolved only by verified outcome, verified reversal, or an explicit accepted residual risk so that “dismiss” is not silent deletion. | Resolution produces an attributable append-only record. |
+| AR-REV-05 | P1 | As an owner, I want a monthly autonomy review by action class and tenant so that delegation can expand or contract from evidence. | Report shows counts, gaps, drift, reversals, and review decisions—not a synthetic trust score. |
+| AR-REV-06 | P1 | As a component owner, I want repeated failures grouped by adapter/action class so that systemic integration defects are distinguishable from tenant mistakes. | Seeded recurrence produces a consolidated issue candidate with supporting action IDs. |
+| AR-REV-07 | P2 | As an owner, I want policy-change proposals based on reviewed receipts so that evidence can improve autonomy without policy changing itself. | Suggestions require human acceptance and cite the exact receipt set. |
+| AR-REV-08 | P2 | As an auditor/reviewer, I want a redacted, scoped export so that I can evaluate a period or incident without broad ledger access. | Export obeys tenant, time, action-class, and privacy filters and remains verifiable. |
+
+### 6. Privacy, retention, and data lifecycle
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-PRV-01 | P0 | As a data steward, I want receipts to contain references, digests, and bounded summaries rather than prompts, messages, diffs, or records so that the ledger does not become a shadow data store. | Schema and redaction tests reject representative sensitive payload fields. |
+| AR-PRV-02 | P0 | As an integrator, I want conservative classification defaults so that omitted labels never make evidence less protected. | Unlabeled events receive the configured floor; callers cannot downgrade it. |
+| AR-PRV-03 | P0 | As an owner, I want secrets rejected before persistence so that hash chaining does not make accidental credentials harder to remove. | Seeded API keys, tokens, and credential fields never reach durable storage. |
+| AR-PRV-04 | P0 | As a data steward, I want retention selected by evidence class and action domain so that “append-only” does not silently mean “keep all personal metadata forever.” | Policy fixtures yield explicit expiry/retain behavior for each supported class. |
+| AR-PRV-05 | P1 | As a data subject/owner, I want approved erasure or crypto-shredding to leave a verifiable tombstone so that privacy obligations and chain continuity can coexist honestly. | Removed protected fields are unrecoverable; the tombstone states what category was erased and why. |
+| AR-PRV-06 | P1 | As a reviewer, I want access to receipt metadata separately authorized from source-object access so that a ledger link does not bypass the source system's controls. | A receipt reader cannot dereference a protected source without separate authorization. |
+| AR-PRV-07 | P1 | As a data steward, I want export and backup scopes to preserve classification so that moving evidence does not downgrade it. | Restored/exported fixtures retain policy labels and access checks. |
+| AR-PRV-08 | P2 | As an owner, I want measurable metadata-leakage checks before external anchoring so that integrity proofs do not reveal sensitive action timing or targets. | The anchor contains only approved aggregate/checkpoint material. |
+
+### 7. Integrity, continuity, and degraded operation
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-OPS-01 | P0 | As an operator, I want complete-chain verification so that corruption or discontinuity is detected before evidence is trusted. | A clean fixture passes; deletion, reordering, and mutation fixtures fail at the expected record. |
+| AR-OPS-02 | P0 | As an owner, I want checkpoints witnessed outside Verdandi's host so that a Pi compromise cannot rewrite both ledger and proof undetectably. | A verifier compares a restored ledger to an independently retained checkpoint. |
+| AR-OPS-03 | P0 | As an operator, I want backup restoration tested, not merely scheduled, so that evidence continuity is demonstrated after host loss. | A clean-room restore passes schema, chain, anchor, identity, and query checks. |
+| AR-OPS-04 | P0 | As an owner, I want consequential autonomous mutations to fail closed when intent or reversal evidence cannot be durably accepted so that audit impairment cannot silently increase autonomy risk. | Fault injection proves the provider is untouched. |
+| AR-OPS-05 | P0 | As an operator, I want a bounded break-glass path with a durable local gap receipt so that essential recovery is possible without pretending the ledger was healthy. | An outage drill records authority/reason locally and later reconciles it visibly. |
+| AR-OPS-06 | P1 | As an operator, I want health signals for intake, pending outcomes, anchor age, backup age, and verification without exposing receipt contents so that Heimdall can monitor the control plane safely. | Health contract and seeded alerts cover each failure mode. |
+| AR-OPS-07 | P1 | As an integrator, I want explicit generation and schema boundaries so that breaking changes cannot imply false continuity. | Mixed-generation verification reports the boundary and never chains across an unproved reset. |
+| AR-OPS-08 | P2 | As an operator, I want signed/offline verification tooling independent of the running API so that a compromised application cannot be its own sole verifier. | A small read-only verifier detects tampered database/export fixtures. |
+
+### 8. Developer experience and product integration
+
+| ID | Pri | User story | Acceptance evidence |
+|---|---:|---|---|
+| AR-DEV-01 | P0 | As an integrator, I want versioned JSON Schemas and positive/negative fixtures so that products can implement the contract without importing Verdandi internals. | CI validates at least two independent implementations against the same fixtures. |
+| AR-DEV-02 | P0 | As an integrator, I want a small TypeScript client/middleware API so that intent-before-write and outcome-after-readback are hard to order incorrectly. | Reference example demonstrates gate, provider call, observer readback, and failure paths. |
+| AR-DEV-03 | P0 | As an adapter author, I want actor and observer capabilities separated in the SDK so that integration convenience cannot collapse the trust boundary. | Compile/runtime tests reject outcome emission from actor-only clients. |
+| AR-DEV-04 | P0 | As a product owner, I want a conformance harness with a fake provider so that fail-closed, idempotency, drift, and reversal can be proved before live access. | The harness runs locally and makes no external mutation. |
+| AR-DEV-05 | P1 | As an MCP host integrator, I want tool annotations to seed risk classification so that `readOnly`, `destructive`, idempotency, and open-world hints are reusable without being trusted as proof. | Local policy overrides dishonest/missing annotations and defaults cautiously. |
+| AR-DEV-06 | P1 | As an observability integrator, I want optional trace correlation so that execution detail can be found without copying traces into receipts. | A receipt holds only `trace_id`/task reference and works when the trace has expired. |
+| AR-DEV-07 | P2 | As a platform integrator, I want an optional CloudEvents envelope so that existing brokers can transport receipts without changing receipt semantics. | Round-trip preserves the receipt schema; CloudEvents fields are not used as authority evidence. |
+| AR-DEV-08 | P2 | As a security integrator, I want optional signed-statement envelopes so that higher-risk deployments can add portable authenticity without making PKI mandatory for the Grimnir MVP. | Signature verification is layered over, not embedded into, business semantics. |
+
+## Anti-stories — explicitly not the product
+
+These requests should be rejected or routed elsewhere unless a later, named consumer changes the
+evidence:
+
+1. As a developer, I want every prompt, completion, and chain-of-thought in Verdandi so that I can
+   debug models. Use scoped traces/evaluations instead.
+2. As an operator, I want every tool call and read operation in Verdandi so that nothing is missed.
+   Use service logs or OpenTelemetry; volume is not accountability.
+3. As a product owner, I want Verdandi to be the universal source of truth. Source systems remain
+   authoritative; receipts point to them.
+4. As an analyst, I want complete email, invoice, file, calendar, or diff contents copied into the
+   ledger. Store a stable reference/digest and read the protected source when authorized.
+5. As an agent author, I want the LLM to decide whether its own action succeeded. A constrained
+   observer must perform authoritative readback.
+6. As an integrator, I want a successful HTTP response to count as verified outcome. Provider
+   acceptance and authoritative post-state are different facts.
+7. As an owner, I want human actions copied from every provider for completeness. Only delegated
+   Grimnir actions or specifically selected substrate-control actions belong here.
+8. As an operator, I want a real-time stream of all successful receipts. The default consumer is an
+   exception view; successful history is queried on demand.
+9. As a manager, I want one opaque “agent trust score.” Review concrete gaps, drift, reversals, and
+   action classes; do not launder judgment into a number.
+10. As an integrator, I want Verdandi availability to gate reads, drafts, and non-consequential
+    work. The fail-closed boundary applies only to autonomous consequential mutation.
+11. As a vendor, I want to claim regulatory compliance because receipts are hash-chained. The
+    protocol can provide evidence, not legal compliance by itself.
+12. As a maintainer, I want another workflow runtime, policy engine, SIEM, or observability UI
+    bundled into Verdandi. Integrate with those layers; do not absorb them.
+
+## Where it fits in Grimnir
+
+The same protocol should appear in different products at their **write boundary**, while Verdandi
+stores and verifies the shared receipt relationship.
+
+| Product | Receipt-worthy boundary | Authoritative readback | Reversal/mitigation | Recommendation |
+|---|---|---|---|---|
+| **Grimnir deploy tooling** | Apply a service revision or unit/config artifact | Production marker, installed-file digest, service health, exact Git SHA | `git_revert`, prior artifact/unit restore, redeploy | **First adapter.** The source refs, rollback convention, and marker discipline largely exist already. |
+| **Hugin** | Dispatch/permit a task that crosses into a consequential write | Domain adapter, not the task's own success status | Domain recipe carried through the task contract | **Core integration.** Put receipt selection and fail-closed intent at the mutation gateway, not in prompts. |
+| **Heimdall** | No mutations needed for the first slice | Verdandi verification/gap health | Links to runbook/action detail | **First consumer.** Show only stale intents, drift, failed outcomes, anchor/restore problems, and unresolved gaps. |
+| **noxctl / Fortnox MCP** | Create/update/book/send/delete a financial object | Fortnox object ID plus fresh GET/readback | Supported inverse, correcting entry, or explicit irreversible mitigation | **Strong second domain, sandbox first.** High consequence and good source authority; never duplicate invoice/accounting payloads. |
+| **Brokkr** | Change host config, systemd state, storage, backup, ACL, or key posture | Host/provider state, file digest, snapshot or service status | Pre-state snapshot, config restore, service rollback | Strong operational fit after the deploy adapter; use only for autonomous/substrate mutations, not routine metrics. |
+| **Mimir** | Delete, restore, move, or change access to protected files | Filesystem/object metadata and digest | Snapshot/backup restore or verified erasure record | Future fit when Mimir gains writes; its present read-only serving path should not be gated. |
+| **Ratatoskr** | Send an external message or execute a routed consequential command | Telegram/provider message ID or domain adapter result | Correction/notification for sends; domain recipe for commands | Useful but privacy-sensitive. Log target reference minimally; do not ingest messages or routing chatter. |
+| **Munin Memory** | Destructive correction, namespace erasure, classification/security change, or autonomous overwrite with operational consequence | Fresh memory read/history reference | Prior value/snapshot or explicit erasure semantics | Select narrowly. Logging every memory write would recreate v1 volume and duplicate Munin's own history. |
+| **M5 inference gateway** | Change model availability, routing policy, admin config, key, or download/load state | Gateway/admin state and artifact digest | Prior config/model state or containment | Admin-plane fit only. Inference calls, prompts, latency, token use, and model scores stay in traces/ledger designed for inference. |
+| **Skuld** | Publish/send a briefing autonomously, if that becomes consequential | Delivery/provider reference | Correction/notification | Not a general receipt consumer. It may summarize unresolved exceptions only after Heimdall proves the view useful. |
+| **Any Grimnir tenant** | The common consequential-action seam in the tenant contract | Domain-specific observer | Standard recipe vocabulary | This is the portability payoff: tenants adopt one contract without writing directly to Verdandi's database. |
+
+### Recommended Grimnir event path
+
+1. Hugin or product-local middleware classifies a requested operation using local policy. MCP tool
+   annotations may inform this classification, but the MCP specification requires clients to treat
+   annotations as untrusted unless the server is trusted.
+2. For a consequential autonomous mutation, the middleware submits a bounded intent using the
+   authenticated tenant identity and authority reference.
+3. Verdandi durably accepts or rejects the intent. Rejection prevents the mutation.
+4. The product performs the write against the authoritative system.
+5. A domain adapter reads the authoritative state back using observer-only capability.
+6. Verdandi appends outcome or gap. Heimdall receives only exception/health state.
+7. Reversal is another action with its own intent, readback, and link to the original.
+
+## Where it could fit in other products
+
+### Product-category fit
+
+| Product category | Where the protocol sits | Strong value case | Main caveat |
+|---|---|---|---|
+| **MCP hosts and tool gateways** | Around execution of destructive/open-world tools; annotations seed classification and structured results help adapters | Adds durable pre-action authority and post-action verification across many agent tools | Tool annotations are hints, not trustworthy declarations; a server-provided success result is not independent outcome. |
+| **Agent SDKs and harnesses** | A middleware hook around consequential tool invocations | Makes autonomy controls portable across model vendors and agent runtimes | Keep it outside prompt/trace capture; the model must not control receipt truth. |
+| **Coding agents / DevOps** | PR creation/merge, release, deployment, infrastructure apply, secret or environment change | Git SHAs, PRs, deployment markers, and provider state make outcomes unusually verifiable and reversals concrete | GitHub artifact attestations prove build provenance, not the full runtime authorization→deployment→rollback relationship; link rather than duplicate them. |
+| **Accounting, payments, and finance automation** | Immediately around create/book/send/pay/correct operations | High consequence, stable source IDs, bounded action classes, strong need for principal authority and corrective evidence | Domain/legal rules define valid reversal; do not promise compliance or store financial payloads. |
+| **Enterprise SaaS admin/control planes** | User/role/ACL/key/config changes made by automation | Joins delegated authority to provider readback and rollback across otherwise disconnected SaaS systems | Provider audit logs may already cover outcome; value exists only if cross-system authority/recovery is missing. |
+| **RPA and back-office automation** | At connectors that mutate CRM, ERP, ticketing, HR, procurement, or records | Replaces screenshot/task-success assertions with source-object verification and partial-batch drift | UI-only systems may lack stable readback and IDs; unsupported actions should remain human-gated. |
+| **Personal assistants** | Send email/message, change calendar, buy/book, share/delete files | Makes personal autonomy reviewable with explicit irreversible-action mitigation | Very privacy-sensitive; references and recipient pseudonyms must replace content capture. |
+| **Infrastructure and IT operations** | Config deploy, service restart, ACL/key change, backup/restore, host remediation | Strong pre-state/post-state and reversal patterns; incident responders are obvious consumers | Avoid duplicating config/log/metrics payloads; link to Git, CMDB, or provider authority. |
+| **Data lifecycle and privacy tooling** | Delete, restore, retention, legal-hold, export, or access-policy operations | Can prove which stores were addressed and expose residual gaps rather than declaring broad success | Append-only integrity and erasure obligations must be designed together; tombstones are not universal legal answers. |
+| **Robotics, drones, labs, and industrial/IoT control** | Immediately before actuator commands and after sensor/controller confirmation | Physical actions make authority, bounded intent, independent observation, and mitigation unusually valuable | Safety certification, real-time constraints, and domain interlocks exceed this protocol; the ledger is evidence, not the safety controller. |
+| **Smart-home agents** | Door/lock, alarm, appliance, energy, access-code, or purchase actions | Small action vocabulary and local control align with sovereign receipts | Consumer usability and outage behavior are critical; do not gate harmless automations or pretend all physical outcomes are observable. |
+| **API gateways / policy engines** | After allow/deny, before upstream mutation, then joined to a domain readback adapter | Complements policy decision logs by proving what actually happened after authorization | A gateway often sees only request/response, not authoritative post-state; adapter coverage is the real work. |
+| **Regulated/high-stakes workflow products** | As an evidence layer linked to existing approval, record, and retention systems | Clear actor/principal split, source references, exceptions, and recovery evidence can strengthen controls | Requirements are jurisdiction/domain-specific. Sell evidence primitives, never blanket compliance. |
+
+### Fit with adjacent standards and products
+
+- [MCP tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) provide a useful
+  invocation boundary, structured results, and risk annotations. Their own security guidance calls
+  for user confirmation on sensitive operations and says annotations are untrusted unless the
+  server is trusted. Action receipts can consume these hints, but must add identity, durable
+  authority, independent readback, and reversal.
+- [CloudEvents](https://cloudevents.io/) is a good optional event **envelope** when products already
+  use brokers. It should not define authorization, integrity, or outcome semantics.
+- OpenTelemetry trace/task identifiers are useful correlation references. Execution telemetry can
+  expire independently; the minimal receipt must remain meaningful without the trace.
+- [GitHub artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations)
+  can establish signed build provenance. A deploy receipt should link to an attestation when one
+  exists, while separately proving runtime authority, observed deployment state, and reversal.
+- OPA/Cerbos-style decision logs can supply `authority_ref` and policy version. They prove a policy
+  decision, not the external mutation or its continuing source state.
+- Provider audit logs can be authoritative outcome evidence or supporting references. Verdandi
+  should not re-ingest their full content.
+
+## Product packaging options
+
+| Option | Assessment |
+|---|---|
+| **A. Grimnir-only Verdandi service** | Useful as the first proof, but makes every adopter depend on a particular service and obscures which semantics are portable. |
+| **B. Open protocol + SDK/middleware + adapters; Verdandi as reference server** | **Recommended if the internal proof succeeds.** Keeps the contract small, enables embedding in existing products, and makes adapter quality the product moat. |
+| **C. Standalone generic audit-log SaaS** | Reject now. It enters a crowded category, weakens sovereignty, rewards ingestion volume, and still cannot independently observe domain outcomes without adapters. |
+| **D. Feature copied independently into Hugin/noxctl/etc.** | Reject duplication. Products should own classification and readback adapters, but share schemas, client behavior, and verification semantics. |
+
+If externalized, a sensible package family would be:
+
+```text
+@action-receipts/schema        versioned protocol + fixtures
+@action-receipts/client        intent/gap/query client
+@action-receipts/middleware    fail-closed mutation wrapper
+@action-receipts/adapter-sdk   constrained authoritative outcome API
+verdandi                       self-hosted reference ledger/verifier
+verdandi-verify                offline verification CLI/library
+```
+
+The name **Verdandi** can remain the Grimnir component. A neutral protocol name is easier to embed
+elsewhere and avoids making the server the architecture.
+
+## Recommended proof sequence
+
+### Stage 0 — contract, no genesis
+
+Freeze only enough semantics to run fixtures: selection rule, intent/outcome/gap, actor/principal/
+observer split, action ID/idempotency, reversal vocabulary, privacy fields, and failure behavior.
+Build the conformance harness before a real ingestion path.
+
+### Stage 1 — deploy adapter, simulated first
+
+Use Grimnir deployment as the first vertical slice because it already has exact revisions,
+transactional markers, health gates, and `git_revert` recovery. Prove:
+
+- intent accepted before mutation;
+- exact production revision read back by an observer;
+- failure and missing-marker drift;
+- reversal as a linked action;
+- Verdandi outage leaves production untouched;
+- independent checkpoint and clean-room restore.
+
+### Stage 2 — Hugin gate and Heimdall exception consumer
+
+Put shared selection/fail-closed middleware at Hugin's consequential mutation boundary. Add only an
+exception/health surface to Heimdall. Run an owner review after real exceptions have been handled.
+
+### Stage 3 — independent second tenant and domain
+
+Add a non-Claude tenant and the noxctl/Fortnox adapter against mocks or a safe sandbox/dry-run
+harness. This tests per-tenant identity, financial-domain minimization, provider readback, and
+irreversible/corrective semantics without authorizing a live accounting write.
+
+### Stage 4 — decide whether there is a product
+
+Publish/extract the protocol only if two independent integrations implement it without Verdandi
+internals and receipts have changed at least one real operating decision. Otherwise keep it an
+internal Grimnir seam or retire it.
+
+## Minimum activation backlog
+
+The 64 stories are a discovery bank. The smallest defensible activation slice is:
+
+1. AR-SEL-01 through AR-SEL-05 — selection, durable intent, bounded authority, reversal.
+2. AR-OUT-01 through AR-OUT-05 — independent observer, source reference, drift, gaps, idempotency.
+3. AR-REC-01 through AR-REC-04 — reconstruct and verify reversal.
+4. AR-ID-01 through AR-ID-04 plus AR-ID-07 — per-tenant identity, scope/revoke, observer isolation.
+5. AR-REV-01 and AR-REV-02 — a concrete exception consumer.
+6. AR-PRV-01 through AR-PRV-04 — minimization, classification, secret rejection, retention.
+7. AR-OPS-01 through AR-OPS-05 — verification, independent anchor, restore, fail-closed,
+   break-glass.
+8. AR-DEV-01 through AR-DEV-04 — schemas, safe middleware, role separation, conformance harness.
+
+That is already a meaningful control product. P1/P2 work should not delay proof of this vertical
+slice or create a broad platform before use exists.
+
+## Success measures and falsifiers
+
+Verdandi v2 earns permanence only if it changes decisions or recovery outcomes. Measure:
+
+- percentage of selected actions with timely authoritative outcomes;
+- unresolved gap age by risk;
+- rate and class of intent drift;
+- reversals attempted and independently verified;
+- time to reconstruct one consequential action during review/incident;
+- receipts referenced in a rollback, incident, policy change, or autonomy decision;
+- payload-minimization and retention/erasure test results;
+- false-positive burden from selection and Heimdall exceptions;
+- adapter maintenance cost per real consequential action.
+
+Stop or narrow the product if, across two monthly reviews:
+
+- no receipt informs a gate, exception response, rollback, incident, or autonomy decision;
+- most “outcomes” are still assertions from the acting tenant;
+- event selection expands toward prompts, tool telemetry, or generic task history;
+- source payload duplication or privacy exceptions become routine;
+- independent anchoring/restore verification is not operational;
+- integrators must understand Verdandi internals rather than the protocol;
+- adapter cost exceeds the value of the actions being protected.
+
+## Owner decisions still required
+
+1. Is the protocol/server separation the desired definition, or should this remain explicitly
+   Grimnir-internal even if successful?
+2. Is fail-closed correct for **autonomous consequential mutations**, with a durable break-glass
+   path for recovery?
+3. Is Grimnir deploy tooling the right first vertical slice and Heimdall the first consumer?
+4. Should noxctl/Fortnox be the second domain under mocks/sandbox, or should Brokkr host operations
+   come first?
+5. Which P1 stories, if any, are prerequisites for owner trust beyond the proposed P0 activation
+   backlog?
+
+Until those decisions and the purpose-reset activation gates are accepted, Verdandi remains stopped
+and this document remains product discovery rather than a delivery plan.

--- a/docs/vision-review-fable-2026-07-09.md
+++ b/docs/vision-review-fable-2026-07-09.md
@@ -1,0 +1,204 @@
+# Fable Review — Grimnir Vision, Subsystems & Top 5 Priorities
+
+> **2026-07-09** — produced by Claude (Fable 5) on request: a complete overview of the Grimnir
+> vision and its subsystems, plus the five highest-priority/value work items.
+> Sources: `docs/vision.md` (v0.2), `docs/architecture.md`, `services.json`,
+> `docs/gap-analysis-2026-07-03.md`, `docs/threat-model.md` (v0.1),
+> `docs/tenant-contract.md` + `docs/tenant-validation-2026-07-04.md`,
+> `docs/roadmap-now-decision-brief.md`, `docs/agent-harness-bakeoff-2026-07-08.md`,
+> `docs/observability-and-improvement.md`, `STATUS.md`, Munin `projects/grimnir`,
+> and the live GitHub backlog (all component repos + Roadmap board, surveyed today).
+> **No work has been started** — this is an assessment only.
+
+---
+
+## 1. The vision in brief
+
+**Thesis (v0.2):** *Grimnir is a sovereign, self-knowing personal-AI substrate that any agent
+can safely act through.* The substrate is the identity; the agent — loop, channels, model — is
+a replaceable tenant. As models and harnesses commoditize, the scarce assets are *your* memory,
+*your* files, *your* accountability record, and *your* learned model of what to route where.
+
+**Two protected pillars** (built, never outsourced):
+
+1. **Sovereign Memory** — Munin (memory) · Mimir (files) · Verdandi (audit). Your data on your
+   hardware, auth at every layer, tamper-evident record of what was done with it.
+2. **Self-Knowing Inference** — M5 gateway · capability ledger · offloadability eval. A system
+   that *learns* what it can trust cheaper compute with and routes accordingly. The most
+   original idea in the system.
+
+**Decision rule:** build only what touches Memory or Inference-routing; reuse open-source for
+everything in the harness layer, provided it plugs into Munin + the gateway.
+
+**The Arc:** Phase 1 Reactive (largely complete) → **Phase 2 Self-maintaining (current)** →
+Phase 3 Proactive collaborator → Phase 4 Trusted autonomous agent. Autonomy rides on the
+pillars; it does not replace them.
+
+---
+
+## 2. Subsystem map
+
+**Topology.** Two Raspberry Pi 5s: `huginmunin` (Pi 1) runs the service constellation; Pi 2 is
+the NAS running Mimir + backups. Inference nodes on the tailnet: the BosGame M5
+(`inference.gille.ai`, gateway :8080 + llama-swap :8091 + capability ledger), an Orin Nano, and
+the laptop (intermittent). Services bind loopback; ingress is Cloudflare Tunnel with two-layer
+auth (CF Access at the edge + per-service Bearer at origin); Tailscale carries internal traffic.
+
+| Component | Host | Role | State (2026-07-09) |
+|---|---|---|---|
+| **Munin** | Pi 1 :3030 | Persistent memory (MCP + HTTP, FTS5 + vectors) | Mature (5/5 in gap analysis); OAuth 2.1 + Bearer; the system's strongest asset |
+| **Hugin** | Pi 1 :3032 | Task dispatcher / policy-and-routing gateway | Deployed; gating + injection/exfil scanners; provenance unsigned; OpenCode adapter path active |
+| **Heimdall** | Pi 1 :3033 | Monitoring dashboard | Deployed; collects fleet metrics; critical alerts are display-only (no push) |
+| **Ratatoskr** | Pi 1 :3034 | Telegram router + concierge | Deployed; `/repo` hardening live-validated 2026-07-08; still hardcodes Anthropic SDK (no gateway routing) |
+| **Skuld** | Pi 1 timer | Daily briefing synthesizer | SSOT drift: declared in services.json, not actually running; revive-or-cut decision pending (grimnir#69) |
+| **Verdandi** | Pi 1 :3036 | Audit log (hash-chained, redact-before-persist) | Live with 67k+ events, but loopback-only — no off-Pi intake, laptop Claude Code is the only emitter |
+| **Mimir** | Pi 2 :3031 | Authenticated file server | Deployed; hourly backup rsync; rsync ingest path unscanned for secrets (mimir#13) |
+| **Brokkr** | Pi 1 timers | Substrate: OS patching, deps, health | Live; off-box dead-man check merged, not yet deployed/drilled |
+| **noxctl** | laptop | Fortnox accounting CLI/MCP | 0.4.0 shipped; healthy |
+| **M5 gateway** | M5 :8080 | OpenAI-compatible front door + ledger + admission control | Production-grade; measured delegation savings; `/delegate` and `code_loop` in daily use |
+
+**Cross-cutting layers:**
+
+- **Tenant contract** (`tenant-contract.md`) — the four seams any acting agent must satisfy:
+  **A** Munin (auth'd memory access), **B** gateway (ledger-routed inference), **C** Hugin safety
+  gating + provenance, **D** Verdandi audit emission. Validated 2026-07-04 with Codex CLI as a
+  real non-Claude tenant: A/B/C **transports passed** (the substrate is genuinely
+  model-agnostic), but **per-tenant identity is missing at every seam** and Seam D is
+  unreachable off-Pi.
+- **Threat model** (v0.1, T1–T11) — residual-High today: T1/T2 exfiltration via the lethal
+  trifecta (autonomous and interactive paths), T4 unattributable autonomous action, T7
+  unencrypted data at rest, T9 untested backup/restore. (T3, Ratatoskr command injection, was
+  substantially closed by the 2026-07-08 hardening validation.)
+- **Observability loop** (`observability-and-improvement.md`) — trace → score → reflect →
+  improve. Trace capture and heuristic scoring are the contract; the reflect/improve stages are
+  designed but largely unbuilt.
+- **Failure recovery** (`failure-recovery.md`) — every autonomous mutation leaves a reversal
+  recipe + audit event. Convention defined; adoption across components is thin.
+
+---
+
+## 3. Where the system actually stands
+
+**Strong:** Munin, the M5 inference substrate (gateway, ledger, eval crons, measured savings),
+noxctl, the security perimeter (CF Access, tunnel auth, timing-safe compares), and — as of this
+week — registry validation green (7 ok / 0 issues), Ratatoskr hardened and live-validated, and
+a completed harness bake-off giving a concrete Claude-decoupling path (OpenCode for the Hugin
+coding lane, Goose as general worker).
+
+**The dominant failure pattern** (gap analysis, still true): the **half-open loop** — evidence
+emitted that nothing reads, or loops designed that nothing feeds. The emit→consume→decide arc
+completes almost nowhere. Concretely: the ledger learns but Hugin's routing barely consumes it
+and no production workload feeds it; grimnir-validate has written daily results since April
+that nothing reads; Heimdall alerts don't notify anyone; ~1,500 green tests exist but 7 of 10
+repos have no CI to run them; Verdandi records everything the laptop does and nothing the
+autonomous system does.
+
+**The single most-blocked thread:** grimnir#58 (tenant-contract validation) is blocked on
+verdandi#15 (no off-Pi audit intake, no per-tenant key mint). The same missing identity spine
+shows up independently as munin-memory#191 (writes attributed to "owner"), hugin#146 (task
+provenance self-reported, unsigned), and gille-inference#152 (ledger can't attribute keys).
+
+**Pending owner decisions** (the "now" cluster, decision brief 2026-07-07): succession (#65),
+data lifecycle/retention (#66), system ROI + off-ramp (#67), Skuld revive-or-cut (#69),
+interactive-session trust posture (#70).
+
+---
+
+## 4. Top 5 priorities
+
+Ranked by vision-centrality × risk reduction × unblocking effect. Each is a coherent program,
+not a single ticket.
+
+### P1 — Build the tenant trust spine: identity, provenance, enforced gating, reachable audit
+
+**What:** Give every tenant a distinct credential at all four seams and make the safety gate
+preventive, not detective. Concretely: verdandi#15 (off-Pi intake + per-tenant key mint) →
+hugin#146 (signed task provenance, Seam C) → hugin#148 (Hugin actually emits to Verdandi) →
+munin-memory#191 (per-tenant attribution on writes) → gille-inference#152 (key alias in ledger)
+→ hugin#149 (gating enforcement / remove unconditional `bypassPermissions`, T1). Then rerun the
+grimnir#58 Seam-D validation and update `tenant-validation-2026-07-04.md`.
+
+**Why first:** This is the thesis sentence — "*any agent* can *safely* act through" — and it is
+currently unproven on exactly the safety half. It closes two residual-High threats at once (T1
+exfiltration on the autonomous path, T4 unattributable action), it is the explicitly named
+blocker in project status, and it is the prerequisite for every Phase 3 trust decision. Five
+repos' worth of cross-filed tickets already converge here; the work is specified, not open-ended.
+
+### P2 — Make the sovereign core survivable: tested restore, encryption at rest, off-box dead-man
+
+**What:** brokkr#39 (off-site backup + an actually *tested* restore — the NAS is a single point
+of data loss), brokkr#40 (encryption at rest on Pi SD cards + NAS), deploy and drill the merged
+off-box dead-man check (brokkr#41 / T8), heimdall#101 (last-push heartbeat that feeds it), and
+deploy the merged Verdandi hash-chain checkpoint cadence (verdandi#17, T5).
+
+**Why:** Pillar 1's entire justification is "the asset that cannot be bought back" — yet today a
+single disk failure loses it (T9, restore never tested) and a stolen SD card leaks it in
+plaintext (T7). Three of the five residual-High threats live here. This is bounded, mostly
+mechanical work with no dependencies on anything else, and nothing else in the roadmap matters
+if the substrate itself is one incident from unrecoverable.
+
+### P3 — Close Pillar 2's learning loop with real production workload
+
+**What:** Finish the Hugin **OpenCode HarnessAdapter** (the active thread from the bake-off:
+gate/provenance → adapter → normalized events → Munin trace + Verdandi event), route at least
+one always-on production workload through the gateway so the ledger learns from real traffic
+(Ratatoskr triage is the named candidate — ratatoskr#27 also delivers the triage-offloadability
+dataset), and give the routing table writers: gille-inference#145 (auto-regenerate
+`m5-routing.json` from ledger + cartography). Supporting: hugin#157 (queue/retry when M5 busy).
+
+**Why:** The vision calls self-knowing inference "Grimnir's most original idea, a first-class
+pillar" — and the gap analysis found its learning loop severed at both ends: the ledger is real
+but no production workload feeds it, and "the learned model of what to route where" is a
+hand-edited file that doesn't learn. The harness adapter simultaneously delivers the
+Claude-decoupling the bake-off recommended, so one program advances both the pillar and tenant
+replaceability.
+
+### P4 — Decide the "now" cluster in one owner sitting, then write the five small docs
+
+**What:** The decision brief has already reduced grimnir#65/#66/#67/#69/#70 to one explicit
+owner choice each: name the succession delegate(s) + goal (#65); pick default retention windows
+for four data classes (#66); set the service exit threshold (#67); choose Skuld four-week trial
+vs. cut now (#69); choose the interactive-session friction level (#70). Then split the brief
+into the five planned artifacts (succession checklist, data-lifecycle map, ROI/off-ramp section,
+Skuld decision record, interactive-posture note) and start the first monthly ROI ledger entry.
+
+**Why:** Highest value-per-effort item on the board — the analysis is done and only decisions
+block execution. It covers the remaining residual-High threat (T2, interactive-session
+trifecta — the one exposure Hugin's gating can't fix), T11 (third-party data without a map),
+and the bus-factor risk that is existential for a one-operator sovereign system. Every week
+undecided is a week the queued follow-on docs and the Skuld question stay stalled.
+
+### P5 — Make Phase 2 real: close the self-maintenance loop (CI, alerts that notify, evidence that gets read)
+
+**What:** Minimal CI across the 7 repos that have none (verdandi#11, ratatoskr#28, skuld#4,
+mimir#14, heimdall#104, brokkr#26, grimnir#48 — the gap analysis's "single biggest Phase-2
+unlock"); heimdall#112 (push alert-engine reds to Telegram — monitoring that actually
+notifies); grimnir#2 (delta-alert on the validate runs that have been written unread since
+April); hugin#147 (enable the installed-but-never-activated daily-analysis timer); grimnir#63
+(validate's user-scope false reports). Fold in the small sovereignty seam fixes as touched:
+skuld#3 (direct SQLite into Munin) and mimir#13 (secret-scan the rsync ingest).
+
+**Why:** Grimnir claims Phase 2 — "keeps itself healthy without being asked" — but the system
+cannot currently notice its own failures: tests gate nothing, alerts reach no one, and its own
+validation evidence goes unread. This is the causal parent of the incidents the gap analysis
+documented (poisoned registry, silent drift, lying READMEs). Closing it is what makes the other
+four programs *stay* fixed.
+
+---
+
+## 5. Deliberately not in the top 5
+
+- **munin-memory#192** (memory correction/forgetting, T10) — real, but sequenced after the #66
+  retention decisions, which shape it.
+- **Security tier grimnir#9–18** — keep on the weekly sweep; grimnir#9 (verify rotation of the
+  leaked Anthropic key) is a quick standalone check worth doing opportunistically.
+- **Mimir revival details** (mimir#11/#12) and Heimdall dashboard polish (#110, #97, #93…) —
+  worthwhile, small, not load-bearing; several fold naturally into P5.
+- **Skuld phases 4–5, Ratatoskr photo/voice, Librarian/Sara onboarding** — Phase-3-flavored
+  features; premature before P1/P4 settle trust and whether Skuld lives at all.
+- **Hugin composition-mechanism convergence** (hugin#117) — needed eventually, but the vision
+  caps Hugin as platform; don't invest ahead of the adapter work in P3.
+
+---
+
+*Assessment only — no tickets were modified and no work was started.*

--- a/docs/vision-review-sol-2026-07-09.md
+++ b/docs/vision-review-sol-2026-07-09.md
@@ -1,0 +1,343 @@
+# Sol Review — Grimnir Vision, Subsystems, and Top Five Priorities
+
+> **Date:** 2026-07-09  
+> **Scope:** System-level review of Grimnir's vision, architecture, current evidence, and live backlog.  
+> **Mode:** Assessment only. No implementation, deployment, ticket mutation, or production probe was performed.
+
+## Executive conclusion
+
+Grimnir's core idea is strong and increasingly real:
+
+> **Grimnir is a sovereign, self-knowing personal-AI substrate that any agent can safely act through.**
+
+The system is not primarily an agent framework. Its durable value is the substrate that remains when models, harnesses, and channels are replaced:
+
+1. **Sovereign Memory** — personal memory, files, and accountability on Magnus's hardware.
+2. **Self-Knowing Inference** — evidence-based routing of work to the cheapest model that has earned trust for that task.
+
+The implementation has advanced beyond the 2026-07-03 gap-analysis baseline. The M5 learning loop is now live, production workloads feed it, the routing table has guarded writers, the CI sweep landed, Ratatoskr is hardened, Hugin's unconditional permission bypass was replaced by scoped profiles, Munin and the gateway gained tenant attribution, and registry validation is green.
+
+The remaining problem is no longer “build the pieces.” It is **finish the guarantees**:
+
+- the audit/provenance path is still incomplete for non-Pi tenants and Hugin mutations;
+- the irreplaceable data is not yet covered by a complete, tested recovery and physical-security story;
+- five owner decisions block trust, retention, succession, ROI, and the Skuld decision;
+- local/open-harness execution works in tests but is not yet a reliable, auditable production lane;
+- Phase 2 still has signals that do not trigger action.
+
+The recommended top five are therefore:
+
+1. Close the accountable tenant-and-audit path.
+2. Resolve the five owner decisions in one focused session.
+3. Prove whole-substrate survivability and recovery.
+4. Productionize the open-harness, self-knowing inference lane.
+5. Make Phase 2 signals reliably reach a human or an automated response.
+
+## 1. The vision
+
+### 1.1 Identity: substrate, not tenant
+
+The most important architectural choice in vision v0.2 is the separation between **substrate** and **tenant**.
+
+- The **substrate** is Grimnir: memory, files, audit, inference evidence, routing, safety policy, and durable identity.
+- A **tenant** is any replaceable agent loop, model, channel, or harness: Claude Agent SDK, Codex, OpenCode, Goose, Telegram, or a future ingress.
+
+That distinction prevents Grimnir from competing with fast-moving agent frameworks. It owns only what compounds personally and cannot be reacquired from a vendor.
+
+### 1.2 The two protected pillars
+
+#### Pillar 1 — Sovereign Memory
+
+**Munin + Mimir + Verdandi** form the personal knowledge and accountability core:
+
+- Munin holds searchable state, history, summaries, task records, and cross-environment orientation.
+- Mimir holds full files and artifacts that should not be copied into every model context.
+- Verdandi records consequential actions in a tamper-evident chain.
+
+The value proposition is not merely local hosting. It is continuity and control over the personal context that makes an agent useful over time.
+
+#### Pillar 2 — Self-Knowing Inference
+
+**M5 gateway + capability ledger + evaluation/probe system + guarded routing table** form the inference core.
+
+The system does not assume that a local model is good enough. It records outcomes, uses trusted verifiers where possible, detects regressions, and routes based on accumulated evidence. This is Grimnir's most distinctive technical idea.
+
+### 1.3 The build rule
+
+The vision's decision rule is sound:
+
+> Build only what touches Memory or Inference-routing. Reuse open-source in the harness layer, provided it conforms to the substrate contract.
+
+This implies:
+
+- deepen Munin, Verdandi, routing evidence, safety gates, and identity;
+- keep Hugin as policy/routing glue, not a bespoke universal agent framework;
+- use OpenCode, Goose, Claude Agent SDK, Codex, or successors behind a stable adapter;
+- cut channels, dashboards, experiments, and services that do not protect a pillar or show measured use.
+
+### 1.4 The autonomy arc
+
+| Phase | Promise | Honest current state |
+|---|---|---|
+| 1. Reactive | “Do X and go to sleep.” | Largely complete: memory, files, dispatch, Telegram, monitoring, briefings, local inference. |
+| 2. Self-maintaining | Detect and handle upkeep without being asked. | Current phase. Deployment validation and maintenance machinery are real, but several detect→notify→act loops remain open. |
+| 3. Proactive collaborator | Identify useful work and do or propose it. | Technically approachable, but premature until identity, audit, recovery, and interactive trust are settled. |
+| 4. Trusted autonomous agent | Act independently on meaningful business work. | Aspirational. Requires earned trust, reliable reversal, and accountable identity—not just better models. |
+
+The correct near-term objective is not “more autonomy.” It is making Phase 2 trustworthy enough that Phase 3 becomes a controlled expansion rather than a leap.
+
+## 2. System map
+
+### 2.1 Physical and network substrate
+
+| Node | Role | Important workloads |
+|---|---|---|
+| `huginmunin` Raspberry Pi | Primary service host | Munin, Hugin, Heimdall, Ratatoskr, Skuld timer, Verdandi, Grimnir validation/security timers |
+| `nas` | Storage host | Mimir, artifact storage, Time Machine, backup disk |
+| BosGame M5 | Main inference node | OpenAI-compatible gateway, model serving, capability ledger, routing/evaluation jobs |
+| Orin Nano | Secondary inference node | Ollama / specialist or overflow capacity |
+| MacBook Air | Development + intermittent inference | Claude/Codex, noxctl, local model servers, artifact source |
+| `skald` Raspberry Pi | Display | E-paper display endpoint |
+
+Tailscale is the internal mesh. Cloudflare Tunnel/Access fronts selected public services. systemd is the process and schedule manager. `services.json` is the inventory authority for components, hosts, ports, deployment shape, and units.
+
+### 2.2 The main flows
+
+#### Memory and file flow
+
+`agent → Munin search/state` and `laptop artifacts → Mimir → Munin summary/index`.
+
+Munin is the cross-environment discovery layer. Mimir is the content layer. This supports laptop, CLI, desktop, web, mobile, and Telegram without copying full documents into every environment.
+
+#### Task and action flow
+
+`agent or Ratatoskr → Munin task → Hugin claim/gate/route → runtime or harness → result → Munin → optional Telegram reply`.
+
+Hugin owns macro-routing and safety/policy around execution. The chosen runtime may be Claude, Codex, a local executor, an M5 `/delegate` worker, or eventually an OpenCode/Goose adapter. The missing final edge is consistent tenant provenance and Verdandi emission for consequential actions.
+
+#### Inference-learning flow
+
+`production request → M5 gateway → model/verifier outcome → capability ledger → guarded routing-table regeneration → future routing decision`.
+
+Unlike the July 3 baseline, this loop now operates in production. Its current weaknesses are admission/backpressure, verifier quality, promotion safety, and honest ROI calibration—not absence of a loop.
+
+#### Operations flow
+
+`service/system metrics → Heimdall/Brokkr/Grimnir validation → dashboard or alert → operator/automation`.
+
+Collection is comparatively mature. The weak edge is delivery and response: some critical signals are still dashboard-only, and some validation evidence is stored without driving a decision.
+
+## 3. Subsystem overview and current state
+
+| Subsystem | Strategic role | Current evidence | Main remaining gap |
+|---|---|---|---|
+| **Grimnir repo** | System authority, registry, architecture, deploy/validation/security orchestration | Registry validation reported 7 OK, 0 issues, 0 warnings on 2026-07-08 | Architecture/threat/backlog text now contains stale claims; Phase-2 evidence still needs better consumption |
+| **Munin Memory** | Pillar 1 memory and cross-environment state | Mature; per-tenant principal work (#191) closed; large test suite; orientation/search are core daily infrastructure | Correction, supersession, expiry, and ownership-aware forgetting remain open in [#192](https://github.com/Magnus-Gille/munin-memory/issues/192) |
+| **Mimir** | Pillar 1 full-file archive | Healthy; encrypted OneDrive off-site leg and byte-identical restore test are live; public-doc scrub current | Heimdall health/push configuration remains ambiguous ([#11](https://github.com/Magnus-Gille/mimir/issues/11), [#12](https://github.com/Magnus-Gille/mimir/issues/12)); recovery coverage must be assessed as part of the whole system |
+| **Verdandi** | Pillar 1 tamper-evident accountability | Real hash chain; checkpoint command/timer merged in PR #17 | Checkpoint deploy pending; off-Pi intake and tenant key lifecycle blocked by [#15](https://github.com/Magnus-Gille/verdandi/issues/15); Hugin still does not emit |
+| **M5 / gille-inference** | Pillar 2 gateway, ledger, evaluation, routing | Live production delegation, guarded routing-table updates, quality-adjusted savings evidence, Heimdall panels | Policy remains shadow/HOLD; verifier and promotion evidence can be gamed or inflated; audit emission blocked on Verdandi |
+| **Hugin** | Policy, safety, macro-routing, task lifecycle | Active; M5 worker attribution deployed; scoped permission profiles replaced unconditional bypass; Claude fallback retained | Tenant signing/provenance [#146](https://github.com/Magnus-Gille/hugin/issues/146), Verdandi emission [#148](https://github.com/Magnus-Gille/hugin/issues/148), and M5 busy retry [#157](https://github.com/Magnus-Gille/hugin/issues/157) |
+| **Ratatoskr** | Telegram ingress and task/result routing | Production; gateway-backed triage; `/repo` path and header-injection hardening live-validated | Mostly maintenance/UX; no longer a load-bearing architecture gap |
+| **Skuld** | Morning briefing / orientation product | Timer-only deployment is now present and registry validation is green | Value is unproven. [Grimnir #69](https://github.com/Magnus-Gille/grimnir/issues/69) has a stale incident description; the live question is four-week measured trial vs cut |
+| **Heimdall** | System visibility and human-facing health | Active; fleet and inference panels are real | Critical alert-engine reds remain display-only in [#112](https://github.com/Magnus-Gille/heimdall/issues/112) |
+| **Brokkr** | Hardware, OS, storage, backups, off-box substrate care | Dead-man check merged; maintenance timers and hardware ownership established | Dead-man deploy/drill pending; restore coverage [#39](https://github.com/Magnus-Gille/brokkr/issues/39) and encryption-at-rest decision [#40](https://github.com/Magnus-Gille/brokkr/issues/40) remain open |
+| **noxctl** | Fortnox CLI/MCP and controlled accounting access | Mature 0.4.0 release with broad tests and explicit mutation confirmation | Sensitive-data lifecycle belongs in Grimnir's data map; otherwise not a current substrate bottleneck |
+
+## 4. Cross-cutting contracts and trust boundaries
+
+### 4.1 Tenant contract
+
+Any acting tenant must pass four seams:
+
+| Seam | Obligation | Current state |
+|---|---|---|
+| A — Munin | Authenticated memory/state access with tenant identity | Transport proven with Codex; per-tenant principal ticket closed |
+| B — Gateway | Inference through evidence-producing routing with caller attribution | Transport and ledger proven; key-alias attribution ticket closed |
+| C — Hugin | Safety-gated task execution with verified provenance | Gate/execution proven; signing and lifecycle attribution still open |
+| D — Verdandi | Reachable, tenant-attributed audit emission | Still blocked off-Pi; this prevents end-to-end conformance |
+
+The first Codex validation proved that the transports are genuinely model-agnostic. It did **not** prove that a non-Claude tenant can act with end-to-end accountability. That distinction should remain explicit.
+
+### 4.2 Security posture
+
+The relevant trust boundaries are:
+
+- untrusted email, web pages, documents, Telegram content, dependencies, and model output;
+- powerful agents that can combine private data, untrusted content, tools, credentials, and egress;
+- a semi-trusted tailnet where per-service auth—not network location—is the real control;
+- physical possession of unencrypted media;
+- a single trusted operator whose absence is itself a continuity risk.
+
+Hugin's queue path is materially safer after issue #149, but interactive sessions still bypass that gate. Verdandi's hash chain is real, but the actor doing the most consequential autonomous work—Hugin—still does not feed it.
+
+### 4.3 Failure recovery
+
+The convention is well designed: every autonomous mutation must leave both a reversal recipe (`git_revert`, `snapshot`, or `irreversible` plus mitigation) and a Verdandi event. The weakness is adoption, not design. Until Hugin emits and tenant identity is verified, this convention cannot be claimed as a system property.
+
+### 4.4 Self-improvement
+
+The intended cycle is:
+
+`execute → trace → score → reflect → improve`.
+
+Pillar 2 now demonstrates a real version of this cycle. The wider fleet is uneven: several components emit evidence without a consumer, and some scoring signals are structurally easy to satisfy without measuring real task quality. The correct next move is better evidence and closed responses, not a new observability service.
+
+## 5. Evidence reconciliation: what changed after the July 3 baseline
+
+Older documents and some open issue bodies are useful history but not current truth. The following corrections materially change the priority ranking:
+
+1. **Pillar 2 is no longer severed.** Hugin and Ratatoskr feed M5 production traffic; routing-table generation/adoption and regression guards are live. The remaining work is reliability, verifier integrity, and policy maturity.
+2. **The “7 repos without CI” program is no longer open.** The July fleet closed the original CI sweep. It should not consume a top-five slot.
+3. **Skuld is deployed as a user-scoped timer.** Issue #69's “not installed / never run” body is stale. The unresolved question is whether briefings earn their maintenance cost.
+4. **Mimir has encrypted off-site backup and a tested restore.** Brokkr #39 still matters for stores not covered by that mechanism and for a whole-system drill, but the ticket's original “Mimir local-only” premise is stale.
+5. **Hugin issue #149 is closed and deployed.** Unconditional `bypassPermissions` is no longer the current permission model. The threat model should be revised after validation evidence is consolidated.
+6. **Munin #191 and gille-inference #152 are closed.** Tenant identity is not “missing everywhere” anymore; the remaining structural gaps are Hugin provenance and Verdandi intake/emission.
+7. **Verdandi checkpointing and the Brokkr dead-man implementation are merged.** Their remaining value is operational: deploy, drill, and verify.
+8. **Grimnir's user-scope validator behavior is fixed in deployed code despite #63 remaining open.** This is backlog hygiene, not a fresh engineering gap.
+
+This review therefore ranks the remaining edges, not the already-shipped July program.
+
+## 6. The five highest-priority/value items
+
+The ranking uses four criteria: vision centrality, risk reduction, unblocking effect, and value relative to effort.
+
+### 1. Close the accountable tenant-and-audit path
+
+**Why it ranks first:** This is the unresolved half of the thesis sentence: “any agent can **safely** act through.” It also closes the accountability inversion in which Hugin performs mutations but Verdandi mostly records laptop activity.
+
+**Scope, in dependency order:**
+
+1. Deliver [verdandi#15](https://github.com/Magnus-Gille/verdandi/issues/15): a reachable off-Pi intake plus mint/list/rotate/revoke for tenant/component credentials.
+2. Deliver [hugin#146](https://github.com/Magnus-Gille/hugin/issues/146): verified tenant signing, provenance in structured results, and a path toward requiring signatures.
+3. Deliver [hugin#148](https://github.com/Magnus-Gille/hugin/issues/148): emit execution/mutation events with reversal metadata.
+4. Unblock [gille-inference#154](https://github.com/Magnus-Gille/gille-inference/issues/154): audit routing-regression alarms without making audit availability a runtime dependency.
+5. Deploy Verdandi checkpointing and rerun [grimnir#58](https://github.com/Magnus-Gille/grimnir/issues/58) through all four seams with a distinct non-Claude identity.
+
+**Done means:** A Codex/OpenCode tenant has distinct credentials at all four seams; a consequential action produces a verified provenance chain, a Verdandi event, and a reversal recipe; Seam D passes from off-Pi.
+
+**Effort:** Medium, cross-repo. **Unblocking value:** Very high.
+
+### 2. Resolve the five owner decisions in one focused session
+
+**Why it ranks second:** The analysis is already done in `docs/roadmap-now-decision-brief.md`. A short owner session unlocks several high-risk and high-value paths at far lower cost than another implementation sprint.
+
+Decide:
+
+- [#65](https://github.com/Magnus-Gille/grimnir/issues/65): emergency delegate(s) and `recover` vs `export-and-shutdown` vs temporary operation.
+- [#66](https://github.com/Magnus-Gille/grimnir/issues/66): retention defaults for client/accounting data, personal memory, telemetry, and transient task artifacts.
+- [#67](https://github.com/Magnus-Gille/grimnir/issues/67): the service/system exit threshold and minimal dormant mode.
+- [#69](https://github.com/Magnus-Gille/grimnir/issues/69): four-week measured Skuld trial or cut. The old deployment premise should be corrected first.
+- [#70](https://github.com/Magnus-Gille/grimnir/issues/70): interactive-session posture. The safest practical default is to route consequential mutations following untrusted input through Hugin, with a fresh session as the fallback.
+
+Then write only the five already-scoped artifacts: succession checklist, data-lifecycle map, vision ROI/off-ramp paragraph, Skuld decision record, and interactive-session posture. Use the retention decision to shape Munin correction/forgetting [#192](https://github.com/Magnus-Gille/munin-memory/issues/192).
+
+**Done means:** The five choices are explicit, the small documents exist, and each implementation ticket has a policy answer instead of inventing one.
+
+**Effort:** Small owner session plus small documentation follow-up. **Value/effort:** Highest in the backlog.
+
+### 3. Prove whole-substrate survivability and recovery
+
+**Why it ranks third:** Pillar 1 contains assets that cannot be recreated. A sovereign system that cannot be restored—or whose disks disclose everything when stolen—is not yet sovereign in the strong sense.
+
+**Scope:**
+
+- Reframe and complete [brokkr#39](https://github.com/Magnus-Gille/brokkr/issues/39) as a restore matrix across Munin, Mimir, Verdandi, Time Machine, and essential configuration/key manifests. Credit Mimir's existing encrypted off-site leg and restore evidence rather than duplicating it.
+- Verify and decide encryption at rest in [brokkr#40](https://github.com/Magnus-Gille/brokkr/issues/40), including boot/recovery/key-custody consequences.
+- Deploy the merged off-box dead-man timer on M5 and run the blackhole and recovery drills.
+- Deploy Verdandi's checkpoint timer and confirm that the anchor survives compromise of the audited host.
+- Tie the technical runbook to the succession decision from priority 2.
+- Keep the physical UPS issue [grimnir#4](https://github.com/Magnus-Gille/grimnir/issues/4) visible as the cheap protection against a failure mode already experienced.
+
+**Done means:** A documented drill restores representative data from every critical store into an isolated target; off-site coverage gaps are explicit; encrypted-media status is verified; host loss produces an off-box alert; another named person can follow the recovery entry point.
+
+**Effort:** Medium. **Risk reduction:** Very high.
+
+### 4. Productionize the open-harness, self-knowing inference lane
+
+**Why it ranks fourth:** Pillar 2 is live, and the harness bake-off proved that OpenCode and Goose can execute real local edit/test loops through M5. The gap is now policy, event normalization, backpressure, and evidence quality—not model availability.
+
+**Scope:**
+
+- Fix Hugin busy-lane behavior in [#157](https://github.com/Magnus-Gille/hugin/issues/157): bounded retry, `Retry-After`, a homeserver-specific concurrency cap, and explicit degraded-coverage reporting.
+- Create the narrow Hugin `HarnessAdapter` implementation ticket recommended by the bake-off, starting with OpenCode for coding tasks.
+- Pin the acceptance fixture: normalized events, machine-readable diff/test evidence, no global side effects, and a read-only mode proven unable to edit or run shell.
+- Keep gating, credentials, provenance, audit, and reversal outside the harness.
+- Harden model promotion and evidence quality through the currently open gille-inference work, especially [#156](https://github.com/Magnus-Gille/gille-inference/issues/156), [#158](https://github.com/Magnus-Gille/gille-inference/issues/158), and [#176](https://github.com/Magnus-Gille/gille-inference/issues/176).
+- Keep delegate policy in shadow until real lane volume, verifier quality, and cost calibration support enforcement.
+
+**Done means:** A production Hugin task can use OpenCode+M5 behind the same gate/audit contract, survives M5 admission pressure without silently dropping workers, and produces trustworthy evidence that can change routing.
+
+**Effort:** Medium. **Strategic value:** Very high, but correctly sequenced after identity/audit foundations.
+
+### 5. Make Phase 2 signals reliably trigger action
+
+**Why it ranks fifth:** Grimnir already collects substantial evidence. Phase 2 becomes real when important changes reliably reach a human or a safe automated response, while routine green state stays quiet.
+
+**Scope:**
+
+- Route Heimdall red alerts through Telegram with deduplication/throttling in [heimdall#112](https://github.com/Magnus-Gille/heimdall/issues/112).
+- Deploy and drill the Brokkr dead-man path as the independent host-loss channel.
+- Make Grimnir validation deltas drive a decision instead of accumulating unread history ([grimnir#2](https://github.com/Magnus-Gille/grimnir/issues/2), [#23](https://github.com/Magnus-Gille/grimnir/issues/23)).
+- Use proven signal quality before enabling documentation auto-remediation in [grimnir#5](https://github.com/Magnus-Gille/grimnir/issues/5).
+- Resolve Mimir's false/unknown Heimdall state so operational dashboards distinguish an unreachable probe from an unhealthy service.
+- As the first keyboard action when work resumes, close the known credential-containment loose end in [grimnir#9](https://github.com/Magnus-Gille/grimnir/issues/9): verify the previously exposed Anthropic key is revoked. This is tiny, urgent hygiene—not a new program.
+
+**Done means:** Simulated service failure and host loss create one deduplicated off-box notification; a validation regression surfaces once; recovery produces a resolved notification; green runs remain silent; known compromised credentials are confirmed dead.
+
+**Effort:** Small to medium. **Operational value:** High.
+
+## 7. Recommended sequencing
+
+No implementation is started by this review. When work does begin, the lowest-risk sequence is:
+
+1. **Owner/P0:** verify key revocation and make the five owner decisions.
+2. **Trust track:** Verdandi #15 → Hugin provenance/emission → tenant-contract rerun.
+3. **Resilience track, in parallel:** deploy/drill already-merged controls, then restore/encryption work.
+4. **Inference track:** Hugin backpressure first, then the OpenCode adapter and promotion-quality gates.
+5. **Phase-2 closure:** wire alert/delta consumers and only then consider automated remediation.
+
+This sequence avoids building more autonomy on top of ambiguous identity, untested recovery, or weak signals.
+
+## 8. What should not take a top-five slot now
+
+- More channels, Telegram media features, or a richer dashboard.
+- New in-house agent-loop machinery.
+- Skuld phases 4–5 before the measured trial/cut decision.
+- More local models before promotion and verifier integrity are trustworthy.
+- Large compliance prose before the small data map and retention defaults exist.
+- A new observability service; the missing work is wiring and response.
+- Reopening the completed July CI, Ratatoskr hardening, registry, or routing-table programs.
+
+## 9. Method and sources
+
+### Claude-shaped orientation completed first
+
+Before analysis, this review inspected:
+
+- root `CLAUDE.md`, `STATUS.md`, `AGENTS.md`, `.claude/settings.local.json`, and `docs/.claude/settings.local.json`;
+- the Claude skill catalog and the relevant `issues`, `research-spike`, and `magnus-security-review` skill instructions;
+- Claude MCP configuration names relevant to this ecosystem: `munin-memory`, `m5`, `friction-mcp`, and `arxiv`;
+- current Munin project status for Grimnir and its major components;
+- the installed GitHub connector and live open issues across the component repositories.
+
+Munin and GitHub were used read-only. M5/Hugin delegation, friction triage, production SSH, deployments, and ticket changes were deliberately not used.
+
+### Primary repo sources
+
+- `docs/vision.md`
+- `docs/architecture.md`
+- `docs/tenant-contract.md`
+- `docs/tenant-validation-2026-07-04.md`
+- `docs/threat-model.md`
+- `docs/gap-analysis-2026-07-03.md`
+- `docs/roadmap-now-decision-brief.md`
+- `docs/observability-and-improvement.md`
+- `docs/failure-recovery.md`
+- `docs/agent-harness-bakeoff-2026-07-08.md`
+- `docs/authority.md`, `docs/role-separation.md`, `services.json`, and `STATUS.md`
+
+The same-day `fable_review_20260709.md` was used as an independent cross-check, not as authority. Where it conflicted with newer status or live issue state, this review followed the newer evidence and documented the correction in section 5.
+
+---
+
+**Bottom line:** Grimnir has crossed from architecture experiment into a functioning personal substrate. The highest-value work is now to make its strongest claims boringly true under failure: attributable tenants, complete audit, recoverable sovereign data, trustworthy routing evidence, and signals that reliably cause the right response.

--- a/scripts/output-audit-identities.example.json
+++ b/scripts/output-audit-identities.example.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Copy to ~/.config/grimnir/output-audit-identities.json and fill in real addresses. Never commit the filled-in file — it may contain private/historical identities.",
+  "owner": ["you@example.com", "you@your-domain.tld", "old-identity@example.com", "12345+You@users.noreply.github.com"],
+  "agent": ["your-bot@example.com", "noreply@anthropic.com"],
+  "ci": ["49699333+dependabot[bot]@users.noreply.github.com", "github-actions[bot]@users.noreply.github.com", "fluxcdbot@users.noreply.github.com"]
+}

--- a/scripts/output-audit.py
+++ b/scripts/output-audit.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Frozen, reproducible audit of owner+AI output over a date window.
+
+Single source of truth for the team-equivalent assessment (debate/team-equivalent-6mo-*).
+Emits a manifest with per-repo HEAD SHAs so the corpus can be re-derived exactly.
+
+Usage:  python3 scripts/output-audit.py [--root ~/repos] [--since 2026-01-12] [--until 2026-07-13]
+"""
+import argparse, collections, hashlib, os, re, subprocess, sys, json
+
+# --- identity sets (author email -> class) -----------------------------------
+# Loaded from a local, untracked config: this repo is public, and the owner's git
+# identities include a former personal address that must not be published here.
+# See output-audit-identities.example.json; copy it and fill in the real addresses.
+IDENTITIES_PATH = os.environ.get(
+    "OUTPUT_AUDIT_IDENTITIES",
+    os.path.expanduser("~/.config/grimnir/output-audit-identities.json"))
+
+try:
+    _ids = json.load(open(IDENTITIES_PATH))
+except OSError:
+    sys.exit(f"missing identity config: {IDENTITIES_PATH}\n"
+             f"copy scripts/output-audit-identities.example.json and fill it in, "
+             f"or set OUTPUT_AUDIT_IDENTITIES")
+
+OWNER = set(_ids["owner"])   # all of the owner's git identities, incl. historical ones
+AGENT = set(_ids["agent"])   # AI agents committing on the owner's behalf
+CI = set(_ids["ci"])         # dependabot, github-actions, flux, etc.
+
+# Upstream forks / other people's repos: excluded only if they have 0 owner commits in window.
+# (No hardcoded exclusion list — the filter is empirical.)
+
+SRC = {".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".c", ".h", ".cpp", ".swift", ".sh",
+       ".lua", ".java", ".kt", ".rb", ".php", ".sql", ".vue", ".svelte", ".mjs", ".cjs"}
+DOC = {".md", ".rst"}
+VENDORED = re.compile(
+    r"(^|/)(node_modules|dist|build|\.next|vendor|target|__pycache__|coverage|\.venv|venv|third_party)/"
+    r"|\.min\.(js|css)$|\.map$")
+
+
+def git(repo, *args, timeout=180):
+    return subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True,
+                          timeout=timeout).stdout
+
+
+def classify(email):
+    if email in OWNER: return "owner"
+    if email in AGENT:  return "agent"
+    if email in CI:     return "ci"
+    return "other_human"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=os.path.expanduser("~/repos"))
+    ap.add_argument("--since", default="2026-01-12")
+    ap.add_argument("--until", default="2026-07-13")  # exclusive upper bound
+    args = ap.parse_args()
+    os.chdir(args.root)
+
+    # Only true repos: a git *worktree* has .git as a FILE, and would double-count its parent's tree.
+    repos = sorted(d for d in os.listdir(".") if os.path.isdir(os.path.join(d, ".git")))
+
+    # --- commits: global SHA dedup, so one commit counts once across all checkouts ---
+    seen, per_repo, dup = set(), {}, collections.Counter()
+    for r in repos:
+        ents = [l.split("|", 1) for l in
+                git(r, "log", f"--since={args.since}", f"--until={args.until}", "--format=%H|%ae",
+                    "HEAD").splitlines() if "|" in l]
+        c = collections.Counter()
+        for sha, email in ents:
+            if sha in seen:
+                dup[r] += 1
+                continue
+            seen.add(sha)
+            c[classify(email)] += 1
+        if sum(c.values()):
+            per_repo[r] = c
+
+    mine = {r: c for r, c in per_repo.items() if c["owner"] > 0}
+    totals = collections.Counter()
+    for c in mine.values():
+        totals.update(c)
+
+    # --- standing artifact: byte-identical blobs deduped across repos ---
+    blobs, src_lines, doc_lines, dup_lines = {}, 0, 0, 0
+    for r in mine:
+        for f in git(r, "ls-files").splitlines():
+            if VENDORED.search(f):
+                continue
+            ext = os.path.splitext(f)[1].lower()
+            if ext not in SRC and ext not in DOC:
+                continue
+            try:
+                data = open(os.path.join(r, f), "rb").read()
+            except OSError:
+                continue
+            n = data.count(b"\n") + (1 if data and not data.endswith(b"\n") else 0)
+            h = hashlib.sha1(data).hexdigest()
+            if h in blobs:
+                dup_lines += n
+                continue
+            blobs[h] = r
+            if ext in SRC: src_lines += n
+            else:          doc_lines += n
+
+    manifest = {
+        "window": {"since": args.since, "until_exclusive": args.until, "calendar_dates": 182},
+        "method": {
+            "dedup": "global SHA set across all checkouts; git worktrees excluded (.git is a file)",
+            "authorship": "commit author email matched against explicit identity sets",
+            "artifact": "current HEAD, vendored/generated paths excluded, byte-identical blobs deduped",
+        },
+        "repos": {r: {"head": git(r, "rev-parse", "HEAD").strip(), **dict(c)}
+                  for r, c in sorted(mine.items())},
+        "duplicate_commits_skipped": dict(dup),
+        "totals": {
+            "repos_with_owner_commits": len(mine),
+            "commits": dict(totals),
+            "commits_total": sum(totals.values()),
+            "owner_plus_ai_share": round((totals["owner"] + totals["agent"]) / sum(totals.values()), 4),
+            "standing_source_lines": src_lines,
+            "standing_doc_lines": doc_lines,
+            "standing_total_lines": src_lines + doc_lines,
+            "cross_repo_duplicate_lines_removed": dup_lines,
+        },
+    }
+    json.dump(manifest, sys.stdout, indent=2)
+    print()
+    t = manifest["totals"]
+    print(f"\n# repos={t['repos_with_owner_commits']}  commits={t['commits_total']} "
+          f"(owner={totals['owner']} agent={totals['agent']} ci={totals['ci']} "
+          f"other_human={totals['other_human']})", file=sys.stderr)
+    print(f"# Owner+AI share={t['owner_plus_ai_share']:.1%}  "
+          f"standing={t['standing_total_lines']:,} lines "
+          f"(src={src_lines:,} docs={doc_lines:,}; {dup_lines:,} dup lines removed)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adopts the untracked session leftovers found in the canonical checkout at session start (2026-07-21), so the working tree is clean again.

- **debate/**: team-equivalent-6mo debate (summary + critique log) + reviewer column in the index
- **scripts/**: `output-audit.py` — the frozen, reproducible output-corpus audit behind the team-equivalent assessment (identities config stays untracked-local; example file included) + AGENTS.md Scripts row
- **docs/**: the two 2026-07-13 Verdandi research notes (feeding verdandi#21 / draft PR verdandi#22 — explicitly not an authorization to restart Verdandi) + AGENTS.md key-document entries
- **docs/**: the 2026-07-09 independent Fable and Sol vision/priority reviews, moved from repo root to dated `docs/vision-review-*` names + one combined key-document entry

Safety and process:
- Grimnir is public: all 8 files passed a publication-safety pass before push — deterministic pattern scan + M5 semantic scan (gpt-oss-120b, 11 scan units), findings independently verified against already-public docs; committed byte-identical to the scanned content.
- Implemented headless by Codex (gpt-5.6-sol); reviewed by the grimnir session (Fable 5). `make test`: 73 passed / 0 failed.
- Note: open PR #92 proposes deleting `debate/` and trimming docs for a lean public variant; main's practice since has gone the other way, which this PR follows. Everything here is a plain `git revert` away if #92's direction is ever revived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)