### PR TITLE
Render host-specific systemd unit identity during deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -30,6 +30,9 @@ test-registry-smoke: ## Schema/consistency smoke check for services.json (issue 
 test-deploy-persistent-paths: ## Fail closed before rsync can delete an in-target runtime path
 	@bash scripts/tests/deploy-persistent-paths.test.sh
 
+test-deploy-systemd-render: ## Render and preflight host-specific systemd runtime identity (issue #107)
+	@bash scripts/tests/deploy-systemd-render.test.sh
+
 test-failure-recovery-doc: ## Regression test: assert docs/failure-recovery.md defines the undo convention (issue #46)
 	@bash tests/scripts/test-failure-recovery-doc.sh
 
@@ -45,7 +48,7 @@ test-systemd-status: ## Scope-aware local/remote systemd status checks (issue #6
 test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
 	@bash scripts/tests/worktree-hygiene.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,7 +15,7 @@ or `systemctl --user disable --now gille-autonomy-tick.timer` on M5.
 
 ## Active draft PR (2026-07-23)
 
-- **#110 / issue #107 — host-specific systemd runtime rendering:** draft PR head
+- **#110 / issue #107 — host-specific systemd runtime rendering:** implementation commit
   `378f7a45560795e23f6824dad6290482c8f0ba0f` adds registry-owned runtime
   user/home/deploy target rendering, private environment-file preservation, fail-before-restart
   unit/path preflight, network-boundary health acceptance, markerless failure regression, and

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,17 +13,6 @@ The self-improving delegation loop remains **ARMED with no human in the operatin
 Owner controls unchanged: `AUTONOMY_KILL_SWITCH=on` in `/home/magnus/home-server-eval/.env`,
 or `systemctl --user disable --now gille-autonomy-tick.timer` on M5.
 
-## Active draft PR (2026-07-23)
-
-- **#110 / issue #107 — host-specific systemd runtime rendering:** draft branch
-  `agent/render-host-systemd-units` adds registry-owned runtime
-  user/home/deploy target rendering, private environment-file preservation, fail-before-restart
-  unit/path preflight, network-boundary health acceptance, markerless failure regression, and
-  migration/rollback documentation.
-- Local verification is green: `make test`, full repository shellcheck, and `git diff --check`.
-- No deployment or merge was performed. Next gate is independent PR review plus green CI, followed
-  by an explicitly authorized selective deployment.
-
 ## Completed this session (2026-07-21 → 22)
 
 - **Session-leftover adoption — PR #99** (squash `dc6f625`, CI green, `make test` 73/73):

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,8 +15,8 @@ or `systemctl --user disable --now gille-autonomy-tick.timer` on M5.
 
 ## Active draft PR (2026-07-23)
 
-- **#110 / issue #107 — host-specific systemd runtime rendering:** implementation commit
-  `378f7a45560795e23f6824dad6290482c8f0ba0f` adds registry-owned runtime
+- **#110 / issue #107 — host-specific systemd runtime rendering:** draft branch
+  `agent/render-host-systemd-units` adds registry-owned runtime
   user/home/deploy target rendering, private environment-file preservation, fail-before-restart
   unit/path preflight, network-boundary health acceptance, markerless failure regression, and
   migration/rollback documentation.

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,17 @@ The self-improving delegation loop remains **ARMED with no human in the operatin
 Owner controls unchanged: `AUTONOMY_KILL_SWITCH=on` in `/home/magnus/home-server-eval/.env`,
 or `systemctl --user disable --now gille-autonomy-tick.timer` on M5.
 
+## Active draft PR (2026-07-23)
+
+- **#110 / issue #107 — host-specific systemd runtime rendering:** draft PR head
+  `378f7a45560795e23f6824dad6290482c8f0ba0f` adds registry-owned runtime
+  user/home/deploy target rendering, private environment-file preservation, fail-before-restart
+  unit/path preflight, network-boundary health acceptance, markerless failure regression, and
+  migration/rollback documentation.
+- Local verification is green: `make test`, full repository shellcheck, and `git diff --check`.
+- No deployment or merge was performed. Next gate is independent PR review plus green CI, followed
+  by an explicitly authorized selective deployment.
+
 ## Completed this session (2026-07-21 → 22)
 
 - **Session-leftover adoption — PR #99** (squash `dc6f625`, CI green, `make test` 73/73):

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -8,7 +8,7 @@
 | Fact type | Authoritative source | Derived by / consumers |
 |-----------|---------------------|------------------------|
 | **Port assignments** | `services.json` | `generate-architecture.sh`, `deploy.sh`, `security-scan.sh`, `docs/architecture.md` |
-| **Hostnames / hosts** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
+| **SSH and consumer-health hostnames** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
 | **Deploy paths, targets, systemd units & timer semantics** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
 | **Systemd unit structure / templates** | Owning component repo | `deploy.sh` installs install-ready units byte-for-byte or renders the bounded registry placeholders |
 | **Host systemd runtime identity, home, deploy target, private-environment paths and exact external sandbox dependencies** | `services.json` | `deploy.sh`, `render-systemd-units.sh` |

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -10,7 +10,8 @@
 | **Port assignments** | `services.json` | `generate-architecture.sh`, `deploy.sh`, `security-scan.sh`, `docs/architecture.md` |
 | **Hostnames / hosts** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
 | **Deploy paths, targets, systemd units & timer semantics** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
-| **Install-ready systemd unit contents** | Owning component repo | `deploy.sh` installs selected `systemd/{unit}` or root `{unit}` bytes without rendering |
+| **Systemd unit structure / templates** | Owning component repo | `deploy.sh` installs install-ready units byte-for-byte or renders the bounded registry placeholders |
+| **Host systemd runtime identity, home, deploy target, private-environment paths and sandbox roots** | `services.json` | `deploy.sh`, `render-systemd-units.sh` |
 | **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
 | **Global rsync safety exclusions** (`.env`, `.git`, dependencies, tests, deploy marker) | `scripts/deploy.sh` | deploy persistence tests |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |
@@ -57,11 +58,13 @@
    before acceptance. A timer whose only trigger is legitimately single-fire, such as a lone
    `OnBootSec`, must be declared with `timer_semantics: "one-shot"` in `services.json`.
 
-9. **Declared unit sources are install-ready artifacts, not templates.** The owning component repo
-   owns unit contents. Central deploy selects `systemd/{unit}` before root `{unit}` and installs the
-   selected bytes without component-specific rendering. Unresolved angle-bracket identifiers on
-   active unit lines fail preflight; template files must use a different name or live outside those
-   selected paths. Placeholder prose in comments is allowed.
+9. **Unit rendering is explicit and bounded.** The owning component repo owns unit structure.
+   Components without `systemd_runtime` remain install-ready artifacts: central deploy selects
+   `systemd/{unit}` before root `{unit}` and installs the selected bytes. Opted-in components may
+   use only the host placeholders defined in
+   [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md); the renderer validates runtime
+   identity and every relevant path before restart. Unknown active placeholders always fail.
+   Private values remain in required, host-owned environment files.
 
 10. **The learning contract assigns authority; it does not centralize evidence.** Hugin owns its
     task/execution/product/correction and prompt/harness-experiment facts. `gille-inference` owns

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -11,7 +11,7 @@
 | **Hostnames / hosts** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
 | **Deploy paths, targets, systemd units & timer semantics** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
 | **Systemd unit structure / templates** | Owning component repo | `deploy.sh` installs install-ready units byte-for-byte or renders the bounded registry placeholders |
-| **Host systemd runtime identity, home, deploy target, private-environment paths and sandbox roots** | `services.json` | `deploy.sh`, `render-systemd-units.sh` |
+| **Host systemd runtime identity, home, deploy target, private-environment paths and exact external sandbox dependencies** | `services.json` | `deploy.sh`, `render-systemd-units.sh` |
 | **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
 | **Global rsync safety exclusions** (`.env`, `.git`, dependencies, tests, deploy marker) | `scripts/deploy.sh` | deploy persistence tests |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,7 +24,7 @@ All components are named after figures from Norse mythology, reflecting their ro
 
 Remote install paths live in `services.json` as `deploy_path`. Most services live under `~/repos/<service-name>/`, but a few have intentional exceptions such as `munin-memory` (`~/munin-memory`) and `mimir` (`~/mimir-server`).
 
-Deploy all services from the laptop with `make deploy` (from the grimnir repo), or selectively with `make deploy ARGS="munin-memory hugin"`. The centralized script deploys the local working tree via rsync, runs a local build when `needs_build: true`, installs production dependencies on the target host, and restarts primary service units. Declared unit files must be install-ready: the deployer installs the selected `systemd/{unit}` or root `{unit}` bytes without rendering component-specific templates. For worktree-based deploys, pass an explicit source override such as `make deploy ARGS="munin-memory=/tmp/munin-memory-awesome"`.
+Deploy all services from the laptop with `make deploy` (from the grimnir repo), or selectively with `make deploy ARGS="munin-memory hugin"`. The centralized script deploys the local working tree via rsync, runs a local build when `needs_build: true`, installs production dependencies on the target host, and restarts primary service units. Declared units are install-ready by default. A component may opt into the bounded host renderer with `systemd_runtime`; see [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md) for the registry contract, preflight, migration, and rollback procedure. For worktree-based deploys, pass an explicit source override such as `make deploy ARGS="munin-memory=/tmp/munin-memory-awesome"`.
 
 ## GitHub ownership
 

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -125,8 +125,10 @@ therefore deliberately markerless/unknown, never certified by the old SHA.
   before choosing the captured rollback commit.
 - **Rendered systemd units:** opted-in components preserve the prior installed unit as
   `<unit>.grimnir-previous`. Render/preflight failure occurs before restart and stays markerless.
-  If restart or boundary health later fails, restore that host-local snapshot and verify the same
-  controller and health gates before restoring the captured prior marker. See
+  A partial multi-unit copy failure restores every destination already replaced and returns before
+  daemon reload; an incomplete restore is reported explicitly and requires inspection. If restart
+  or boundary health later fails, restore the host-local snapshots and verify the same controller
+  and health gates before restoring the captured prior marker. See
   [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md#rollback).
 
 ### Auto dependency bumps

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -124,7 +124,8 @@ therefore deliberately markerless/unknown, never certified by the old SHA.
   begin. If transport fails after later mutation starts, treat live state as unknown and inspect it
   before choosing the captured rollback commit.
 - **Rendered systemd units:** opted-in components preserve the prior installed unit as
-  `<unit>.grimnir-previous`. Render/preflight failure occurs before restart and stays markerless.
+  `<unit>.grimnir-previous`. Render/path preflight and scope-correct `systemd-analyze verify`
+  failures occur before any unit snapshot or install, before restart, and stay markerless.
   A partial multi-unit copy failure restores every destination already replaced and returns before
   daemon reload; an incomplete restore is reported explicitly and requires inspection. If restart
   or boundary health later fails, restore the host-local snapshots and verify the same controller

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -123,6 +123,11 @@ therefore deliberately markerless/unknown, never certified by the old SHA.
 - **Transport uncertainty:** if marker invalidation cannot be confirmed, code mutation does not
   begin. If transport fails after later mutation starts, treat live state as unknown and inspect it
   before choosing the captured rollback commit.
+- **Rendered systemd units:** opted-in components preserve the prior installed unit as
+  `<unit>.grimnir-previous`. Render/preflight failure occurs before restart and stays markerless.
+  If restart or boundary health later fails, restore that host-local snapshot and verify the same
+  controller and health gates before restoring the captured prior marker. See
+  [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md#rollback).
 
 ### Auto dependency bumps
 

--- a/docs/systemd-runtime-rendering.md
+++ b/docs/systemd-runtime-rendering.md
@@ -1,0 +1,111 @@
+# Host-specific systemd runtime rendering
+
+Registry deploys may opt a component into host-specific unit rendering with
+`systemd_runtime`. This is the stabilization path for clean-install unit templates whose runtime
+identity differs from the registered host. It prevents a reviewed code deployment from installing
+the wrong `User=`, entering a `217/USER` loop, or silently losing a host-private listener setting.
+
+The registry owns non-secret host facts. Secret values remain in environment files on the host.
+Component repositories continue to own unit structure and may use only these placeholders on active
+unit lines:
+
+- `<user>` — `systemd_runtime.user`
+- `<home>` — `systemd_runtime.home`
+- `<deploy-path>` — `systemd_runtime.deploy_target`
+- `<install-dir>` — basename of `deploy_target`, retained for existing clean-install templates
+
+Any other active placeholder fails closed.
+
+## Registry contract
+
+```json
+{
+  "deploy_path": "/home/example/service",
+  "persistent_paths": ["/home/example/.service"],
+  "systemd_runtime": {
+    "user": "example",
+    "home": "/home/example",
+    "deploy_target": "/home/example/service",
+    "environment_files": ["/home/example/service/.env"],
+    "sandbox_paths": ["/home/example/.service"]
+  },
+  "health_check": {
+    "boundary": "network",
+    "paths": ["/health"]
+  }
+}
+```
+
+`deploy_target` deliberately duplicates `deploy_path`: registry validation requires exact equality,
+so a unit cannot be rendered against one tree while rsync mutates another. `environment_files`
+lists required private-environment file paths, never their contents. Each file must already exist,
+must not be a symlink, and must be referenced by the rendered service without systemd's optional
+`-` prefix. Global rsync policy continues to exclude `.env`.
+
+`sandbox_paths` lists additional registered roots that path-bearing sandbox directives may use.
+They must lie under the deploy target or a declared `persistent_paths` root. The renderer also
+accepts the deploy target and declared persistent roots themselves.
+
+`health_check.boundary` is:
+
+- `host` — probe from the target host. This retains the legacy behaviour and is appropriate only
+  when loopback/host-local reachability is the real consumer boundary.
+- `network` — probe `http://<registered host>:<registered port><path>` from the deploy client after
+  restart and before acceptance. Use this when another node must reach the listener; a loopback-only
+  bind cannot pass this gate.
+
+## Deployment and preflight order
+
+For an opted-in rsync component, `scripts/deploy.sh` performs these phases:
+
+1. Validate the complete registry and the selected local unit templates.
+2. Invalidate `.deployed-commit`, then sync code and install dependencies.
+3. Stream the reviewed Grimnir renderer to the host. It renders every declared unit into a
+   temporary directory and preflights every service before installing any rendered unit.
+4. Verify the runtime account exists and its passwd home matches the registry.
+5. Require `WorkingDirectory=` to equal the deploy target; verify `ExecStart` executables and
+   absolute arguments; require declared environment files; and reject unregistered or missing
+   sandbox paths.
+6. Preserve each prior installed unit as `<unit>.grimnir-previous`, install all rendered units,
+   reload systemd, restart, and verify controller state.
+7. Run the declared host- or network-boundary health probe.
+8. Write `.deployed-commit` only after every gate succeeds.
+
+A render or preflight failure happens after marker invalidation but before restart. The target is
+therefore deliberately markerless, and the previously running process is not restarted. A later
+restart or health failure is also markerless.
+
+## Migration from raw units
+
+Migrate one component at a time:
+
+1. On the target, inventory the effective unit and drop-ins with `systemctl cat <unit>`. Record
+   paths and variable names, but do not copy secret values into git, issue comments, or logs.
+2. Ensure private runtime values live in a host-owned environment file that rsync preserves.
+3. In the owning component repo, replace only host identity/path literals with the supported
+   placeholders. Keep component logic and systemd policy in that repo.
+4. Add `systemd_runtime` and an explicit `health_check` to `services.json`. Register every required
+   environment file and sandbox root; do not guess unknown host values.
+5. Run `make test`, then perform a selective deployment. Confirm the health probe uses the consumer
+   boundary and that the new accepted marker matches the reviewed commit.
+6. After one healthy deployment and rollback-window observation, the
+   `.grimnir-previous` snapshot may be removed manually.
+
+Components without `systemd_runtime` retain the install-ready, byte-for-byte unit contract. This
+keeps migration explicit and avoids silently assigning host identities.
+
+## Rollback
+
+The deploy log reports the prior accepted commit before mutation.
+
+- If render/preflight fails, do not restart: the old process is still running. Correct the registry
+  or template and redeploy; the target remains markerless until acceptance.
+- If a rendered unit was installed and restart/health later fails, restore
+  `<unit>.grimnir-previous` to the original unit path, run the appropriate daemon reload and restart,
+  and verify the same declared health boundary. For system units use `sudo`; for user units use
+  `systemctl --user`.
+- Restore `.deployed-commit` to the captured prior SHA only after the restored service passes its
+  controller and health gates. If the prior unit snapshot or prior SHA is unknown, leave the marker
+  absent and treat live state as unknown.
+- Reverting this feature in git does not itself repair a host. A rollback must restore the host unit
+  and health first; otherwise the next raw-unit deployment can recreate the incident.

--- a/docs/systemd-runtime-rendering.md
+++ b/docs/systemd-runtime-rendering.md
@@ -31,6 +31,7 @@ Any other active placeholder fails closed.
   },
   "health_check": {
     "boundary": "network",
+    "host": "service-host",
     "paths": ["/health"]
   }
 }
@@ -54,9 +55,10 @@ directives may reference paths within either tree.
 
 - `host` — probe from the target host. This retains the legacy behaviour and is appropriate only
   when loopback/host-local reachability is the real consumer boundary.
-- `network` — probe `http://<registered host>:<registered port><path>` from the deploy client after
-  restart and before acceptance. Use this when another node must reach the listener; a loopback-only
-  bind cannot pass this gate.
+- `network` — probe `http://<health_check.host>:<registered port><path>` from the deploy client
+  after restart and before acceptance. `host` is required for this boundary, is independent of the
+  component's SSH `host`, and must be a safe hostname rather than an IP locator. Use the stable
+  non-secret hostname seen by the real consumer; a loopback-only bind cannot pass this gate.
 
 ## Deployment and preflight order
 
@@ -65,16 +67,21 @@ For an opted-in rsync component, `scripts/deploy.sh` performs these phases:
 1. Validate the complete registry and the selected local unit templates.
 2. Invalidate `.deployed-commit`, then sync code and install dependencies.
 3. Stream the reviewed Grimnir renderer to the host. It renders every declared unit into a
-   temporary directory and preflights every service before installing any rendered unit.
+   temporary directory and runs the bounded path/identity preflight.
 4. Verify the runtime account exists and its passwd home matches the registry.
 5. Require `WorkingDirectory=` to equal the deploy target; verify `ExecStart` executables and
    absolute arguments; require declared environment files; and reject unregistered or missing
    sandbox paths.
-6. Snapshot every prior installed unit as `<unit>.grimnir-previous`, then install all rendered
+6. Run `systemd-analyze --system verify` and `systemd-analyze --user verify` as applicable, passing
+   each manager scope's complete rendered unit set together. The temporary render directory leads
+   the unit search path, so referenced rendered units are checked before any installed unit can
+   shadow them. Verification parses unit references but never reads or prints environment-file
+   contents.
+7. Snapshot every prior installed unit as `<unit>.grimnir-previous`, then install all rendered
    units. If any copy fails, restore every unit already replaced and return before daemon reload.
    Otherwise reload systemd, restart, and verify controller state.
-7. Run the declared host- or network-boundary health probe.
-8. Write `.deployed-commit` only after every gate succeeds.
+8. Run the declared host- or network-boundary health probe.
+9. Write `.deployed-commit` only after every gate succeeds.
 
 A render or preflight failure happens after marker invalidation but before restart. The target is
 therefore deliberately markerless, and the previously running process is not restarted. A later
@@ -115,8 +122,9 @@ deployment-blocked until the owning-repository change is green, reviewed, and me
 
 The deploy log reports the prior accepted commit before mutation.
 
-- If render/preflight fails, do not restart: the old process is still running. Correct the registry
-  or template and redeploy; the target remains markerless until acceptance.
+- If render, bounded preflight, or `systemd-analyze verify` fails, no unit or rollback snapshot is
+  installed and no restart occurs: the old process is still running. Correct the registry or
+  template and redeploy; the target remains markerless until acceptance.
 - If one unit copy fails during a multi-unit install, the renderer restores every unit it already
   replaced and exits before daemon reload. An explicit incomplete-rollback error means the
   destinations must be inspected manually before any reload.

--- a/docs/systemd-runtime-rendering.md
+++ b/docs/systemd-runtime-rendering.md
@@ -106,8 +106,10 @@ change must not be deployed on its own: Heimdall's canonical templates currently
 `User=heimdall` and `/home/heimdall`, which no bounded placeholder renderer can safely reinterpret.
 A companion PR in the Heimdall repository must first replace those host literals with the supported
 placeholders. Merge and deploy that owning-repository template change before selectively deploying
-Heimdall through this contract. The companion PR link is pending; Grimnir PR #110 remains draft and
-deployment-blocked until it is recorded.
+Heimdall through this contract. The required companion is
+[Heimdall PR #14](https://github.com/Magnus-Gille/heimdall/pull/14), reviewed here at exact head
+`6748365d92192fa267ef69c48716c9e6f0940e57`. Grimnir PR #110 remains draft and
+deployment-blocked until the owning-repository change is green, reviewed, and merged first.
 
 ## Rollback
 

--- a/docs/systemd-runtime-rendering.md
+++ b/docs/systemd-runtime-rendering.md
@@ -26,8 +26,8 @@ Any other active placeholder fails closed.
     "user": "example",
     "home": "/home/example",
     "deploy_target": "/home/example/service",
-    "environment_files": ["/home/example/service/.env"],
-    "sandbox_paths": ["/home/example/.service"]
+    "environment_files": ["/home/example/.service/env"],
+    "sandbox_paths": ["/home/example/.ssh/service_read_only"]
   },
   "health_check": {
     "boundary": "network",
@@ -40,11 +40,15 @@ Any other active placeholder fails closed.
 so a unit cannot be rendered against one tree while rsync mutates another. `environment_files`
 lists required private-environment file paths, never their contents. Each file must already exist,
 must not be a symlink, and must be referenced by the rendered service without systemd's optional
-`-` prefix. Global rsync policy continues to exclude `.env`.
+`-` prefix. Each path must be inside the deploy target or a declared `persistent_paths` root.
+Global rsync policy continues to exclude `.env`.
 
-`sandbox_paths` lists additional registered roots that path-bearing sandbox directives may use.
-They must lie under the deploy target or a declared `persistent_paths` root. The renderer also
-accepts the deploy target and declared persistent roots themselves.
+`sandbox_paths` lists exact external dependencies that path-bearing sandbox directives may use,
+such as a read-only key or another component's data directory. Declaring one does not claim that
+the opting-in component owns or persists it, does not authorize descendants, and never grants
+write access. Exact external paths are accepted only by `ReadOnlyPaths=`, `BindReadOnlyPaths=`, or
+`InaccessiblePaths=`. The deploy target and declared persistent paths remain authorized roots, so
+directives may reference paths within either tree.
 
 `health_check.boundary` is:
 
@@ -66,8 +70,9 @@ For an opted-in rsync component, `scripts/deploy.sh` performs these phases:
 5. Require `WorkingDirectory=` to equal the deploy target; verify `ExecStart` executables and
    absolute arguments; require declared environment files; and reject unregistered or missing
    sandbox paths.
-6. Preserve each prior installed unit as `<unit>.grimnir-previous`, install all rendered units,
-   reload systemd, restart, and verify controller state.
+6. Snapshot every prior installed unit as `<unit>.grimnir-previous`, then install all rendered
+   units. If any copy fails, restore every unit already replaced and return before daemon reload.
+   Otherwise reload systemd, restart, and verify controller state.
 7. Run the declared host- or network-boundary health probe.
 8. Write `.deployed-commit` only after every gate succeeds.
 
@@ -94,12 +99,25 @@ Migrate one component at a time:
 Components without `systemd_runtime` retain the install-ready, byte-for-byte unit contract. This
 keeps migration explicit and avoids silently assigning host identities.
 
+### Heimdall migration dependency
+
+Heimdall is the incident-owning component and the first registry opt-in. The Grimnir registry
+change must not be deployed on its own: Heimdall's canonical templates currently hardcode
+`User=heimdall` and `/home/heimdall`, which no bounded placeholder renderer can safely reinterpret.
+A companion PR in the Heimdall repository must first replace those host literals with the supported
+placeholders. Merge and deploy that owning-repository template change before selectively deploying
+Heimdall through this contract. The companion PR link is pending; Grimnir PR #110 remains draft and
+deployment-blocked until it is recorded.
+
 ## Rollback
 
 The deploy log reports the prior accepted commit before mutation.
 
 - If render/preflight fails, do not restart: the old process is still running. Correct the registry
   or template and redeploy; the target remains markerless until acceptance.
+- If one unit copy fails during a multi-unit install, the renderer restores every unit it already
+  replaced and exits before daemon reload. An explicit incomplete-rollback error means the
+  destinations must be inspected manually before any reload.
 - If a rendered unit was installed and restart/health later fails, restore
   `<unit>.grimnir-previous` to the original unit path, run the appropriate daemon reload and restart,
   and verify the same declared health boundary. For system units use `sudo`; for user units use

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,6 +13,7 @@ GRIMNIR_DIR="$(dirname "$SCRIPT_DIR")"
 REGISTRY="${REGISTRY_PATH:-$GRIMNIR_DIR/services.json}"
 REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 REGISTRY_VALIDATOR="$SCRIPT_DIR/lib/validate-registry.js"
+SYSTEMD_RENDER_HELPER="$SCRIPT_DIR/lib/render-systemd-units.sh"
 # shellcheck source=scripts/lib/deploy-safety.sh
 source "$SCRIPT_DIR/lib/deploy-safety.sh"
 
@@ -152,23 +153,53 @@ unit_rows() {
 }
 
 preflight_local_unit_sources() {
-  local local_path=$1 units_json=$2 fallback_name=$3 fallback_type=$4 fallback_scope=$5
+  local local_path=$1 units_json=$2 fallback_name=$3 fallback_type=$4 fallback_scope=$5 render_enabled=${6:-false}
   local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file
 
   rows="$(unit_rows "$units_json" "$fallback_name" "$fallback_type" "$fallback_scope")"
   while IFS='|' read -r unit_name unit_kind unit_actual_scope unit_timer_semantics; do
     [[ -n "$unit_name" ]] || continue
     unit_file="${unit_name}.${unit_kind}"
-    if ! preflight_local_install_ready_unit_source "$local_path" "$unit_file" true; then
+    if ! preflight_local_install_ready_unit_source "$local_path" "$unit_file" true "$render_enabled"; then
       return 1
     fi
     if [[ "$unit_kind" == "timer" ]]; then
       companion_file="${unit_name}.service"
-      if ! preflight_local_install_ready_unit_source "$local_path" "$companion_file" false; then
+      if ! preflight_local_install_ready_unit_source "$local_path" "$companion_file" false "$render_enabled"; then
         return 1
       fi
     fi
   done <<< "$rows"
+}
+
+health_path_rows() {
+  local health_json=$1
+  HEALTH_JSON="$health_json" node --input-type=commonjs -e '
+    var health = JSON.parse(process.env.HEALTH_JSON || "null");
+    var paths = health && Array.isArray(health.paths) ? health.paths : ["/health", "/api/health"];
+    paths.forEach(function (path) { process.stdout.write(path + "\n"); });
+  '
+}
+
+network_health_check() {
+  local host=$1 port=$2 health_json=$3 path health_ok=false attempt
+  attempt=1
+  while [[ "$attempt" -le 5 ]]; do
+    while IFS= read -r path; do
+      [[ -n "$path" ]] || continue
+      if curl -fsS --max-time 3 "http://${host}:${port}${path}" >/dev/null 2>&1; then
+        health_ok=true
+        break
+      fi
+    done < <(health_path_rows "$health_json")
+    [[ "$health_ok" == "true" ]] && break
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  if [[ "$health_ok" != "true" ]]; then
+    echo "ERROR: network-boundary health check failed for ${host}:${port}" >&2
+    return 1
+  fi
 }
 
 rsync_exclude_rows() {
@@ -216,6 +247,7 @@ report_markerless_failure() {
 deploy_service() {
   local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync} units_json=${9:-[]}
   local rsync_excludes_json=${10:-[]} health_port=${11:-}
+  local persistent_paths_json=${12:-[]} systemd_runtime_json=${13:-null} health_check_json=${14:-null}
   local local_path
   local remote_host
   local remote
@@ -224,6 +256,15 @@ deploy_service() {
   local commit_full
   local dirty_state
   local q_deploy_path
+  local render_enabled=false health_boundary=host
+
+  if [[ "$systemd_runtime_json" != "null" && -n "$systemd_runtime_json" ]]; then
+    render_enabled=true
+  fi
+  if [[ "$health_check_json" != "null" && -n "$health_check_json" ]]; then
+    health_boundary=$(HEALTH_JSON="$health_check_json" node --input-type=commonjs -e \
+      'process.stdout.write(JSON.parse(process.env.HEALTH_JSON).boundary)')
+  fi
 
   echo -e "\n${BOLD}=== ${name} (${host}) ===${NC}"
 
@@ -263,7 +304,7 @@ deploy_service() {
     # Central deploy installs declared units byte-for-byte. Reject a missing
     # source or a component-owned template before build, marker invalidation,
     # host resolution, or any remote mutation.
-    if ! preflight_local_unit_sources "$local_path" "$units_json" "$name" "$unit_type" "$unit_scope"; then
+    if ! preflight_local_unit_sources "$local_path" "$units_json" "$name" "$unit_type" "$unit_scope" "$render_enabled"; then
       results+=("${RED}✗${NC} ${name}")
       fail=$((fail + 1))
       return
@@ -368,6 +409,30 @@ deploy_service() {
 
   fi # end rsync-mode block (deploy_mode != git-pull)
 
+  if [[ "$render_enabled" == "true" ]]; then
+    echo "==> Rendering and preflighting systemd units on ${remote_host}..."
+    local render_cmd render_output
+    render_cmd="bash -s -- ${q_deploy_path} $(posix_shell_quote "$systemd_runtime_json") "
+    render_cmd+="$(posix_shell_quote "$units_json") $(posix_shell_quote "$persistent_paths_json")"
+    if ! render_output=$(ssh -o ConnectTimeout=10 "$remote" "$render_cmd" < "$SYSTEMD_RENDER_HELPER" 2>&1); then
+      [[ -n "$render_output" ]] && echo "$render_output" >&2
+      report_markerless_failure
+      echo -e "${RED}FAILED${NC}"
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+      return
+    fi
+    if ! echo "$render_output" | grep -Fxq "SYSTEMD_UNITS_PREPARED"; then
+      [[ -n "$render_output" ]] && echo "$render_output" >&2
+      echo "ERROR: remote systemd renderer returned no trustworthy preparation receipt" >&2
+      report_markerless_failure
+      echo -e "${RED}FAILED${NC}"
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+      return
+    fi
+  fi
+
   local cmd="cd ${q_deploy_path} && "
   local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file
   local timer_entry timer_name timer_semantics timer_next_check
@@ -386,41 +451,49 @@ deploy_service() {
     q_unit_label=$(posix_shell_quote "$unit_file")
 
     if [[ "$unit_actual_scope" == "user" ]]; then
-      cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
-      cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
-      unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
-      cmd+="${unit_guard} && "
-      cmd+="install -D -m644 \"\$unit_src\" \"\$HOME\"/${q_user_dest} && "
+      if [[ "$render_enabled" != "true" ]]; then
+        cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
+        cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
+        unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
+        cmd+="${unit_guard} && "
+        cmd+="install -D -m644 \"\$unit_src\" \"\$HOME\"/${q_user_dest} && "
+      fi
       user_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
         user_services+=("$unit_name")
       elif [[ "$unit_kind" == "timer" ]]; then
-        companion_file="${unit_name}.service"
-        q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
-        q_unit_root=$(posix_shell_quote "$companion_file")
-        q_user_dest=$(posix_shell_quote ".config/systemd/user/${companion_file}")
-        cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
-        companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
-        cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && install -D -m644 \"\$companion_src\" \"\$HOME\"/${q_user_dest}; fi && "
+        if [[ "$render_enabled" != "true" ]]; then
+          companion_file="${unit_name}.service"
+          q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
+          q_unit_root=$(posix_shell_quote "$companion_file")
+          q_user_dest=$(posix_shell_quote ".config/systemd/user/${companion_file}")
+          cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
+          companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
+          cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && install -D -m644 \"\$companion_src\" \"\$HOME\"/${q_user_dest}; fi && "
+        fi
         user_timers+=("${unit_name}|${unit_timer_semantics}")
       fi
     else
-      cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
-      cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
-      unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
-      cmd+="${unit_guard} && "
-      cmd+="sudo install -D -m644 \"\$unit_src\" ${q_system_dest} && "
+      if [[ "$render_enabled" != "true" ]]; then
+        cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
+        cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
+        unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
+        cmd+="${unit_guard} && "
+        cmd+="sudo install -D -m644 \"\$unit_src\" ${q_system_dest} && "
+      fi
       system_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
         system_services+=("$unit_name")
       elif [[ "$unit_kind" == "timer" ]]; then
-        companion_file="${unit_name}.service"
-        q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
-        q_unit_root=$(posix_shell_quote "$companion_file")
-        q_system_dest=$(posix_shell_quote "/etc/systemd/system/${companion_file}")
-        cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
-        companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
-        cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && sudo install -D -m644 \"\$companion_src\" ${q_system_dest}; fi && "
+        if [[ "$render_enabled" != "true" ]]; then
+          companion_file="${unit_name}.service"
+          q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
+          q_unit_root=$(posix_shell_quote "$companion_file")
+          q_system_dest=$(posix_shell_quote "/etc/systemd/system/${companion_file}")
+          cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
+          companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
+          cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && sudo install -D -m644 \"\$companion_src\" ${q_system_dest}; fi && "
+        fi
         system_timers+=("${unit_name}|${unit_timer_semantics}")
       fi
     fi
@@ -477,11 +550,18 @@ deploy_service() {
       cmd+="${timer_next_check} && "
     fi
   done
-  if [[ -n "$health_port" && "$health_port" != "null" ]]; then
+  if [[ -n "$health_port" && "$health_port" != "null" && "$health_boundary" == "host" ]]; then
+    local health_path q_health_path
     cmd+="{ health_ok=false; for attempt in 1 2 3 4 5; do "
     cmd+="for target in localhost 127.0.0.1 \$(hostname -I 2>/dev/null || true); do "
     cmd+="[ -n \"\$target\" ] || continue; case \"\$target\" in *:*) continue ;; esac; "
-    cmd+="for path in /health /api/health; do if curl -fsS --max-time 3 \"http://\${target}:${health_port}\${path}\" >/dev/null 2>&1; then health_ok=true; break 2; fi; done; done; "
+    cmd+="for path in "
+    while IFS= read -r health_path; do
+      [[ -n "$health_path" ]] || continue
+      q_health_path=$(posix_shell_quote "$health_path")
+      cmd+="${q_health_path} "
+    done < <(health_path_rows "$health_check_json")
+    cmd+="; do if curl -fsS --max-time 3 \"http://\${target}:${health_port}\${path}\" >/dev/null 2>&1; then health_ok=true; break 2; fi; done; done; "
     cmd+="[ \"\$health_ok\" = true ] && break; sleep 1; done; "
     cmd+="[ \"\$health_ok\" = true ] || { printf 'ERROR: health check failed on port %s\\n' $(posix_shell_quote "$health_port") >&2; exit 1; }; } && "
   fi
@@ -489,18 +569,55 @@ deploy_service() {
   # source (excluded from rsync above so --delete won't clobber it). Heimdall
   # reads <deploy_path>/.deployed-commit instead of trusting /health (often no
   # commit) or an on-Pi .git (rsync deployments remove repository metadata).
-  if [[ "$deploy_mode" == "git-pull" ]]; then
+  if [[ "$health_boundary" == "network" ]]; then
+    cmd+="echo 'DEPLOY_READY'"
+  elif [[ "$deploy_mode" == "git-pull" ]]; then
     # In git-pull mode the remote HEAD is the ground truth (origin/main was
     # just pulled) — stamp that, not the local checkout's commit.
     cmd+="git rev-parse HEAD > .deployed-commit && "
   else
     cmd+="printf '%s\\n' $(posix_shell_quote "$commit_full") > .deployed-commit && "
   fi
-  cmd+="echo 'DEPLOY_OK'"
+  if [[ "$health_boundary" != "network" ]]; then
+    cmd+="echo 'DEPLOY_OK'"
+  fi
 
   local output
   if output=$(ssh -o ConnectTimeout=10 "$remote" "$cmd" 2>&1); then
-    if echo "$output" | grep -q "DEPLOY_OK"; then
+    if [[ "$health_boundary" == "network" ]] && echo "$output" | grep -q "DEPLOY_READY"; then
+      if ! network_health_check "$remote_host" "$health_port" "$health_check_json"; then
+        report_markerless_failure
+        echo -e "${RED}FAILED${NC}"
+        results+=("${RED}✗${NC} ${name}")
+        fail=$((fail + 1))
+        return
+      fi
+      local stamp_cmd
+      if [[ "$deploy_mode" == "git-pull" ]]; then
+        stamp_cmd="cd ${q_deploy_path} && git rev-parse HEAD > .deployed-commit && echo DEPLOY_OK"
+      else
+        stamp_cmd="cd ${q_deploy_path} && printf '%s\\n' $(posix_shell_quote "$commit_full") > .deployed-commit && echo DEPLOY_OK"
+      fi
+      if ! output=$(ssh -o ConnectTimeout=10 "$remote" "$stamp_cmd" 2>&1) ||
+         ! echo "$output" | grep -q "DEPLOY_OK"; then
+        [[ -n "$output" ]] && echo "$output"
+        report_markerless_failure
+        echo -e "${RED}FAILED${NC}"
+        results+=("${RED}✗${NC} ${name}")
+        fail=$((fail + 1))
+        return
+      fi
+      echo -e "${GREEN}OK${NC}"
+      results+=("${GREEN}✓${NC} ${name}")
+      pass=$((pass + 1))
+    elif [[ "$health_boundary" == "network" ]]; then
+      [[ -n "$output" ]] && echo "$output"
+      echo "ERROR: remote restart gates returned no trustworthy readiness receipt" >&2
+      report_markerless_failure
+      echo -e "${RED}FAILED${NC}"
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+    elif echo "$output" | grep -q "DEPLOY_OK"; then
       echo -e "${GREEN}OK${NC}"
       results+=("${GREEN}✓${NC} ${name}")
       pass=$((pass + 1))
@@ -534,6 +651,9 @@ for entry in "${SERVICES[@]}"; do
   units_json=$(service_field "$entry" systemd_units)
   rsync_excludes_json=$(service_field "$entry" rsync_excludes)
   health_port=$(service_field "$entry" port)
+  persistent_paths_json=$(service_field "$entry" persistent_paths)
+  systemd_runtime_json=$(service_field "$entry" systemd_runtime)
+  health_check_json=$(service_field "$entry" health_check)
 
   if [[ ${#requested[@]} -gt 0 ]]; then
     match=false
@@ -543,7 +663,7 @@ for entry in "${SERVICES[@]}"; do
     $match || continue
   fi
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}" "${health_port:-}"
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}" "${health_port:-}" "${persistent_paths_json:-[]}" "${systemd_runtime_json:-null}" "${health_check_json:-null}"
 done
 
 # Summary

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -256,7 +256,7 @@ deploy_service() {
   local commit_full
   local dirty_state
   local q_deploy_path
-  local render_enabled=false health_boundary=host
+  local render_enabled=false health_boundary=host health_probe_host=
 
   if [[ "$systemd_runtime_json" != "null" && -n "$systemd_runtime_json" ]]; then
     render_enabled=true
@@ -264,6 +264,10 @@ deploy_service() {
   if [[ "$health_check_json" != "null" && -n "$health_check_json" ]]; then
     health_boundary=$(HEALTH_JSON="$health_check_json" node --input-type=commonjs -e \
       'process.stdout.write(JSON.parse(process.env.HEALTH_JSON).boundary)')
+    health_probe_host=$(HEALTH_JSON="$health_check_json" node --input-type=commonjs -e '
+      var host = JSON.parse(process.env.HEALTH_JSON).host;
+      if (typeof host === "string") process.stdout.write(host);
+    ')
   fi
 
   echo -e "\n${BOLD}=== ${name} (${host}) ===${NC}"
@@ -585,7 +589,7 @@ deploy_service() {
   local output
   if output=$(ssh -o ConnectTimeout=10 "$remote" "$cmd" 2>&1); then
     if [[ "$health_boundary" == "network" ]] && echo "$output" | grep -q "DEPLOY_READY"; then
-      if ! network_health_check "$remote_host" "$health_port" "$health_check_json"; then
+      if ! network_health_check "$health_probe_host" "$health_port" "$health_check_json"; then
         report_markerless_failure
         echo -e "${RED}FAILED${NC}"
         results+=("${RED}✗${NC} ${name}")

--- a/scripts/lib/deploy-safety.sh
+++ b/scripts/lib/deploy-safety.sh
@@ -16,8 +16,15 @@ posix_shell_quote() {
 # component-owned template was selected instead of an install-ready unit.
 # Comments may document placeholders without making the unit unsafe.
 unit_template_token_awk() {
+  local render_enabled=${1:-false}
+  local allowed=''
+  if [[ "$render_enabled" == "true" ]]; then
+    allowed=' token != "<user>" && token != "<home>" && token != "<deploy-path>" && token != "<install-dir>" &&'
+  fi
   # shellcheck disable=SC2016 # emitted for awk, not expanded by this shell
-  printf '%s' '/^[[:space:]]*[#;]/ { next } match($0, /<[A-Za-z][A-Za-z0-9_-]*>/) { print substr($0, RSTART, RLENGTH); exit }'
+  printf '%s' '/^[[:space:]]*[#;]/ { next } { rest=$0; while (match(rest, /<[A-Za-z][A-Za-z0-9_-]*>/)) { token=substr(rest, RSTART, RLENGTH); if ('
+  printf '%s' "${allowed:-1 &&}"
+  printf '%s' ' 1) { print token; exit } rest=substr(rest, RSTART + RLENGTH) } }'
 }
 
 resolve_local_unit_source() {
@@ -32,7 +39,7 @@ resolve_local_unit_source() {
 }
 
 preflight_local_install_ready_unit_source() {
-  local repo_path=$1 unit_file=$2 required=${3:-true}
+  local repo_path=$1 unit_file=$2 required=${3:-true} render_enabled=${4:-false}
   local source token
 
   if ! source=$(resolve_local_unit_source "$repo_path" "$unit_file"); then
@@ -44,7 +51,7 @@ preflight_local_install_ready_unit_source() {
     return 0
   fi
 
-  token=$(awk "$(unit_template_token_awk)" "$source")
+  token=$(awk "$(unit_template_token_awk "$render_enabled")" "$source")
   if [[ -n "$token" ]]; then
     printf 'ERROR: unit source is not install-ready: %s (unit %s contains unresolved placeholder %s)\n' \
       "$source" "$unit_file" "$token" >&2

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -75,7 +75,10 @@ switch (query) {
         unit_scope: unitScope,
         deploy_mode: deployMode,
         systemd_units: c.systemd_units || [],
-        rsync_excludes: c.rsync_excludes || []
+        rsync_excludes: c.rsync_excludes || [],
+        persistent_paths: c.persistent_paths || [],
+        systemd_runtime: c.systemd_runtime || null,
+        health_check: c.health_check || null
       }) + '\n');
     });
     break;

--- a/scripts/lib/render-systemd-units.sh
+++ b/scripts/lib/render-systemd-units.sh
@@ -375,6 +375,32 @@ if (errors.length) {
 }
 NODE
 
+# systemd-analyze loads every command-line unit plus referenced units. Verify
+# each manager scope as one complete rendered set, with the temporary render
+# directory taking precedence over installed units. The trailing empty search
+# path component retains the manager's standard unit paths for dependencies.
+system_units=()
+user_units=()
+while IFS='|' read -r unit_file unit_scope; do
+  [[ -n "$unit_file" ]] || continue
+  if [[ "$unit_scope" == "user" ]]; then
+    user_units+=("$render_dir/$unit_file")
+  else
+    system_units+=("$render_dir/$unit_file")
+  fi
+done < "$manifest"
+
+if [[ ${#system_units[@]} -gt 0 ]] &&
+    ! SYSTEMD_UNIT_PATH="$render_dir:" systemd-analyze --system verify "${system_units[@]}"; then
+  echo "ERROR: systemd-analyze verify failed for rendered system units" >&2
+  exit 1
+fi
+if [[ ${#user_units[@]} -gt 0 ]] &&
+    ! SYSTEMD_UNIT_PATH="$render_dir:" systemd-analyze --user verify "${user_units[@]}"; then
+  echo "ERROR: systemd-analyze verify failed for rendered user units" >&2
+  exit 1
+fi
+
 system_root="${SYSTEMD_SYSTEM_ROOT:-/etc/systemd/system}"
 install_plan="$render_dir/install-plan"
 installed_plan="$render_dir/installed-plan"

--- a/scripts/lib/render-systemd-units.sh
+++ b/scripts/lib/render-systemd-units.sh
@@ -214,14 +214,14 @@ function last(map, key) {
   return values.length ? values[values.length - 1] : null;
 }
 
-function requireExisting(file, candidate, kind) {
+function requireExisting(file, candidate, kind, allowSymlink = false) {
   if (!canonicalAbsolute(candidate)) {
     fail(file, kind + " is not a canonical absolute path: " + candidate);
     return false;
   }
   try {
     const info = fs.lstatSync(candidate);
-    if (info.isSymbolicLink()) {
+    if (info.isSymbolicLink() && !allowSymlink) {
       fail(file, kind + " must not be a symlink: " + candidate);
       return false;
     }
@@ -288,7 +288,7 @@ for (const entry of manifest) {
       continue;
     }
     const executable = tokens[0].replace(/^[+\-!:@]+/, "");
-    if (!requireExisting(entry.file, executable, "ExecStart executable")) continue;
+    if (!requireExisting(entry.file, executable, "ExecStart executable", true)) continue;
     try {
       fs.accessSync(executable, fs.constants.X_OK);
     } catch (_) {

--- a/scripts/lib/render-systemd-units.sh
+++ b/scripts/lib/render-systemd-units.sh
@@ -234,15 +234,19 @@ function requireExisting(file, candidate, kind, allowSymlink = false) {
 
 const environmentFiles = runtime.environment_files || [];
 const sandboxPaths = runtime.sandbox_paths || [];
-const allowedSandboxRoots = [runtime.deploy_target].concat(persistentPaths, sandboxPaths);
+const ownedSandboxRoots = [runtime.deploy_target].concat(persistentPaths);
+
+function allowedSandboxPath(candidate, directive) {
+  if (ownedSandboxRoots.some((root) => within(candidate, root))) return true;
+  const exactExternalReadOnly = directive === "ReadOnlyPaths" ||
+    directive === "BindReadOnlyPaths" || directive === "InaccessiblePaths";
+  return exactExternalReadOnly && sandboxPaths.includes(candidate);
+}
 
 for (const envFile of environmentFiles) {
   requireExisting("runtime", envFile, "declared environment file");
 }
 for (const sandboxPath of sandboxPaths) {
-  if (!allowedSandboxRoots.some((root) => within(sandboxPath, root))) {
-    fail("runtime", "sandbox path is outside registered roots: " + sandboxPath);
-  }
   requireExisting("runtime", sandboxPath, "declared sandbox path");
 }
 
@@ -354,7 +358,7 @@ for (const entry of manifest) {
             fail(entry.file, key + " contains a non-absolute path: " + candidate);
             continue;
           }
-          if (!allowedSandboxRoots.some((root) => within(candidate, root))) {
+          if (!allowedSandboxPath(candidate, key)) {
             fail(entry.file, key + " path is outside registered roots: " + candidate);
           }
           requireExisting(entry.file, candidate, key + " path");
@@ -372,39 +376,120 @@ if (errors.length) {
 NODE
 
 system_root="${SYSTEMD_SYSTEM_ROOT:-/etc/systemd/system}"
+install_plan="$render_dir/install-plan"
+installed_plan="$render_dir/installed-plan"
+mkdir -p "$render_dir/backups"
+: > "$install_plan"
+: > "$installed_plan"
+
+destination_is_symlink() {
+  local privileged=$1 destination=$2
+  if [[ "$privileged" == "true" ]]; then
+    sudo test -L "$destination"
+  else
+    [[ -L "$destination" ]]
+  fi
+}
+
+destination_is_file() {
+  local privileged=$1 destination=$2
+  if [[ "$privileged" == "true" ]]; then
+    sudo test -f "$destination"
+  else
+    [[ -f "$destination" ]]
+  fi
+}
+
+copy_preserving() {
+  local privileged=$1 source=$2 destination=$3
+  if [[ "$privileged" == "true" ]]; then
+    sudo cp -p -- "$source" "$destination"
+  else
+    cp -p -- "$source" "$destination"
+  fi
+}
+
+install_rendered() {
+  local privileged=$1 source=$2 destination=$3
+  if [[ "$privileged" == "true" ]]; then
+    sudo install -D -m644 "$source" "$destination"
+  else
+    install -D -m644 "$source" "$destination"
+  fi
+}
+
+remove_destination() {
+  local privileged=$1 destination=$2
+  if [[ "$privileged" == "true" ]]; then
+    sudo rm -f -- "$destination"
+  else
+    rm -f -- "$destination"
+  fi
+}
+
+install_index=0
 while IFS='|' read -r unit_file unit_scope; do
   [[ -n "$unit_file" ]] || continue
+  install_index=$((install_index + 1))
+  privileged=false
   if [[ "$unit_scope" == "user" ]]; then
     unit_destination="$runtime_home/.config/systemd/user/$unit_file"
-    if [[ -L "$unit_destination" ]]; then
-      echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
-      exit 1
-    fi
-    if [[ -f "$unit_destination" ]]; then
-      cp -p -- "$unit_destination" "${unit_destination}.grimnir-previous"
-    fi
-    install -D -m644 "$render_dir/$unit_file" "$unit_destination"
   elif [[ "$system_root" == "/etc/systemd/system" ]]; then
     unit_destination="$system_root/$unit_file"
-    if sudo test -L "$unit_destination"; then
-      echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
-      exit 1
-    fi
-    if sudo test -f "$unit_destination"; then
-      sudo cp -p -- "$unit_destination" "${unit_destination}.grimnir-previous"
-    fi
-    sudo install -D -m644 "$render_dir/$unit_file" "$unit_destination"
+    privileged=true
   else
     unit_destination="$system_root/$unit_file"
-    if [[ -L "$unit_destination" ]]; then
-      echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
-      exit 1
-    fi
-    if [[ -f "$unit_destination" ]]; then
-      cp -p -- "$unit_destination" "${unit_destination}.grimnir-previous"
-    fi
-    install -D -m644 "$render_dir/$unit_file" "$unit_destination"
   fi
+
+  if destination_is_symlink "$privileged" "$unit_destination"; then
+    echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
+    exit 1
+  fi
+
+  backup="$render_dir/backups/$install_index"
+  had_previous=false
+  if destination_is_file "$privileged" "$unit_destination"; then
+    copy_preserving "$privileged" "$unit_destination" "$backup"
+    copy_preserving "$privileged" "$backup" "${unit_destination}.grimnir-previous"
+    had_previous=true
+  fi
+  printf '%s|%s|%s|%s|%s\n' \
+    "$unit_file" "$unit_destination" "$privileged" "$had_previous" "$backup" >> "$install_plan"
 done < "$manifest"
+
+install_failed=false
+while IFS='|' read -r unit_file unit_destination privileged had_previous backup; do
+  [[ -n "$unit_file" ]] || continue
+  if install_rendered "$privileged" "$render_dir/$unit_file" "$unit_destination"; then
+    printf '%s|%s|%s|%s|%s\n' \
+      "$unit_file" "$unit_destination" "$privileged" "$had_previous" "$backup" >> "$installed_plan"
+  else
+    echo "ERROR: failed to install rendered unit: $unit_destination" >&2
+    install_failed=true
+    break
+  fi
+done < "$install_plan"
+
+if [[ "$install_failed" == "true" ]]; then
+  rollback_failed=false
+  while IFS='|' read -r unit_file unit_destination privileged had_previous backup; do
+    [[ -n "$unit_file" ]] || continue
+    if [[ "$had_previous" == "true" ]]; then
+      if ! copy_preserving "$privileged" "$backup" "$unit_destination"; then
+        echo "ERROR: failed to restore prior unit after install failure: $unit_destination" >&2
+        rollback_failed=true
+      fi
+    elif ! remove_destination "$privileged" "$unit_destination"; then
+      echo "ERROR: failed to remove newly installed unit after install failure: $unit_destination" >&2
+      rollback_failed=true
+    fi
+  done < "$installed_plan"
+  if [[ "$rollback_failed" == "true" ]]; then
+    echo "ERROR: rendered unit rollback was incomplete; inspect destinations before daemon-reload" >&2
+  else
+    echo "ERROR: restored all previously replaced units; daemon-reload was not requested" >&2
+  fi
+  exit 1
+fi
 
 echo "SYSTEMD_UNITS_PREPARED"

--- a/scripts/lib/render-systemd-units.sh
+++ b/scripts/lib/render-systemd-units.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# Render registry-authorized systemd templates, preflight every rendered unit,
+# then install them as one fail-closed phase. This script is streamed to the
+# target by deploy.sh; it does not rely on component-owned deployment logic.
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "ERROR: usage: render-systemd-units.sh DEPLOY_PATH RUNTIME_JSON UNITS_JSON PERSISTENT_PATHS_JSON" >&2
+  exit 2
+fi
+
+deploy_path=$1
+runtime_json=$2
+units_json=$3
+persistent_paths_json=$4
+
+json_field() {
+  local json=$1 field=$2
+  JSON_INPUT="$json" JSON_FIELD="$field" node --input-type=commonjs -e '
+    var value = JSON.parse(process.env.JSON_INPUT)[process.env.JSON_FIELD];
+    if (value === undefined || value === null) process.exit(1);
+    process.stdout.write(typeof value === "object" ? JSON.stringify(value) : String(value));
+  '
+}
+
+runtime_user=$(json_field "$runtime_json" user)
+runtime_home=$(json_field "$runtime_json" home)
+runtime_target=$(json_field "$runtime_json" deploy_target)
+
+if [[ "$deploy_path" != "$runtime_target" ]]; then
+  echo "ERROR: runtime deploy_target does not match registry deploy_path" >&2
+  exit 1
+fi
+
+passwd_entry=$(getent passwd "$runtime_user" 2>/dev/null || true)
+if [[ -z "$passwd_entry" ]]; then
+  echo "ERROR: runtime user does not exist: $runtime_user" >&2
+  exit 1
+fi
+IFS=: read -r passwd_user _ _ _ _ passwd_home _ <<< "$passwd_entry"
+if [[ "$passwd_user" != "$runtime_user" || "$passwd_home" != "$runtime_home" ]]; then
+  echo "ERROR: runtime user/home mismatch for $runtime_user: expected $runtime_home, got ${passwd_home:-unknown}" >&2
+  exit 1
+fi
+if [[ ! -d "$deploy_path" || -L "$deploy_path" ]]; then
+  echo "ERROR: deploy target is missing, not a directory, or symlinked: $deploy_path" >&2
+  exit 1
+fi
+
+render_dir=$(mktemp -d)
+trap 'rm -rf "$render_dir"' EXIT
+manifest="$render_dir/manifest"
+: > "$manifest"
+
+unit_rows() {
+  UNITS_JSON="$units_json" node --input-type=commonjs -e '
+    var units = JSON.parse(process.env.UNITS_JSON);
+    units.forEach(function (unit) {
+      process.stdout.write([
+        unit.name,
+        unit.type || "service",
+        unit.scope || "system"
+      ].join("|") + "\n");
+    });
+  '
+}
+
+resolve_source() {
+  local unit_file=$1 candidate
+  for candidate in "$deploy_path/systemd/$unit_file" "$deploy_path/$unit_file"; do
+    if [[ -f "$candidate" && ! -L "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+render_one() {
+  local unit_file=$1 scope=$2 required=$3 source destination install_dir token
+  if ! source=$(resolve_source "$unit_file"); then
+    if [[ "$required" == "true" ]]; then
+      echo "ERROR: unit file missing: $unit_file" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  destination="$render_dir/$unit_file"
+  install_dir=${deploy_path##*/}
+  RUNTIME_USER="$runtime_user" RUNTIME_HOME="$runtime_home" \
+    DEPLOY_TARGET="$deploy_path" INSTALL_DIR="$install_dir" \
+    awk '
+      {
+        gsub(/<user>/, ENVIRON["RUNTIME_USER"]);
+        gsub(/<home>/, ENVIRON["RUNTIME_HOME"]);
+        gsub(/<deploy-path>/, ENVIRON["DEPLOY_TARGET"]);
+        gsub(/<install-dir>/, ENVIRON["INSTALL_DIR"]);
+        print;
+      }
+    ' "$source" > "$destination"
+
+  token=$(awk '/^[[:space:]]*[#;]/ { next } match($0, /<[A-Za-z][A-Za-z0-9_-]*>/) { print substr($0, RSTART, RLENGTH); exit }' "$destination")
+  if [[ -n "$token" ]]; then
+    echo "ERROR: rendered unit contains unresolved placeholder $token: $unit_file" >&2
+    return 1
+  fi
+  printf '%s|%s\n' "$unit_file" "$scope" >> "$manifest"
+}
+
+rows=$(unit_rows)
+while IFS='|' read -r unit_name unit_kind unit_scope; do
+  [[ -n "$unit_name" ]] || continue
+  render_one "${unit_name}.${unit_kind}" "$unit_scope" true
+  if [[ "$unit_kind" == "timer" ]]; then
+    render_one "${unit_name}.service" "$unit_scope" false
+  fi
+done <<< "$rows"
+
+RUNTIME_JSON="$runtime_json" PERSISTENT_PATHS_JSON="$persistent_paths_json" \
+  RENDER_MANIFEST="$manifest" RENDER_DIR="$render_dir" node <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const runtime = JSON.parse(process.env.RUNTIME_JSON);
+const persistentPaths = JSON.parse(process.env.PERSISTENT_PATHS_JSON);
+const manifest = fs.readFileSync(process.env.RENDER_MANIFEST, "utf8")
+  .trim().split("\n").filter(Boolean).map((line) => {
+    const split = line.lastIndexOf("|");
+    return { file: line.slice(0, split), scope: line.slice(split + 1) };
+  });
+const errors = [];
+
+function fail(file, message) {
+  errors.push(file + ": " + message);
+}
+
+function within(candidate, root) {
+  return candidate === root || candidate.startsWith(root + "/");
+}
+
+function canonicalAbsolute(value) {
+  return typeof value === "string" && path.posix.isAbsolute(value) &&
+    path.posix.normalize(value) === value && value !== "/";
+}
+
+function tokenize(value) {
+  const tokens = [];
+  let token = "";
+  let quote = null;
+  let escaped = false;
+  for (const char of value) {
+    if (escaped) {
+      token += char;
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (quote) {
+      if (char === quote) quote = null;
+      else token += char;
+    } else if (char === "'" || char === '"') {
+      quote = char;
+    } else if (/\s/.test(char)) {
+      if (token) {
+        tokens.push(token);
+        token = "";
+      }
+    } else {
+      token += char;
+    }
+  }
+  if (escaped || quote) throw new Error("unsupported or unterminated quoting");
+  if (token) tokens.push(token);
+  return tokens;
+}
+
+function directives(source) {
+  const logical = [];
+  let pending = "";
+  for (const physical of source.split(/\r?\n/)) {
+    const line = pending + physical;
+    if (line.endsWith("\\")) pending = line.slice(0, -1);
+    else {
+      logical.push(line);
+      pending = "";
+    }
+  }
+  if (pending) throw new Error("unterminated line continuation");
+
+  let section = "";
+  const result = new Map();
+  for (const raw of logical) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#") || line.startsWith(";")) continue;
+    const sectionMatch = line.match(/^\[([A-Za-z]+)\]$/);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      continue;
+    }
+    if (section !== "Service") continue;
+    const equals = line.indexOf("=");
+    if (equals < 1) continue;
+    const key = line.slice(0, equals).trim();
+    const value = line.slice(equals + 1).trim();
+    if (!result.has(key)) result.set(key, []);
+    result.get(key).push(value);
+  }
+  return result;
+}
+
+function last(map, key) {
+  const values = map.get(key) || [];
+  return values.length ? values[values.length - 1] : null;
+}
+
+function requireExisting(file, candidate, kind) {
+  if (!canonicalAbsolute(candidate)) {
+    fail(file, kind + " is not a canonical absolute path: " + candidate);
+    return false;
+  }
+  try {
+    const info = fs.lstatSync(candidate);
+    if (info.isSymbolicLink()) {
+      fail(file, kind + " must not be a symlink: " + candidate);
+      return false;
+    }
+    return true;
+  } catch (_) {
+    fail(file, kind + " does not exist: " + candidate);
+    return false;
+  }
+}
+
+const environmentFiles = runtime.environment_files || [];
+const sandboxPaths = runtime.sandbox_paths || [];
+const allowedSandboxRoots = [runtime.deploy_target].concat(persistentPaths, sandboxPaths);
+
+for (const envFile of environmentFiles) {
+  requireExisting("runtime", envFile, "declared environment file");
+}
+for (const sandboxPath of sandboxPaths) {
+  if (!allowedSandboxRoots.some((root) => within(sandboxPath, root))) {
+    fail("runtime", "sandbox path is outside registered roots: " + sandboxPath);
+  }
+  requireExisting("runtime", sandboxPath, "declared sandbox path");
+}
+
+for (const entry of manifest) {
+  if (!entry.file.endsWith(".service")) continue;
+  const fullPath = path.join(process.env.RENDER_DIR, entry.file);
+  let parsed;
+  try {
+    parsed = directives(fs.readFileSync(fullPath, "utf8"));
+  } catch (error) {
+    fail(entry.file, error.message);
+    continue;
+  }
+
+  const user = last(parsed, "User");
+  if (entry.scope === "system" && user !== runtime.user) {
+    fail(entry.file, "User must equal registered runtime user " + runtime.user);
+  } else if (entry.scope === "user" && user && user !== runtime.user) {
+    fail(entry.file, "User conflicts with registered runtime user " + runtime.user);
+  }
+
+  const workingDirectory = last(parsed, "WorkingDirectory");
+  if (workingDirectory !== runtime.deploy_target) {
+    fail(entry.file, "WorkingDirectory must equal registered deploy target " + runtime.deploy_target);
+  } else {
+    requireExisting(entry.file, workingDirectory, "WorkingDirectory");
+  }
+
+  const execStarts = (parsed.get("ExecStart") || []).filter(Boolean);
+  if (execStarts.length === 0) {
+    fail(entry.file, "ExecStart is required");
+  }
+  for (const execStart of execStarts) {
+    let tokens;
+    try {
+      tokens = tokenize(execStart);
+    } catch (error) {
+      fail(entry.file, "ExecStart " + error.message);
+      continue;
+    }
+    if (!tokens.length) {
+      fail(entry.file, "ExecStart is empty");
+      continue;
+    }
+    const executable = tokens[0].replace(/^[+\-!:@]+/, "");
+    if (!requireExisting(entry.file, executable, "ExecStart executable")) continue;
+    try {
+      fs.accessSync(executable, fs.constants.X_OK);
+    } catch (_) {
+      fail(entry.file, "ExecStart executable is not executable: " + executable);
+    }
+    for (const argument of tokens.slice(1)) {
+      let candidate = argument;
+      const equals = candidate.indexOf("=/");
+      if (equals >= 0) candidate = candidate.slice(equals + 1);
+      if (!candidate.startsWith("/")) continue;
+      if (!within(candidate, runtime.deploy_target)) {
+        fail(entry.file, "ExecStart path is outside registered deploy target: " + candidate);
+      }
+      requireExisting(entry.file, candidate, "ExecStart path");
+    }
+  }
+
+  const actualEnvironmentFiles = [];
+  for (const value of parsed.get("EnvironmentFile") || []) {
+    let tokens;
+    try {
+      tokens = tokenize(value);
+    } catch (error) {
+      fail(entry.file, "EnvironmentFile " + error.message);
+      continue;
+    }
+    for (let candidate of tokens) {
+      if (candidate.startsWith("-")) {
+        fail(entry.file, "registered private environment file must not be optional: " + candidate);
+        candidate = candidate.slice(1);
+      }
+      actualEnvironmentFiles.push(candidate);
+      if (!environmentFiles.includes(candidate)) {
+        fail(entry.file, "EnvironmentFile is not registered: " + candidate);
+      }
+      requireExisting(entry.file, candidate, "EnvironmentFile");
+    }
+  }
+  for (const required of environmentFiles) {
+    if (!actualEnvironmentFiles.includes(required)) {
+      fail(entry.file, "required EnvironmentFile is absent: " + required);
+    }
+  }
+
+  const sandboxDirectives = [
+    "ReadWritePaths", "ReadOnlyPaths", "InaccessiblePaths",
+    "BindPaths", "BindReadOnlyPaths"
+  ];
+  for (const key of sandboxDirectives) {
+    for (const value of parsed.get(key) || []) {
+      let tokens;
+      try {
+        tokens = tokenize(value);
+      } catch (error) {
+        fail(entry.file, key + " " + error.message);
+        continue;
+      }
+      for (let token of tokens) {
+        token = token.replace(/^[+\-]+/, "");
+        const candidates = key.startsWith("Bind") ? token.split(":").slice(0, 2) : [token];
+        for (const candidate of candidates) {
+          if (!candidate || !candidate.startsWith("/")) {
+            fail(entry.file, key + " contains a non-absolute path: " + candidate);
+            continue;
+          }
+          if (!allowedSandboxRoots.some((root) => within(candidate, root))) {
+            fail(entry.file, key + " path is outside registered roots: " + candidate);
+          }
+          requireExisting(entry.file, candidate, key + " path");
+        }
+      }
+    }
+  }
+}
+
+if (errors.length) {
+  console.error("ERROR: rendered systemd preflight failed:");
+  for (const error of errors) console.error("  - " + error);
+  process.exit(1);
+}
+NODE
+
+system_root="${SYSTEMD_SYSTEM_ROOT:-/etc/systemd/system}"
+while IFS='|' read -r unit_file unit_scope; do
+  [[ -n "$unit_file" ]] || continue
+  if [[ "$unit_scope" == "user" ]]; then
+    unit_destination="$runtime_home/.config/systemd/user/$unit_file"
+    if [[ -L "$unit_destination" ]]; then
+      echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
+      exit 1
+    fi
+    if [[ -f "$unit_destination" ]]; then
+      cp -p -- "$unit_destination" "${unit_destination}.grimnir-previous"
+    fi
+    install -D -m644 "$render_dir/$unit_file" "$unit_destination"
+  elif [[ "$system_root" == "/etc/systemd/system" ]]; then
+    unit_destination="$system_root/$unit_file"
+    if sudo test -L "$unit_destination"; then
+      echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
+      exit 1
+    fi
+    if sudo test -f "$unit_destination"; then
+      sudo cp -p -- "$unit_destination" "${unit_destination}.grimnir-previous"
+    fi
+    sudo install -D -m644 "$render_dir/$unit_file" "$unit_destination"
+  else
+    unit_destination="$system_root/$unit_file"
+    if [[ -L "$unit_destination" ]]; then
+      echo "ERROR: refusing to replace symlinked unit destination: $unit_destination" >&2
+      exit 1
+    fi
+    if [[ -f "$unit_destination" ]]; then
+      cp -p -- "$unit_destination" "${unit_destination}.grimnir-previous"
+    fi
+    install -D -m644 "$render_dir/$unit_file" "$unit_destination"
+  fi
+done < "$manifest"
+
+echo "SYSTEMD_UNITS_PREPARED"

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -58,6 +58,8 @@ var VALID_COMPONENT_ID = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
 var VALID_HOST = /^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/;
 var VALID_ABSOLUTE_PATH = /^\/[A-Za-z0-9._@%+,=:\/-]+$/;
 var INVALID_RSYNC_EXCLUDE_CHARS = /[\x00-\x1f*?[\]{}\\]/;
+var VALID_HEALTH_BOUNDARIES = ['host', 'network'];
+var VALID_HEALTH_PATH = /^\/[A-Za-z0-9._~%+\/-]*$/;
 
 function isWithinPath(candidate, parent) {
   if (parent === '/') return path.posix.isAbsolute(candidate);
@@ -193,6 +195,92 @@ data.components.forEach(function (c, i) {
           persistentPath + ' (expected a root-anchored exclusion for /' + relativePath + ')');
       }
     });
+  }
+
+  if (c.systemd_runtime !== undefined) {
+    var runtime = c.systemd_runtime;
+    if (!isPlainObject(runtime)) {
+      fail(label + ': "systemd_runtime" must be an object when present');
+    } else {
+      if (c.deploy !== true || deployMode !== 'rsync') {
+        fail(label + ': "systemd_runtime" is only supported for deploy=true rsync components');
+      }
+      if (typeof runtime.user !== 'string' || !/^[a-z_][a-z0-9_-]*$/.test(runtime.user)) {
+        fail(label + '.systemd_runtime.user: must be a safe POSIX account name');
+      }
+      ['home', 'deploy_target'].forEach(function (field) {
+        if (!isCanonicalAbsolutePath(runtime[field])) {
+          fail(label + '.systemd_runtime.' + field + ': must be a canonical absolute path below /');
+        }
+      });
+      if (typeof runtime.deploy_target === 'string' && runtime.deploy_target !== c.deploy_path) {
+        fail(label + '.systemd_runtime.deploy_target: must exactly match deploy_path');
+      }
+      if (isCanonicalAbsolutePath(runtime.home) && isCanonicalAbsolutePath(runtime.deploy_target) &&
+          !isWithinPath(runtime.deploy_target, runtime.home)) {
+        fail(label + '.systemd_runtime.deploy_target: must be within the registered runtime home');
+      }
+
+      ['environment_files', 'sandbox_paths'].forEach(function (field) {
+        if (!Array.isArray(runtime[field])) {
+          fail(label + '.systemd_runtime.' + field + ': must be an explicit array');
+          return;
+        }
+        runtime[field].forEach(function (runtimePath, ri) {
+          if (!isCanonicalAbsolutePath(runtimePath)) {
+            fail(label + '.systemd_runtime.' + field + '[' + ri + ']: must be a canonical absolute path below /');
+          }
+        });
+      });
+
+      if (Array.isArray(runtime.environment_files) && isCanonicalAbsolutePath(runtime.deploy_target)) {
+        runtime.environment_files.forEach(function (environmentFile) {
+          if (isCanonicalAbsolutePath(environmentFile) &&
+              !isWithinPath(environmentFile, runtime.deploy_target)) {
+            fail(label + '.systemd_runtime.environment_files: private environment files must live within deploy_target');
+          }
+        });
+      }
+      if (Array.isArray(runtime.sandbox_paths) && isCanonicalAbsolutePath(runtime.deploy_target)) {
+        runtime.sandbox_paths.forEach(function (sandboxPath) {
+          if (!isCanonicalAbsolutePath(sandboxPath)) return;
+          var registered = isWithinPath(sandboxPath, runtime.deploy_target) ||
+            persistentPaths.some(function (persistentPath) {
+              return isCanonicalAbsolutePath(persistentPath) && isWithinPath(sandboxPath, persistentPath);
+            });
+          if (!registered) {
+            fail(label + '.systemd_runtime.sandbox_paths: path must be within deploy_target or persistent_paths: ' +
+              sandboxPath);
+          }
+        });
+      }
+      if (!isPlainObject(c.health_check)) {
+        fail(label + ': systemd_runtime requires an explicit "health_check" object');
+      }
+    }
+  }
+
+  if (c.health_check !== undefined) {
+    if (!isPlainObject(c.health_check)) {
+      fail(label + ': "health_check" must be an object when present');
+    } else {
+      if (VALID_HEALTH_BOUNDARIES.indexOf(c.health_check.boundary) === -1) {
+        fail(label + '.health_check.boundary: must be one of ' + VALID_HEALTH_BOUNDARIES.join('/'));
+      }
+      if (!Array.isArray(c.health_check.paths) || c.health_check.paths.length === 0) {
+        fail(label + '.health_check.paths: must be a non-empty array');
+      } else {
+        c.health_check.paths.forEach(function (healthPath, hi) {
+          if (typeof healthPath !== 'string' || !VALID_HEALTH_PATH.test(healthPath) ||
+              healthPath.indexOf('//') !== -1) {
+            fail(label + '.health_check.paths[' + hi + ']: must be a safe absolute HTTP path');
+          }
+        });
+      }
+      if (!Number.isInteger(c.port) || c.port < 1 || c.port > 65535) {
+        fail(label + ': health_check requires a registered port');
+      }
+    }
   }
 
   if (!Array.isArray(c.systemd_units)) {

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -235,22 +235,15 @@ data.components.forEach(function (c, i) {
 
       if (Array.isArray(runtime.environment_files) && isCanonicalAbsolutePath(runtime.deploy_target)) {
         runtime.environment_files.forEach(function (environmentFile) {
-          if (isCanonicalAbsolutePath(environmentFile) &&
-              !isWithinPath(environmentFile, runtime.deploy_target)) {
-            fail(label + '.systemd_runtime.environment_files: private environment files must live within deploy_target');
-          }
-        });
-      }
-      if (Array.isArray(runtime.sandbox_paths) && isCanonicalAbsolutePath(runtime.deploy_target)) {
-        runtime.sandbox_paths.forEach(function (sandboxPath) {
-          if (!isCanonicalAbsolutePath(sandboxPath)) return;
-          var registered = isWithinPath(sandboxPath, runtime.deploy_target) ||
+          if (!isCanonicalAbsolutePath(environmentFile)) return;
+          var registered = isWithinPath(environmentFile, runtime.deploy_target) ||
             persistentPaths.some(function (persistentPath) {
-              return isCanonicalAbsolutePath(persistentPath) && isWithinPath(sandboxPath, persistentPath);
+              return isCanonicalAbsolutePath(persistentPath) &&
+                isWithinPath(environmentFile, persistentPath);
             });
           if (!registered) {
-            fail(label + '.systemd_runtime.sandbox_paths: path must be within deploy_target or persistent_paths: ' +
-              sandboxPath);
+            fail(label + '.systemd_runtime.environment_files: private environment files must live within ' +
+              'deploy_target or persistent_paths');
           }
         });
       }

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -61,6 +61,10 @@ var INVALID_RSYNC_EXCLUDE_CHARS = /[\x00-\x1f*?[\]{}\\]/;
 var VALID_HEALTH_BOUNDARIES = ['host', 'network'];
 var VALID_HEALTH_PATH = /^\/[A-Za-z0-9._~%+\/-]*$/;
 
+function isSafeHealthHostname(value) {
+  return typeof value === 'string' && VALID_HOST.test(value) && /[A-Za-z]/.test(value);
+}
+
 function isWithinPath(candidate, parent) {
   if (parent === '/') return path.posix.isAbsolute(candidate);
   return candidate === parent || candidate.indexOf(parent + '/') === 0;
@@ -259,6 +263,13 @@ data.components.forEach(function (c, i) {
     } else {
       if (VALID_HEALTH_BOUNDARIES.indexOf(c.health_check.boundary) === -1) {
         fail(label + '.health_check.boundary: must be one of ' + VALID_HEALTH_BOUNDARIES.join('/'));
+      }
+      if (c.health_check.boundary === 'network') {
+        if (!isSafeHealthHostname(c.health_check.host)) {
+          fail(label + '.health_check.host: network boundary requires an explicit safe hostname, not an IP locator');
+        }
+      } else if (c.health_check.host !== undefined) {
+        fail(label + '.health_check.host: is only valid for the network boundary');
       }
       if (!Array.isArray(c.health_check.paths) || c.health_check.paths.length === 0) {
         fail(label + '.health_check.paths: must be a non-empty array');

--- a/scripts/tests/deploy-systemd-render.test.sh
+++ b/scripts/tests/deploy-systemd-render.test.sh
@@ -45,15 +45,17 @@ printf '%s\n' 'PRIVATE_LISTENER=tailnet-only-value' > "$PRIVATE_ENV"
 printf '%s\n' 'exit 0' > "$DEPLOY_TARGET/server.sh"
 chmod +x "$DEPLOY_TARGET/server.sh"
 printf '%s\n' 'Environment=PRIVATE_LISTENER=legacy-private-value' > "$SYSTEM_ROOT/alpha.service"
+EXEC_SYMLINK="$TMP_DIR/system-sh"
+ln -s /bin/sh "$EXEC_SYMLINK"
 
-cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << EOF
 [Unit]
 Description=Clean-install template
 [Service]
 User=<user>
 WorkingDirectory=<deploy-path>
 EnvironmentFile=<deploy-path>/.env
-ExecStart=/bin/sh <deploy-path>/server.sh
+ExecStart=$EXEC_SYMLINK <deploy-path>/server.sh
 ReadWritePaths=<home>/state
 EOF
 
@@ -93,6 +95,7 @@ assert_file_contains "private environment path is retained" "$rendered_unit" "En
 assert_file_contains "sandbox path is rendered" "$rendered_unit" "ReadWritePaths=$SANDBOX_PATH"
 assert_file_contains "previous installed unit is retained for rollback" \
   "$rendered_unit.grimnir-previous" "PRIVATE_LISTENER=legacy-private-value"
+pass "symlinked system executable is accepted after executable access validation"
 if grep -Fq 'tailnet-only-value' "$rendered_unit"; then
   fail "private environment values must not be copied into the unit"
 else

--- a/scripts/tests/deploy-systemd-render.test.sh
+++ b/scripts/tests/deploy-systemd-render.test.sh
@@ -67,7 +67,18 @@ cat > "$TMP_DIR/bin/getent" << 'EOF'
 [[ "$1" == "passwd" && "$2" == "alpha" ]]
 printf 'alpha:x:1000:1000:Alpha:%s:/bin/sh\n' "$RUNTIME_HOME"
 EOF
-chmod +x "$TMP_DIR/bin/getent"
+
+SYSTEMD_ANALYZE_CAPTURE="$TMP_DIR/systemd-analyze"
+export SYSTEMD_ANALYZE_CAPTURE
+cat > "$TMP_DIR/bin/systemd-analyze" << 'EOF'
+#!/usr/bin/env bash
+printf '%s|%s\n' "${SYSTEMD_UNIT_PATH:-}" "$*" >> "$SYSTEMD_ANALYZE_CAPTURE"
+if [[ "${SYSTEMD_ANALYZE_FAIL_SCOPE:-}" == "${1#--}" ]]; then
+  printf 'synthetic %s unit verification failure\n' "$1" >&2
+  exit 78
+fi
+EOF
+chmod +x "$TMP_DIR/bin/getent" "$TMP_DIR/bin/systemd-analyze"
 
 runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" DEPLOY_TARGET="$DEPLOY_TARGET" \
   PRIVATE_ENV="$PRIVATE_ENV" CROSS_COMPONENT_PATH="$CROSS_COMPONENT_PATH" node -e '
@@ -90,6 +101,11 @@ if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
 else
   fail "clean-install template must render and preflight"
 fi
+if grep -Eq -- '^[^|]+:\|--system verify ' "$SYSTEMD_ANALYZE_CAPTURE"; then
+  pass "system units are verified in system-manager scope before install"
+else
+  fail "system units must be verified in system-manager scope before install"
+fi
 
 rendered_unit="$SYSTEM_ROOT/alpha.service"
 assert_file_contains "runtime user is rendered" "$rendered_unit" "User=alpha"
@@ -105,6 +121,37 @@ if grep -Fq 'tailnet-only-value' "$rendered_unit"; then
   fail "private environment values must not be copied into the unit"
 else
   pass "private environment values stay outside the rendered unit"
+fi
+
+VERIFY_FAIL_ROOT="$TMP_DIR/verify-fail-systemd"
+mkdir -p "$VERIFY_FAIL_ROOT"
+printf '%s\n' 'OLD-VERIFIED-UNIT' > "$VERIFY_FAIL_ROOT/alpha.service"
+if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
+    SYSTEMD_ANALYZE_FAIL_SCOPE=system SYSTEMD_SYSTEM_ROOT="$VERIFY_FAIL_ROOT" \
+    bash "$RENDER_HELPER" "$DEPLOY_TARGET" "$runtime_json" "$units_json" "$persistent_json" \
+    >"$TMP_DIR/verify-fail.out" 2>&1; then
+  fail "systemd-analyze failure must fail the rendering phase"
+else
+  pass "systemd-analyze failure fails the rendering phase"
+fi
+if [[ "$(cat "$VERIFY_FAIL_ROOT/alpha.service")" == "OLD-VERIFIED-UNIT" &&
+      ! -e "$VERIFY_FAIL_ROOT/alpha.service.grimnir-previous" ]]; then
+  pass "systemd-analyze failure occurs before unit or rollback-snapshot mutation"
+else
+  fail "systemd-analyze failure must install nothing and create no rollback snapshot"
+fi
+
+user_units_json='[{"name":"alpha","type":"service","scope":"user"}]'
+mkdir -p "$RUNTIME_HOME/.config/systemd/user"
+if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
+    SYSTEMD_SYSTEM_ROOT="$TMP_DIR/user-scope-unused" \
+    bash "$RENDER_HELPER" "$DEPLOY_TARGET" "$runtime_json" "$user_units_json" "$persistent_json" \
+    >"$TMP_DIR/user-verify.out" 2>&1 &&
+    grep -Fq -- "--user verify " "$SYSTEMD_ANALYZE_CAPTURE"; then
+  pass "user units are verified in user-manager scope"
+else
+  sed 's/^/    /' "$TMP_DIR/user-verify.out" >&2
+  fail "user units must be verified in user-manager scope"
 fi
 
 bad_runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" DEPLOY_TARGET="$DEPLOY_TARGET" \
@@ -283,6 +330,12 @@ if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
 else
   pass "second unit install failure fails rendering phase"
 fi
+if grep -E -- '--system verify .*alpha\.service .*beta\.service' \
+    "$SYSTEMD_ANALYZE_CAPTURE" >/dev/null; then
+  pass "each scope is verified as one complete rendered unit set"
+else
+  fail "systemd-analyze must receive the complete rendered unit set for its scope"
+fi
 if [[ "$(cat "$MULTI_SYSTEM_ROOT/alpha.service")" == "OLD-alpha" &&
       "$(cat "$MULTI_SYSTEM_ROOT/beta.service")" == "OLD-beta" ]]; then
   pass "partial install failure restores the complete previous unit set"
@@ -325,7 +378,7 @@ fs.writeFileSync(process.argv[2], JSON.stringify({
       environment_files: [process.env.PRIVATE_ENV],
       sandbox_paths: [process.env.SANDBOX_PATH]
     },
-    health_check: { boundary: "network", paths: ["/health"] },
+    health_check: { boundary: "network", host: "health-h1", paths: ["/health"] },
     systemd_units: [{ name: "alpha", type: "service", scope: "system" }]
   }]
 }, null, 2));
@@ -353,8 +406,9 @@ elif [[ "$command" == *"npm ci --omit=dev"* ]]; then
 elif [[ "$*" == *"bash -s --"* ]]; then
   cat >/dev/null
   printf '%s\n' preflight >> "$ORDER_CAPTURE"
-  if [[ "${SSH_PREFLIGHT_FAIL:-false}" == "true" ]]; then
-    printf '%s\n' 'ERROR: runtime user does not exist: missing-user' >&2
+  printf '%s\n' verify >> "$ORDER_CAPTURE"
+  if [[ "${SSH_SYSTEMD_VERIFY_FAIL:-false}" == "true" ]]; then
+    printf '%s\n' 'ERROR: systemd-analyze verify failed for system units' >&2
     exit 1
   fi
   printf '%s\n' SYSTEMD_UNITS_PREPARED
@@ -383,31 +437,32 @@ EOF
 chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/curl"
 
 rc=0
-SSH_PREFLIGHT_FAIL=true REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
+SSH_SYSTEMD_VERIFY_FAIL=true REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
   bash "$DEPLOY" alpha >"$TMP_DIR/deploy.out" 2>&1 || rc=$?
 if [[ "$rc" == 1 ]]; then
-  pass "render/preflight failure fails deployment"
+  pass "systemd verification failure fails deployment"
 else
-  fail "render/preflight failure must fail deployment"
+  fail "systemd verification failure must fail deployment"
 fi
 if [[ ! -e "$REMOTE_MARKER_STATE" ]]; then
-  pass "render/preflight failure leaves accepted marker absent"
+  pass "systemd verification failure leaves accepted marker absent"
 else
-  fail "render/preflight failure must leave accepted marker absent"
+  fail "systemd verification failure must leave accepted marker absent"
 fi
-if grep -Fxq preflight "$ORDER_CAPTURE" && ! grep -Fxq restart "$ORDER_CAPTURE"; then
-  pass "render/preflight failure occurs before restart"
+if grep -Fxq verify "$ORDER_CAPTURE" && ! grep -Fxq restart "$ORDER_CAPTURE"; then
+  pass "systemd verification failure occurs before restart"
 else
-  fail "render/preflight failure must prevent restart"
+  fail "systemd verification failure must prevent restart"
 fi
 if grep -Fq 'curl:' "$ORDER_CAPTURE"; then
-  fail "network health must not run after preflight failure"
+  fail "network health must not run after systemd verification failure"
 else
-  pass "network health is skipped after preflight failure"
+  pass "network health is skipped after systemd verification failure"
 fi
 
-# A valid rendered deployment must probe the registered host from the deploy
-# client (not loopback on the target) before repairing the accepted marker.
+# A valid rendered deployment must probe the explicit consumer-health host
+# from the deploy client, independently of the SSH endpoint, before repairing
+# the accepted marker.
 node - "$registry" <<'NODE'
 const fs = require("fs");
 const file = process.argv[2];
@@ -423,10 +478,16 @@ if REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bi
 else
   fail "rendered deployment must pass network-boundary health"
 fi
-if grep -Fq 'curl:-fsS --max-time 3 http://h1:3030/health' "$ORDER_CAPTURE"; then
-  pass "health is verified from the deploy client against the registered host"
+if grep -Fq 'curl:-fsS --max-time 3 http://health-h1:3030/health' "$ORDER_CAPTURE"; then
+  pass "health is verified from the deploy client against the explicit health host"
 else
-  fail "network health must use the registered host and port"
+  fail "network health must use the explicit health host and registered port"
+fi
+if grep -Fq 'magnus@h1' "$SSH_CAPTURE" &&
+    ! grep -Fq 'magnus@health-h1' "$SSH_CAPTURE"; then
+  pass "health host is independent of the SSH deployment host"
+else
+  fail "SSH transport must continue using the component host"
 fi
 preflight_line=$(grep -n '^preflight$' "$ORDER_CAPTURE" | cut -d: -f1)
 restart_line=$(grep -n '^restart$' "$ORDER_CAPTURE" | cut -d: -f1)

--- a/scripts/tests/deploy-systemd-render.test.sh
+++ b/scripts/tests/deploy-systemd-render.test.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Regression for grimnir#107: registry-owned runtime identity must render
+# clean-install units, fail closed before restart, and stay markerless.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY="$SCRIPT_DIR/../deploy.sh"
+RENDER_HELPER="$SCRIPT_DIR/../lib/render-systemd-units.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_file_contains() {
+  local desc=$1 file=$2 expected=$3
+  if grep -Fq -- "$expected" "$file"; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+echo "systemd runtime rendering tests"
+echo "==============================="
+
+RUNTIME_HOME="$TMP_DIR/home/alpha"
+DEPLOY_TARGET="$RUNTIME_HOME/app"
+PRIVATE_ENV="$DEPLOY_TARGET/.env"
+SANDBOX_PATH="$RUNTIME_HOME/state"
+SYSTEM_ROOT="$TMP_DIR/etc/systemd/system"
+mkdir -p "$DEPLOY_TARGET/systemd" "$SANDBOX_PATH" "$SYSTEM_ROOT" "$TMP_DIR/bin"
+printf '%s\n' 'PRIVATE_LISTENER=tailnet-only-value' > "$PRIVATE_ENV"
+printf '%s\n' 'exit 0' > "$DEPLOY_TARGET/server.sh"
+chmod +x "$DEPLOY_TARGET/server.sh"
+printf '%s\n' 'Environment=PRIVATE_LISTENER=legacy-private-value' > "$SYSTEM_ROOT/alpha.service"
+
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+[Unit]
+Description=Clean-install template
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<deploy-path>/.env
+ExecStart=/bin/sh <deploy-path>/server.sh
+ReadWritePaths=<home>/state
+EOF
+
+cat > "$TMP_DIR/bin/getent" << 'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "passwd" && "$2" == "alpha" ]]
+printf 'alpha:x:1000:1000:Alpha:%s:/bin/sh\n' "$RUNTIME_HOME"
+EOF
+chmod +x "$TMP_DIR/bin/getent"
+
+runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" DEPLOY_TARGET="$DEPLOY_TARGET" \
+  PRIVATE_ENV="$PRIVATE_ENV" SANDBOX_PATH="$SANDBOX_PATH" node -e '
+    process.stdout.write(JSON.stringify({
+      user: "alpha",
+      home: process.env.RUNTIME_HOME,
+      deploy_target: process.env.DEPLOY_TARGET,
+      environment_files: [process.env.PRIVATE_ENV],
+      sandbox_paths: [process.env.SANDBOX_PATH]
+    }));
+  ')
+units_json='[{"name":"alpha","type":"service","scope":"system"}]'
+persistent_json=$(SANDBOX_PATH="$SANDBOX_PATH" node -e \
+  'process.stdout.write(JSON.stringify([process.env.SANDBOX_PATH]));')
+
+if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
+    SYSTEMD_SYSTEM_ROOT="$SYSTEM_ROOT" \
+    bash "$RENDER_HELPER" "$DEPLOY_TARGET" "$runtime_json" "$units_json" "$persistent_json"; then
+  pass "clean-install template renders and preflights"
+else
+  fail "clean-install template must render and preflight"
+fi
+
+rendered_unit="$SYSTEM_ROOT/alpha.service"
+assert_file_contains "runtime user is rendered" "$rendered_unit" "User=alpha"
+assert_file_contains "deploy target is rendered" "$rendered_unit" "WorkingDirectory=$DEPLOY_TARGET"
+assert_file_contains "private environment path is retained" "$rendered_unit" "EnvironmentFile=$PRIVATE_ENV"
+assert_file_contains "sandbox path is rendered" "$rendered_unit" "ReadWritePaths=$SANDBOX_PATH"
+assert_file_contains "previous installed unit is retained for rollback" \
+  "$rendered_unit.grimnir-previous" "PRIVATE_LISTENER=legacy-private-value"
+if grep -Fq 'tailnet-only-value' "$rendered_unit"; then
+  fail "private environment values must not be copied into the unit"
+else
+  pass "private environment values stay outside the rendered unit"
+fi
+
+bad_runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" DEPLOY_TARGET="$DEPLOY_TARGET" \
+  PRIVATE_ENV="$PRIVATE_ENV" SANDBOX_PATH="$SANDBOX_PATH" node -e '
+    process.stdout.write(JSON.stringify({
+      user: "missing-user",
+      home: process.env.RUNTIME_HOME,
+      deploy_target: process.env.DEPLOY_TARGET,
+      environment_files: [process.env.PRIVATE_ENV],
+      sandbox_paths: [process.env.SANDBOX_PATH]
+    }));
+  ')
+if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
+    SYSTEMD_SYSTEM_ROOT="$TMP_DIR/bad-systemd" \
+    bash "$RENDER_HELPER" "$DEPLOY_TARGET" "$bad_runtime_json" "$units_json" "$persistent_json" \
+    >"$TMP_DIR/bad-render.out" 2>&1; then
+  fail "unknown rendered user must fail preflight"
+else
+  pass "unknown rendered user fails preflight"
+fi
+if [[ -e "$TMP_DIR/bad-systemd/alpha.service" ]]; then
+  fail "failed preflight must not install a unit"
+else
+  pass "failed preflight installs no unit"
+fi
+
+valid_template="$TMP_DIR/valid-alpha.service"
+cp "$DEPLOY_TARGET/systemd/alpha.service" "$valid_template"
+
+assert_path_preflight_rejected() {
+  local desc=$1 expected=$2 system_root="$TMP_DIR/rejected-${PASS}-${FAIL}"
+  if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
+      SYSTEMD_SYSTEM_ROOT="$system_root" \
+      bash "$RENDER_HELPER" "$DEPLOY_TARGET" "$runtime_json" "$units_json" "$persistent_json" \
+      >"$TMP_DIR/path-rejected.out" 2>&1; then
+    fail "$desc must fail preflight"
+  elif grep -Fq -- "$expected" "$TMP_DIR/path-rejected.out"; then
+    pass "$desc fails preflight"
+  else
+    fail "$desc must report $expected"
+  fi
+  if [[ -e "$system_root/alpha.service" ]]; then
+    fail "$desc must not install a unit"
+  else
+    pass "$desc installs no unit"
+  fi
+}
+
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+[Service]
+User=<user>
+WorkingDirectory=<home>
+EnvironmentFile=<deploy-path>/.env
+ExecStart=/bin/sh <deploy-path>/server.sh
+ReadWritePaths=<home>/state
+EOF
+assert_path_preflight_rejected "mismatched WorkingDirectory" \
+  "WorkingDirectory must equal registered deploy target"
+
+outside_exec="$TMP_DIR/outside.sh"
+printf '%s\n' 'exit 0' > "$outside_exec"
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << EOF
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<deploy-path>/.env
+ExecStart=/bin/sh $outside_exec
+ReadWritePaths=<home>/state
+EOF
+assert_path_preflight_rejected "ExecStart path outside deploy target" \
+  "ExecStart path is outside registered deploy target"
+
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<home>/unregistered.env
+ExecStart=/bin/sh <deploy-path>/server.sh
+ReadWritePaths=<home>/state
+EOF
+assert_path_preflight_rejected "unregistered private environment file" \
+  "EnvironmentFile is not registered"
+
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<deploy-path>/.env
+ExecStart=/bin/sh <deploy-path>/server.sh
+ReadWritePaths=<home>/unregistered-state
+EOF
+assert_path_preflight_rejected "unregistered sandbox path" \
+  "ReadWritePaths path is outside registered roots"
+
+cp "$valid_template" "$DEPLOY_TARGET/systemd/alpha.service"
+
+# Full deploy regression: once mutation begins, render/preflight failure must
+# leave the accepted marker absent and must prevent any restart round trip.
+REPO="$TMP_DIR/repos/alpha"
+mkdir -p "$REPO/systemd"
+cp "$DEPLOY_TARGET/systemd/alpha.service" "$REPO/systemd/alpha.service"
+printf '%s\n' '{"name":"alpha","version":"1.0.0"}' > "$REPO/package.json"
+printf '%s\n' 'exit 0' > "$REPO/server.sh"
+git init -q -b main "$REPO"
+git -C "$REPO" add .
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$REPO" commit -q -m seed
+
+registry="$TMP_DIR/services.json"
+RUNTIME_HOME="$RUNTIME_HOME" PRIVATE_ENV="$PRIVATE_ENV" SANDBOX_PATH="$SANDBOX_PATH" \
+  node - "$registry" <<'NODE'
+const fs = require("fs");
+fs.writeFileSync(process.argv[2], JSON.stringify({
+  components: [{
+    name: "alpha",
+    repo: "alpha",
+    host: "h1",
+    port: 3030,
+    deploy: true,
+    scan: false,
+    deploy_path: process.env.RUNTIME_HOME + "/app",
+    persistent_paths: [process.env.SANDBOX_PATH],
+    needs_build: false,
+    systemd_runtime: {
+      user: "missing-user",
+      home: process.env.RUNTIME_HOME,
+      deploy_target: process.env.RUNTIME_HOME + "/app",
+      environment_files: [process.env.PRIVATE_ENV],
+      sandbox_paths: [process.env.SANDBOX_PATH]
+    },
+    health_check: { boundary: "network", paths: ["/health"] },
+    systemd_units: [{ name: "alpha", type: "service", scope: "system" }]
+  }]
+}, null, 2));
+NODE
+
+ORDER_CAPTURE="$TMP_DIR/order"
+REMOTE_MARKER_STATE="$TMP_DIR/marker"
+SSH_CAPTURE="$TMP_DIR/ssh"
+export ORDER_CAPTURE REMOTE_MARKER_STATE SSH_CAPTURE
+printf '%040d\n' 1 > "$REMOTE_MARKER_STATE"
+
+cat > "$TMP_DIR/bin/ssh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SSH_CAPTURE"
+command=${*: -1}
+if [[ "$command" == *"DEPLOY_MARKER_INVALIDATED"* ]]; then
+  printf '%s\n' invalidate >> "$ORDER_CAPTURE"
+  prior=$(cat "$REMOTE_MARKER_STATE")
+  rm -f "$REMOTE_MARKER_STATE"
+  printf 'DEPLOY_MARKER_INVALIDATED:%s\n' "$prior"
+elif [[ "$command" == *"rm -rf --"*"/.git"* ]]; then
+  printf '%s\n' prepare >> "$ORDER_CAPTURE"
+elif [[ "$command" == *"npm ci --omit=dev"* ]]; then
+  printf '%s\n' npm >> "$ORDER_CAPTURE"
+elif [[ "$*" == *"bash -s --"* ]]; then
+  cat >/dev/null
+  printf '%s\n' preflight >> "$ORDER_CAPTURE"
+  if [[ "${SSH_PREFLIGHT_FAIL:-false}" == "true" ]]; then
+    printf '%s\n' 'ERROR: runtime user does not exist: missing-user' >&2
+    exit 1
+  fi
+  printf '%s\n' SYSTEMD_UNITS_PREPARED
+elif [[ "$command" == *"systemctl"*"restart"* ]]; then
+  printf '%s\n' restart >> "$ORDER_CAPTURE"
+  [[ "$command" == *"DEPLOY_READY"* ]] && printf '%s\n' DEPLOY_READY
+elif [[ "$command" == *".deployed-commit"*"DEPLOY_OK"* ]]; then
+  printf '%s\n' stamp >> "$ORDER_CAPTURE"
+  printf '%s\n' accepted > "$REMOTE_MARKER_STATE"
+  printf '%s\n' DEPLOY_OK
+fi
+exit 0
+EOF
+
+cat > "$TMP_DIR/bin/rsync" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' rsync >> "$ORDER_CAPTURE"
+exit 0
+EOF
+
+cat > "$TMP_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "curl:$*" >> "$ORDER_CAPTURE"
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/curl"
+
+rc=0
+SSH_PREFLIGHT_FAIL=true REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
+  bash "$DEPLOY" alpha >"$TMP_DIR/deploy.out" 2>&1 || rc=$?
+if [[ "$rc" == 1 ]]; then
+  pass "render/preflight failure fails deployment"
+else
+  fail "render/preflight failure must fail deployment"
+fi
+if [[ ! -e "$REMOTE_MARKER_STATE" ]]; then
+  pass "render/preflight failure leaves accepted marker absent"
+else
+  fail "render/preflight failure must leave accepted marker absent"
+fi
+if grep -Fxq preflight "$ORDER_CAPTURE" && ! grep -Fxq restart "$ORDER_CAPTURE"; then
+  pass "render/preflight failure occurs before restart"
+else
+  fail "render/preflight failure must prevent restart"
+fi
+if grep -Fq 'curl:' "$ORDER_CAPTURE"; then
+  fail "network health must not run after preflight failure"
+else
+  pass "network health is skipped after preflight failure"
+fi
+
+# A valid rendered deployment must probe the registered host from the deploy
+# client (not loopback on the target) before repairing the accepted marker.
+node - "$registry" <<'NODE'
+const fs = require("fs");
+const file = process.argv[2];
+const data = JSON.parse(fs.readFileSync(file, "utf8"));
+data.components[0].systemd_runtime.user = "alpha";
+fs.writeFileSync(file, JSON.stringify(data, null, 2));
+NODE
+rm -f "$ORDER_CAPTURE" "$SSH_CAPTURE" "$REMOTE_MARKER_STATE"
+printf '%040d\n' 2 > "$REMOTE_MARKER_STATE"
+if REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
+    bash "$DEPLOY" alpha >"$TMP_DIR/deploy-success.out" 2>&1; then
+  pass "rendered deployment passes network-boundary health"
+else
+  fail "rendered deployment must pass network-boundary health"
+fi
+if grep -Fq 'curl:-fsS --max-time 3 http://h1:3030/health' "$ORDER_CAPTURE"; then
+  pass "health is verified from the deploy client against the registered host"
+else
+  fail "network health must use the registered host and port"
+fi
+preflight_line=$(grep -n '^preflight$' "$ORDER_CAPTURE" | cut -d: -f1)
+restart_line=$(grep -n '^restart$' "$ORDER_CAPTURE" | cut -d: -f1)
+curl_line=$(grep -n '^curl:' "$ORDER_CAPTURE" | cut -d: -f1)
+stamp_line=$(grep -n '^stamp$' "$ORDER_CAPTURE" | cut -d: -f1)
+if [[ -n "$preflight_line" && -n "$restart_line" && -n "$curl_line" && -n "$stamp_line" ]] &&
+   [[ "$preflight_line" -lt "$restart_line" && "$restart_line" -lt "$curl_line" &&
+      "$curl_line" -lt "$stamp_line" ]]; then
+  pass "preflight, restart, network health, and acceptance stamp are ordered"
+else
+  fail "acceptance ordering must be preflight -> restart -> network health -> stamp"
+fi
+if [[ "$(cat "$REMOTE_MARKER_STATE")" == "accepted" ]]; then
+  pass "marker is repaired only after network health succeeds"
+else
+  fail "successful network-boundary deployment must repair the marker"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/tests/deploy-systemd-render.test.sh
+++ b/scripts/tests/deploy-systemd-render.test.sh
@@ -37,10 +37,12 @@ echo "==============================="
 
 RUNTIME_HOME="$TMP_DIR/home/alpha"
 DEPLOY_TARGET="$RUNTIME_HOME/app"
-PRIVATE_ENV="$DEPLOY_TARGET/.env"
 SANDBOX_PATH="$RUNTIME_HOME/state"
+CROSS_COMPONENT_PATH="$RUNTIME_HOME/cross-component"
+PRIVATE_ENV="$SANDBOX_PATH/env"
 SYSTEM_ROOT="$TMP_DIR/etc/systemd/system"
-mkdir -p "$DEPLOY_TARGET/systemd" "$SANDBOX_PATH" "$SYSTEM_ROOT" "$TMP_DIR/bin"
+mkdir -p "$DEPLOY_TARGET/systemd" "$SANDBOX_PATH" "$CROSS_COMPONENT_PATH/child" \
+  "$SYSTEM_ROOT" "$TMP_DIR/bin"
 printf '%s\n' 'PRIVATE_LISTENER=tailnet-only-value' > "$PRIVATE_ENV"
 printf '%s\n' 'exit 0' > "$DEPLOY_TARGET/server.sh"
 chmod +x "$DEPLOY_TARGET/server.sh"
@@ -54,9 +56,10 @@ Description=Clean-install template
 [Service]
 User=<user>
 WorkingDirectory=<deploy-path>
-EnvironmentFile=<deploy-path>/.env
+EnvironmentFile=<home>/state/env
 ExecStart=$EXEC_SYMLINK <deploy-path>/server.sh
 ReadWritePaths=<home>/state
+ReadOnlyPaths=<home>/cross-component
 EOF
 
 cat > "$TMP_DIR/bin/getent" << 'EOF'
@@ -67,13 +70,13 @@ EOF
 chmod +x "$TMP_DIR/bin/getent"
 
 runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" DEPLOY_TARGET="$DEPLOY_TARGET" \
-  PRIVATE_ENV="$PRIVATE_ENV" SANDBOX_PATH="$SANDBOX_PATH" node -e '
+  PRIVATE_ENV="$PRIVATE_ENV" CROSS_COMPONENT_PATH="$CROSS_COMPONENT_PATH" node -e '
     process.stdout.write(JSON.stringify({
       user: "alpha",
       home: process.env.RUNTIME_HOME,
       deploy_target: process.env.DEPLOY_TARGET,
       environment_files: [process.env.PRIVATE_ENV],
-      sandbox_paths: [process.env.SANDBOX_PATH]
+      sandbox_paths: [process.env.CROSS_COMPONENT_PATH]
     }));
   ')
 units_json='[{"name":"alpha","type":"service","scope":"system"}]'
@@ -93,6 +96,8 @@ assert_file_contains "runtime user is rendered" "$rendered_unit" "User=alpha"
 assert_file_contains "deploy target is rendered" "$rendered_unit" "WorkingDirectory=$DEPLOY_TARGET"
 assert_file_contains "private environment path is retained" "$rendered_unit" "EnvironmentFile=$PRIVATE_ENV"
 assert_file_contains "sandbox path is rendered" "$rendered_unit" "ReadWritePaths=$SANDBOX_PATH"
+assert_file_contains "exact external dependency path is rendered" \
+  "$rendered_unit" "ReadOnlyPaths=$CROSS_COMPONENT_PATH"
 assert_file_contains "previous installed unit is retained for rollback" \
   "$rendered_unit.grimnir-previous" "PRIVATE_LISTENER=legacy-private-value"
 pass "symlinked system executable is accepted after executable access validation"
@@ -103,13 +108,13 @@ else
 fi
 
 bad_runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" DEPLOY_TARGET="$DEPLOY_TARGET" \
-  PRIVATE_ENV="$PRIVATE_ENV" SANDBOX_PATH="$SANDBOX_PATH" node -e '
+  PRIVATE_ENV="$PRIVATE_ENV" CROSS_COMPONENT_PATH="$CROSS_COMPONENT_PATH" node -e '
     process.stdout.write(JSON.stringify({
       user: "missing-user",
       home: process.env.RUNTIME_HOME,
       deploy_target: process.env.DEPLOY_TARGET,
       environment_files: [process.env.PRIVATE_ENV],
-      sandbox_paths: [process.env.SANDBOX_PATH]
+      sandbox_paths: [process.env.CROSS_COMPONENT_PATH]
     }));
   ')
 if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
@@ -152,9 +157,10 @@ cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
 [Service]
 User=<user>
 WorkingDirectory=<home>
-EnvironmentFile=<deploy-path>/.env
+EnvironmentFile=<home>/state/env
 ExecStart=/bin/sh <deploy-path>/server.sh
 ReadWritePaths=<home>/state
+ReadOnlyPaths=<home>/cross-component
 EOF
 assert_path_preflight_rejected "mismatched WorkingDirectory" \
   "WorkingDirectory must equal registered deploy target"
@@ -165,9 +171,10 @@ cat > "$DEPLOY_TARGET/systemd/alpha.service" << EOF
 [Service]
 User=<user>
 WorkingDirectory=<deploy-path>
-EnvironmentFile=<deploy-path>/.env
+EnvironmentFile=<home>/state/env
 ExecStart=/bin/sh $outside_exec
 ReadWritePaths=<home>/state
+ReadOnlyPaths=<home>/cross-component
 EOF
 assert_path_preflight_rejected "ExecStart path outside deploy target" \
   "ExecStart path is outside registered deploy target"
@@ -179,6 +186,7 @@ WorkingDirectory=<deploy-path>
 EnvironmentFile=<home>/unregistered.env
 ExecStart=/bin/sh <deploy-path>/server.sh
 ReadWritePaths=<home>/state
+ReadOnlyPaths=<home>/cross-component
 EOF
 assert_path_preflight_rejected "unregistered private environment file" \
   "EnvironmentFile is not registered"
@@ -187,14 +195,101 @@ cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
 [Service]
 User=<user>
 WorkingDirectory=<deploy-path>
-EnvironmentFile=<deploy-path>/.env
+EnvironmentFile=<home>/state/env
 ExecStart=/bin/sh <deploy-path>/server.sh
 ReadWritePaths=<home>/unregistered-state
+ReadOnlyPaths=<home>/cross-component
 EOF
 assert_path_preflight_rejected "unregistered sandbox path" \
   "ReadWritePaths path is outside registered roots"
 
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<home>/state/env
+ExecStart=/bin/sh <deploy-path>/server.sh
+ReadWritePaths=<home>/state
+ReadOnlyPaths=<home>/cross-component/child
+EOF
+assert_path_preflight_rejected "descendant of exact external dependency" \
+  "ReadOnlyPaths path is outside registered roots"
+
+cat > "$DEPLOY_TARGET/systemd/alpha.service" << 'EOF'
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<home>/state/env
+ExecStart=/bin/sh <deploy-path>/server.sh
+ReadWritePaths=<home>/state <home>/cross-component
+ReadOnlyPaths=<home>/cross-component
+EOF
+assert_path_preflight_rejected "write access to exact external dependency" \
+  "ReadWritePaths path is outside registered roots"
+
 cp "$valid_template" "$DEPLOY_TARGET/systemd/alpha.service"
+
+# A later install failure must restore every already-replaced unit so a future
+# daemon-reload cannot activate a mixed old/new set.
+MULTI_TARGET="$RUNTIME_HOME/multi-app"
+MULTI_SYSTEM_ROOT="$TMP_DIR/multi-systemd"
+mkdir -p "$MULTI_TARGET/systemd" "$MULTI_SYSTEM_ROOT"
+printf '%s\n' 'exit 0' > "$MULTI_TARGET/server.sh"
+chmod +x "$MULTI_TARGET/server.sh"
+for unit in alpha beta; do
+  cat > "$MULTI_TARGET/systemd/${unit}.service" << EOF
+[Service]
+User=<user>
+WorkingDirectory=<deploy-path>
+EnvironmentFile=<home>/state/env
+ExecStart=$EXEC_SYMLINK <deploy-path>/server.sh
+ReadWritePaths=<home>/state
+ReadOnlyPaths=<home>/cross-component
+EOF
+  printf 'OLD-%s\n' "$unit" > "$MULTI_SYSTEM_ROOT/${unit}.service"
+done
+multi_runtime_json=$(RUNTIME_HOME="$RUNTIME_HOME" MULTI_TARGET="$MULTI_TARGET" \
+  PRIVATE_ENV="$PRIVATE_ENV" CROSS_COMPONENT_PATH="$CROSS_COMPONENT_PATH" node -e '
+    process.stdout.write(JSON.stringify({
+      user: "alpha",
+      home: process.env.RUNTIME_HOME,
+      deploy_target: process.env.MULTI_TARGET,
+      environment_files: [process.env.PRIVATE_ENV],
+      sandbox_paths: [process.env.CROSS_COMPONENT_PATH]
+    }));
+  ')
+multi_units_json='[
+  {"name":"alpha","type":"service","scope":"system"},
+  {"name":"beta","type":"service","scope":"system"}
+]'
+REAL_INSTALL=$(command -v install)
+INSTALL_COUNT="$TMP_DIR/install-count"
+export REAL_INSTALL INSTALL_COUNT
+cat > "$TMP_DIR/bin/install" << 'EOF'
+#!/usr/bin/env bash
+count=0
+[[ -f "$INSTALL_COUNT" ]] && count=$(cat "$INSTALL_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" > "$INSTALL_COUNT"
+[[ "$count" -eq 2 ]] && exit 91
+exec "$REAL_INSTALL" "$@"
+EOF
+chmod +x "$TMP_DIR/bin/install"
+if RUNTIME_HOME="$RUNTIME_HOME" PATH="$TMP_DIR/bin:$PATH" \
+    SYSTEMD_SYSTEM_ROOT="$MULTI_SYSTEM_ROOT" \
+    bash "$RENDER_HELPER" "$MULTI_TARGET" "$multi_runtime_json" \
+      "$multi_units_json" "$persistent_json" >"$TMP_DIR/partial-install.out" 2>&1; then
+  fail "second unit install failure must fail rendering phase"
+else
+  pass "second unit install failure fails rendering phase"
+fi
+if [[ "$(cat "$MULTI_SYSTEM_ROOT/alpha.service")" == "OLD-alpha" &&
+      "$(cat "$MULTI_SYSTEM_ROOT/beta.service")" == "OLD-beta" ]]; then
+  pass "partial install failure restores the complete previous unit set"
+else
+  fail "partial install failure must not leave a mixed unit set"
+fi
+rm -f "$TMP_DIR/bin/install" "$INSTALL_COUNT"
 
 # Full deploy regression: once mutation begins, render/preflight failure must
 # leave the accepted marker absent and must prevent any restart round trip.

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -346,8 +346,8 @@ cat > "$TMP_DIR/systemd-runtime-valid.json" << 'EOF'
       "persistent_paths": ["/home/alpha/state"], "needs_build": false,
       "systemd_runtime": {
         "user": "alpha", "home": "/home/alpha", "deploy_target": "/home/alpha/app",
-        "environment_files": ["/home/alpha/app/.env"],
-        "sandbox_paths": ["/home/alpha/state"]
+        "environment_files": ["/home/alpha/state/env"],
+        "sandbox_paths": ["/home/alpha/.ssh/read-only-key"]
       },
       "health_check": { "boundary": "network", "paths": ["/health"] },
       "systemd_units": [{ "name": "alpha", "type": "service" }] }
@@ -356,6 +356,25 @@ cat > "$TMP_DIR/systemd-runtime-valid.json" << 'EOF'
 EOF
 assert_eq "valid systemd runtime rendering contract -> exit 0" "0" \
   "$(run_validator "$TMP_DIR/systemd-runtime-valid.json")"
+
+cat > "$TMP_DIR/systemd-runtime-unregistered-env.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/alpha/app",
+      "persistent_paths": ["/home/alpha/state"], "needs_build": false,
+      "systemd_runtime": {
+        "user": "alpha", "home": "/home/alpha", "deploy_target": "/home/alpha/app",
+        "environment_files": ["/home/other/private.env"],
+        "sandbox_paths": []
+      },
+      "health_check": { "boundary": "network", "paths": ["/health"] },
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "environment file outside deploy/persistent roots -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/systemd-runtime-unregistered-env.json")"
 
 cat > "$TMP_DIR/systemd-runtime-mismatch.json" << 'EOF'
 {
@@ -433,6 +452,14 @@ assert_eq "real services.json: Heimdall deploy refreshes boot-check timer compan
   "$(deploy_field "$REPO_REGISTRY" heimdall systemd_units)"
 assert_eq "real services.json: Heimdall deploy carries its health port" \
   "3033" "$(deploy_field "$REPO_REGISTRY" heimdall port)"
+assert_eq "real services.json: munin-memory remains outside runtime rendering scope" \
+  "null" "$(deploy_field "$REPO_REGISTRY" munin-memory systemd_runtime)"
+assert_eq "real services.json: Heimdall owns the reviewed host runtime contract" \
+  '{"user":"magnus","home":"/home/magnus","deploy_target":"/home/magnus/repos/heimdall","environment_files":["/home/magnus/.heimdall/env"],"sandbox_paths":["/home/magnus/.munin-memory","/home/magnus/.ssh/heimdall_ed25519"]}' \
+  "$(deploy_field "$REPO_REGISTRY" heimdall systemd_runtime)"
+assert_eq "real services.json: Heimdall health uses the network consumer boundary" \
+  '{"boundary":"network","paths":["/health","/api/health"]}' \
+  "$(deploy_field "$REPO_REGISTRY" heimdall health_check)"
 
 assert_eq "real services.json: skuld timer deploys via user manager" \
   "user" "$(deploy_field "$REPO_REGISTRY" skuld unit_scope)"

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -349,7 +349,7 @@ cat > "$TMP_DIR/systemd-runtime-valid.json" << 'EOF'
         "environment_files": ["/home/alpha/state/env"],
         "sandbox_paths": ["/home/alpha/.ssh/read-only-key"]
       },
-      "health_check": { "boundary": "network", "paths": ["/health"] },
+      "health_check": { "boundary": "network", "host": "health-alpha", "paths": ["/health"] },
       "systemd_units": [{ "name": "alpha", "type": "service" }] }
   ]
 }
@@ -368,13 +368,55 @@ cat > "$TMP_DIR/systemd-runtime-unregistered-env.json" << 'EOF'
         "environment_files": ["/home/other/private.env"],
         "sandbox_paths": []
       },
-      "health_check": { "boundary": "network", "paths": ["/health"] },
+      "health_check": { "boundary": "network", "host": "health-alpha", "paths": ["/health"] },
       "systemd_units": [{ "name": "alpha", "type": "service" }] }
   ]
 }
 EOF
 assert_eq "environment file outside deploy/persistent roots -> exit 1" "1" \
   "$(run_validator "$TMP_DIR/systemd-runtime-unregistered-env.json")"
+
+cat > "$TMP_DIR/network-health-missing-host.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "ssh-alpha", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/alpha/app",
+      "persistent_paths": [], "needs_build": false,
+      "health_check": { "boundary": "network", "paths": ["/health"] },
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "network health without an explicit host -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/network-health-missing-host.json")"
+
+cat > "$TMP_DIR/network-health-private-ip.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "ssh-alpha", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/alpha/app",
+      "persistent_paths": [], "needs_build": false,
+      "health_check": { "boundary": "network", "host": "100.64.0.1", "paths": ["/health"] },
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "network health private IP locator -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/network-health-private-ip.json")"
+
+cat > "$TMP_DIR/host-health-without-host.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "ssh-alpha", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/alpha/app",
+      "persistent_paths": [], "needs_build": false,
+      "health_check": { "boundary": "host", "paths": ["/health"] },
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "host-boundary health retains implicit local targets -> exit 0" "0" \
+  "$(run_validator "$TMP_DIR/host-health-without-host.json")"
 
 cat > "$TMP_DIR/systemd-runtime-mismatch.json" << 'EOF'
 {
@@ -458,7 +500,7 @@ assert_eq "real services.json: Heimdall owns the reviewed host runtime contract"
   '{"user":"magnus","home":"/home/magnus","deploy_target":"/home/magnus/repos/heimdall","environment_files":["/home/magnus/.heimdall/env"],"sandbox_paths":["/home/magnus/.munin-memory","/home/magnus/.ssh/heimdall_ed25519"]}' \
   "$(deploy_field "$REPO_REGISTRY" heimdall systemd_runtime)"
 assert_eq "real services.json: Heimdall health uses the network consumer boundary" \
-  '{"boundary":"network","paths":["/health","/api/health"]}' \
+  '{"boundary":"network","host":"huginmunin","paths":["/health","/api/health"]}' \
   "$(deploy_field "$REPO_REGISTRY" heimdall health_check)"
 
 assert_eq "real services.json: skuld timer deploys via user manager" \

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -337,6 +337,44 @@ cat > "$TMP_DIR/deploy-mode-bogus.json" << 'EOF'
 EOF
 assert_eq "deploy_mode bogus value -> exit 1" "1" "$(run_validator "$TMP_DIR/deploy-mode-bogus.json")"
 
+# ── Host-specific systemd runtime rendering contract (#107) ────────────────
+cat > "$TMP_DIR/systemd-runtime-valid.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/alpha/app",
+      "persistent_paths": ["/home/alpha/state"], "needs_build": false,
+      "systemd_runtime": {
+        "user": "alpha", "home": "/home/alpha", "deploy_target": "/home/alpha/app",
+        "environment_files": ["/home/alpha/app/.env"],
+        "sandbox_paths": ["/home/alpha/state"]
+      },
+      "health_check": { "boundary": "network", "paths": ["/health"] },
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "valid systemd runtime rendering contract -> exit 0" "0" \
+  "$(run_validator "$TMP_DIR/systemd-runtime-valid.json")"
+
+cat > "$TMP_DIR/systemd-runtime-mismatch.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/alpha/app",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_runtime": {
+        "user": "missing user", "home": "/home/alpha", "deploy_target": "/home/other/app",
+        "environment_files": ["/home/alpha/private.env"],
+        "sandbox_paths": ["/tmp/unregistered"]
+      },
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "mismatched runtime identity/paths and missing health boundary -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/systemd-runtime-mismatch.json")"
+
 # ── Missing file entirely ───────────────────────────────────────────────────
 assert_eq "missing file -> exit 1" "1" "$(run_validator "$TMP_DIR/does-not-exist.json")"
 

--- a/services.json
+++ b/services.json
@@ -10,6 +10,17 @@
       "deploy_path": "/home/magnus/munin-memory",
       "persistent_paths": ["/home/magnus/.munin-memory"],
       "needs_build": true,
+      "systemd_runtime": {
+        "user": "magnus",
+        "home": "/home/magnus",
+        "deploy_target": "/home/magnus/munin-memory",
+        "environment_files": ["/home/magnus/munin-memory/.env"],
+        "sandbox_paths": []
+      },
+      "health_check": {
+        "boundary": "network",
+        "paths": ["/health", "/api/health"]
+      },
       "systemd_units": [
         { "name": "munin-memory", "type": "service" }
       ]

--- a/services.json
+++ b/services.json
@@ -10,17 +10,6 @@
       "deploy_path": "/home/magnus/munin-memory",
       "persistent_paths": ["/home/magnus/.munin-memory"],
       "needs_build": true,
-      "systemd_runtime": {
-        "user": "magnus",
-        "home": "/home/magnus",
-        "deploy_target": "/home/magnus/munin-memory",
-        "environment_files": ["/home/magnus/munin-memory/.env"],
-        "sandbox_paths": []
-      },
-      "health_check": {
-        "boundary": "network",
-        "paths": ["/health", "/api/health"]
-      },
       "systemd_units": [
         { "name": "munin-memory", "type": "service" }
       ]
@@ -50,6 +39,20 @@
       "deploy_path": "/home/magnus/repos/heimdall",
       "persistent_paths": ["/home/magnus/.heimdall"],
       "needs_build": false,
+      "systemd_runtime": {
+        "user": "magnus",
+        "home": "/home/magnus",
+        "deploy_target": "/home/magnus/repos/heimdall",
+        "environment_files": ["/home/magnus/.heimdall/env"],
+        "sandbox_paths": [
+          "/home/magnus/.munin-memory",
+          "/home/magnus/.ssh/heimdall_ed25519"
+        ]
+      },
+      "health_check": {
+        "boundary": "network",
+        "paths": ["/health", "/api/health"]
+      },
       "systemd_units": [
         { "name": "heimdall", "type": "service" },
         { "name": "heimdall-collect", "type": "timer" },

--- a/services.json
+++ b/services.json
@@ -51,6 +51,7 @@
       },
       "health_check": {
         "boundary": "network",
+        "host": "huginmunin",
         "paths": ["/health", "/api/health"]
       },
       "systemd_units": [


### PR DESCRIPTION
Closes #107

Exact head: `7ef1ee5f9906c527bcfdb176981ac4f3a1edf3ba`

## What changed

- adds an opt-in `systemd_runtime` registry contract for explicit host runtime user, home, deploy target, required private-environment paths, and exact external read-only dependencies
- opts in Heimdall only; `munin-memory` remains outside runtime rendering scope
- renders only the bounded `<user>`, `<home>`, `<deploy-path>`, and legacy `<install-dir>` placeholders on the target
- preflights account/home, `WorkingDirectory`, `ExecStart` paths, required `EnvironmentFile` entries, and sandbox paths
- runs scope-correct `systemd-analyze verify` over each complete rendered system/user unit set before creating rollback snapshots or installing anything
- allows environment files under the deploy target or declared persistent roots; exact external sandbox dependencies authorize read-only access only and do not authorize descendants
- snapshots all prior units before copying and restores every already-replaced unit if a later copy fails, before any daemon reload
- separates the SSH endpoint from an explicit, validated `health_check.host`; Heimdall probes the stable non-secret `huginmunin` MagicDNS hostname from the deploy client
- documents authority, the cross-repo migration gate, failure state, and rollback

## Root cause

Heimdall's canonical systemd templates encode a host identity and paths that do not match the incident host. The centralized deploy path only supported byte-for-byte install-ready units, so it could not safely adapt those templates. Custom path checks alone also could not prove that rendered units were valid systemd syntax before install. Finally, Heimdall intentionally listens on the tailnet interface: SSH resolves through `huginmunin.local`, while the real network consumer reaches `huginmunin`; using the SSH endpoint for health timed out despite a healthy service.

## Required companion change

This PR must not be deployed in isolation. [Heimdall PR #14](https://github.com/Magnus-Gille/heimdall/pull/14), verified at exact head `6748365d92192fa267ef69c48716c9e6f0940e57`, replaces the canonical templates' hardcoded identity/path literals with the supported placeholders and makes `/home/magnus/.heimdall/env` required. This PR remains draft and deployment-blocked until the owning-repository change is green, reviewed, and merged first.

## Verification

- red/green renderer/deploy regression: `scripts/tests/deploy-systemd-render.test.sh` (39 assertions)
- registry contract regression: `scripts/tests/registry-smoke.test.sh` (56 assertions)
- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `git diff --check`

The hermetic regression proves systemd verification receives each scope's complete rendered set, uses `--system`/`--user` correctly, and fails before unit or rollback-snapshot mutation. The integrated failure stays markerless and invokes neither restart nor network health. It also proves a later multi-unit copy failure restores the complete prior unit set, exact external dependencies reject descendants and write access, and network health uses its explicit host independently of SSH before the acceptance stamp.

## M5 dogfood

An earlier bounded M5 contract review was attempted. Automatic `code-review` classification correctly escalated to the frontier gap lane; an explicit `classify` retry returned an empty response. No M5 output was trusted or used. The M5 tool/CLI was unavailable for this final correction, and no additional Munin access or writes occurred.

## Operational note

This PR was not deployed and does not merge itself. Live selective deployment remains blocked on the companion Heimdall PR and explicit post-review authorization.