### PR TITLE
fix(validation): model desired runtime state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -45,10 +45,13 @@ test-registry-checkout: ## Unit tests for the registry-checkout integrity helper
 test-systemd-status: ## Scope-aware local/remote systemd status checks (issue #63)
 	@bash scripts/tests/systemd-status.test.sh
 
+test-runtime-state: ## Desired runtime and deployment-state validation (issue #109)
+	@bash scripts/tests/runtime-state.test.sh
+
 test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
 	@bash scripts/tests/worktree-hygiene.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-worktree-hygiene ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -9,7 +9,7 @@
 |-----------|---------------------|------------------------|
 | **Port assignments** | `services.json` | `generate-architecture.sh`, `deploy.sh`, `security-scan.sh`, `docs/architecture.md` |
 | **SSH and consumer-health hostnames** | `services.json` | `deploy.sh`, `generate-architecture.sh`, `docs/architecture.md` |
-| **Deploy paths, targets, systemd units & timer semantics** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
+| **Deploy paths, targets, desired runtime state, systemd units & timer semantics** | `services.json` | `deploy.sh`, `generate-architecture.sh` |
 | **Systemd unit structure / templates** | Owning component repo | `deploy.sh` installs install-ready units byte-for-byte or renders the bounded registry placeholders |
 | **Host systemd runtime identity, home, deploy target, private-environment paths and exact external sandbox dependencies** | `services.json` | `deploy.sh`, `render-systemd-units.sh` |
 | **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
@@ -75,6 +75,15 @@
 11. **Cross-repo contract changes are two-consumer changes.** A LearningTaskContract change is not
     complete until immutable synthetic fixtures pass in both Hugin and `gille-inference` and both
     owners review it. Unknown or incompatible decision-driving semantics fail closed.
+
+12. **Runtime and deployment applicability are separate registry facts.**
+    `desired_runtime_state` is `active`, `stopped`, or `not-applicable` (an omitted value defaults
+    to strict `active` for compatibility). Active components require active declared units and
+    successful HTTP health when a port is declared. Stopped components require cleanly inactive
+    units and are not HTTP-probed; active or failed units are drift. Not-applicable components
+    declare neither units nor a health port. Independently, only `deploy: true` components have a
+    meaningful `.deployed-commit` marker. A `deploy: false` platform peer such as Brokkr can still
+    have active timers, but marker validation is skipped.
 
 ## Validation
 

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -33,6 +33,9 @@ REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
 # shellcheck source=scripts/lib/systemd-status.sh
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/systemd-status.sh"
+# shellcheck source=scripts/lib/runtime-state.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/runtime-state.sh"
 # shellcheck source=scripts/lib/munin-rpc.sh
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/munin-rpc.sh"
@@ -159,7 +162,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   RESULTS=""
 
   # Read host-aware registry data
-  while IFS='|' read -r v_name v_host v_port v_repo v_deploy_path v_deploy_mode v_units_json; do
+  while IFS='|' read -r v_name v_host v_port v_repo v_deploy_path v_deploy_mode v_deploy v_runtime_state v_units_json; do
     [[ -z "$v_name" ]] && continue
 
     # Skip components with no host (laptop-only, e.g. fortnox-mcp)
@@ -179,8 +182,10 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
       IS_LOCAL=false
     fi
 
-    # Check systemd units
-    if [[ "$v_units_json" != "[]" ]] && [[ -n "$v_units_json" ]]; then
+    # Check systemd units against the registry's desired state. "stopped"
+    # requires clean inactivity; failed or unexpectedly active units remain red.
+    if [[ "$(runtime_checks_applicable "$v_runtime_state")" == "yes" ]] &&
+       [[ "$v_units_json" != "[]" ]] && [[ -n "$v_units_json" ]]; then
       unit_rows="$(unit_rows_from_json "$v_units_json")"
 
       while IFS='|' read -r unit_name unit_kind unit_scope; do
@@ -192,9 +197,13 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
           active="$(remote_systemctl_status "$v_host" "$unit_scope" is-active "$unit")"
         fi
 
-        case "$(systemctl_status_severity "$active" "$unit_scope")" in
+        case "$(runtime_observation_severity "$v_runtime_state" "$active" "$unit_scope")" in
           pass)
-            STATUS_LINE+=" unit:$unit($unit_scope)=active"
+            if [[ "$v_runtime_state" == "stopped" ]]; then
+              STATUS_LINE+=" unit:$unit($unit_scope)=inactive(expected)"
+            else
+              STATUS_LINE+=" unit:$unit($unit_scope)=active"
+            fi
             ;;
           warn)
             STATUS_LINE+=" unit:$unit($unit_scope)=unreachable"
@@ -209,7 +218,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     fi
 
     # Check port / health endpoint
-    if [[ -n "$v_port" ]]; then
+    if [[ "$(health_check_applicable "$v_runtime_state" "$v_port")" == "yes" ]]; then
       if [[ "$IS_LOCAL" == "true" ]]; then
         health_status="$(health_status_local "$v_port")"
       else
@@ -222,11 +231,13 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
         STATUS_LINE+=" health:$v_port=http$health_status"
         COMPONENT_OK=false
       fi
+    elif [[ "$v_runtime_state" == "stopped" && -n "$v_port" ]]; then
+      STATUS_LINE+=" health:$v_port=not-probed(expected-stopped)"
     fi
 
     # Check deployment freshness. git-pull components are live git checkouts;
     # rsync components are stamped by deploy.sh because rsync excludes .git/.
-    if [[ -n "$v_repo" ]]; then
+    if [[ -n "$v_repo" && "$(deployment_check_applicable "$v_deploy")" == "yes" ]]; then
       repo_path="${v_deploy_path:-/home/magnus/repos/$v_repo}"
       if [[ "$IS_LOCAL" == "true" ]]; then
         if [[ "$v_deploy_mode" == "git-pull" ]]; then
@@ -304,6 +315,8 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
           fi
         fi
       fi
+    elif [[ -n "$v_repo" ]]; then
+      STATUS_LINE+=" deploy:not-applicable"
     fi
 
     # Emit result line
@@ -313,6 +326,12 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     elif [[ "$COMPONENT_WARN" == "true" ]]; then
       RESULTS+="⚠️  $v_name:$STATUS_LINE\n"
       WARN=$((WARN + 1))
+    elif [[ "$v_runtime_state" == "stopped" ]]; then
+      RESULTS+="⏸️  $v_name: expected stopped;$STATUS_LINE\n"
+      PASS=$((PASS + 1))
+    elif [[ "$v_runtime_state" == "not-applicable" ]]; then
+      RESULTS+="⏭  $v_name: runtime not applicable;$STATUS_LINE\n"
+      PASS=$((PASS + 1))
     else
       RESULTS+="✅ $v_name:$STATUS_LINE\n"
       PASS=$((PASS + 1))
@@ -532,7 +551,7 @@ munin_tool_call() {
 }
 
 service_status_row() {
-  local unit_name="$1" unit_kind="$2" unit_scope="$3"
+  local unit_name="$1" unit_kind="$2" unit_scope="$3" desired_state="${4:-active}"
   local unit="${unit_name}.${unit_kind}"
   local active enabled pid mem mem_mb started
   local -a systemctl_prefix
@@ -544,7 +563,11 @@ service_status_row() {
     active="$("${systemctl_prefix[@]}" is-active "$unit" 2>/dev/null || echo 'unknown')"
     enabled="$("${systemctl_prefix[@]}" is-enabled "$unit" 2>/dev/null || echo 'unknown')"
   fi
-  if [[ "$active" == "active" && "$unit_kind" == "service" ]]; then
+  if [[ "$desired_state" == "stopped" && "$active" == "inactive" ]]; then
+    echo "| $unit | $unit_scope | ⏸️ $active (expected) | $enabled | — | — | — |"
+  elif [[ "$desired_state" == "stopped" ]]; then
+    echo "| $unit | $unit_scope | ❌ $active (expected inactive) | $enabled | — | — | — |"
+  elif [[ "$active" == "active" && "$unit_kind" == "service" ]]; then
     if [[ "$unit_scope" == "user" ]]; then
       pid="$(systemctl_user show "$unit" --property=MainPID | cut -d= -f2)"
       mem="$(systemctl_user show "$unit" --property=MemoryCurrent | cut -d= -f2)"
@@ -578,12 +601,13 @@ echo ""
 
 echo "🔍 Collecting service status..."
 DEPLOYMENT_TABLE=""
-while IFS='|' read -r _s_name _s_host _s_port _s_repo _s_deploy_path _s_deploy_mode s_units_json; do
+while IFS='|' read -r _s_name _s_host _s_port _s_repo _s_deploy_path _s_deploy_mode _s_deploy s_runtime_state s_units_json; do
+  [[ "$s_runtime_state" != "not-applicable" ]] || continue
   [[ -n "$s_units_json" && "$s_units_json" != "[]" ]] || continue
   s_unit_rows="$(unit_rows_from_json "$s_units_json")"
   while IFS='|' read -r s_unit_name s_unit_kind s_unit_scope; do
     [[ -n "$s_unit_name" ]] || continue
-    DEPLOYMENT_TABLE+="$(service_status_row "$s_unit_name" "$s_unit_kind" "$s_unit_scope")\n"
+    DEPLOYMENT_TABLE+="$(service_status_row "$s_unit_name" "$s_unit_kind" "$s_unit_scope" "$s_runtime_state")\n"
   done <<< "$s_unit_rows"
 done < <(REGISTRY_PATH="$REGISTRY" QUERY=validate node --input-type=commonjs "$REGISTRY_JS")
 
@@ -611,8 +635,15 @@ done
 
 echo "🔍 Running health checks..."
 HEALTH_RESULTS=""
-while IFS='|' read -r h_name h_host h_port _h_repo _h_deploy_path _h_deploy_mode _h_units_json; do
+while IFS='|' read -r h_name h_host h_port _h_repo _h_deploy_path _h_deploy_mode _h_deploy h_runtime_state _h_units_json; do
   [[ -n "$h_name" && -n "$h_port" ]] || continue
+
+  if [[ "$h_runtime_state" == "stopped" ]]; then
+    HEALTH_RESULTS+="- ⏸️ **$h_name** (:$h_port) — not probed (expected stopped)\n"
+    continue
+  elif [[ "$h_runtime_state" == "not-applicable" ]]; then
+    continue
+  fi
 
   if [[ "$h_host" == "huginmunin.local" ]] || [[ "$h_host" == "huginmunin" ]]; then
     status="$(health_status_local "$h_port")"

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -9,7 +9,8 @@
 //   components   — all component names, space-separated
 //   systemd      — all systemd unit names, space-separated
 //   ports        — components with ports, output: name|port per line
-//   validate     — host-aware output for validation: name|host|port|repo|deploy_path|deploy_mode|units_json per line
+//   validate     — host-aware output for validation:
+//                  name|host|port|repo|deploy_path|deploy_mode|deploy|desired_runtime_state|units_json
 //   json:<field>=<value> — filter by field, output full JSON array
 //   all          — full JSON array of all components
 //   nodes        — infra/inference hosts (data.nodes): name|hostname|ssh_alias|role|status|llm|monitor per line
@@ -111,15 +112,19 @@ switch (query) {
     break;
   }
   case 'validate': {
-    // Host-aware output for validation: name|host|port|repo|deploy_path|deploy_mode|units_json
+    // Runtime and deployment applicability are separate: deploy=false skips
+    // marker validation but may still declare active systemd units.
     // Includes all components so validator can check each on the correct host
     components.forEach(function (c) {
       var port = c.port || '';
       var host = c.host || '';
       var deployPath = c.deploy_path || '';
       var deployMode = c.deploy_mode || 'rsync';
+      var desiredRuntimeState = c.desired_runtime_state || 'active';
       var units = JSON.stringify(c.systemd_units || []);
-      process.stdout.write(c.name + '|' + host + '|' + port + '|' + c.repo + '|' + deployPath + '|' + deployMode + '|' + units + '\n');
+      process.stdout.write(c.name + '|' + host + '|' + port + '|' + c.repo + '|' +
+        deployPath + '|' + deployMode + '|' + String(Boolean(c.deploy)) + '|' +
+        desiredRuntimeState + '|' + units + '\n');
     });
     break;
   }

--- a/scripts/lib/runtime-state.sh
+++ b/scripts/lib/runtime-state.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Pure desired runtime/deployment-state policy used by validation and snapshots.
+
+RUNTIME_STATE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/systemd-status.sh
+source "$RUNTIME_STATE_LIB_DIR/systemd-status.sh"
+
+runtime_checks_applicable() {
+  case "${1:-active}" in
+    active|stopped) printf '%s\n' yes ;;
+    not-applicable) printf '%s\n' no ;;
+    *) printf '%s\n' no ;;
+  esac
+}
+
+health_check_applicable() {
+  local desired=${1:-active} port=${2:-}
+  if [[ "$desired" == "active" && -n "$port" ]]; then
+    printf '%s\n' yes
+  else
+    printf '%s\n' no
+  fi
+}
+
+deployment_check_applicable() {
+  if [[ "${1:-false}" == "true" ]]; then
+    printf '%s\n' yes
+  else
+    printf '%s\n' no
+  fi
+}
+
+runtime_observation_severity() {
+  local desired=${1:-active} observed=$2 scope=${3:-system}
+  case "$desired" in
+    active)
+      systemctl_status_severity "$observed" "$scope"
+      ;;
+    stopped)
+      case "$observed" in
+        inactive) printf '%s\n' pass ;;
+        unreachable)
+          # Preserve the existing bounded user-manager transport warning.
+          systemctl_status_severity "$observed" "$scope"
+          ;;
+        *) printf '%s\n' fail ;;
+      esac
+      ;;
+    not-applicable)
+      printf '%s\n' skip
+      ;;
+    *)
+      printf '%s\n' fail
+      ;;
+  esac
+}

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -53,6 +53,7 @@ if (!Array.isArray(data.components)) {
 var VALID_UNIT_TYPES = ['service', 'timer'];
 var VALID_UNIT_SCOPES = ['system', 'user'];
 var VALID_TIMER_SEMANTICS = ['recurring', 'one-shot'];
+var VALID_RUNTIME_STATES = ['active', 'stopped', 'not-applicable'];
 var VALID_UNIT_NAME = /^[A-Za-z0-9_.@-]+$/;
 var VALID_COMPONENT_ID = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
 var VALID_HOST = /^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/;
@@ -105,6 +106,12 @@ data.components.forEach(function (c, i) {
       fail(label + ': field "' + field + '" must be a boolean');
     }
   });
+
+  if (c.desired_runtime_state !== undefined &&
+      VALID_RUNTIME_STATES.indexOf(c.desired_runtime_state) === -1) {
+    fail(label + ': "desired_runtime_state" must be one of ' +
+      VALID_RUNTIME_STATES.join('/') + ', got "' + c.desired_runtime_state + '"');
+  }
 
   if (c.deploy_mode !== undefined && c.deploy_mode !== 'rsync' && c.deploy_mode !== 'git-pull') {
     fail(label + ': "deploy_mode" must be "rsync" or "git-pull" when present, got "' + c.deploy_mode + '"');
@@ -290,6 +297,10 @@ data.components.forEach(function (c, i) {
   if (!Array.isArray(c.systemd_units)) {
     fail(label + ': "systemd_units" must be an array');
   } else {
+    if (c.desired_runtime_state === 'not-applicable' &&
+        (c.systemd_units.length > 0 || (c.port !== undefined && c.port !== null))) {
+      fail(label + ': desired_runtime_state "not-applicable" cannot declare systemd units or a health port');
+    }
     c.systemd_units.forEach(function (u, ui) {
       var uLabel = label + '.systemd_units[' + ui + ']';
       if (!isPlainObject(u)) {

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -303,6 +303,32 @@ cat > "$TMP_DIR/unsafe-component-strings.json" << 'EOF'
 EOF
 assert_eq "unsafe name/repo/host/path strings -> exit 1" "1" "$(run_validator "$TMP_DIR/unsafe-component-strings.json")"
 
+# ── Desired runtime state is bounded and internally consistent ─────────────
+cat > "$TMP_DIR/bad-runtime-state.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": null, "port": null,
+      "deploy": false, "scan": true, "needs_build": false,
+      "desired_runtime_state": "paused-maybe", "systemd_units": [] }
+  ]
+}
+EOF
+assert_eq "invalid desired runtime state -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/bad-runtime-state.json")"
+
+cat > "$TMP_DIR/not-applicable-with-runtime.json" << 'EOF'
+{
+  "components": [
+    { "name": "alpha", "repo": "alpha", "host": "h1.local", "port": 3030,
+      "deploy": false, "scan": true, "needs_build": false,
+      "desired_runtime_state": "not-applicable",
+      "systemd_units": [{ "name": "alpha", "type": "service" }] }
+  ]
+}
+EOF
+assert_eq "not-applicable runtime cannot declare units or health -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/not-applicable-with-runtime.json")"
+
 # ── Duplicate node name ──────────────────────────────────────────────────────
 cat > "$TMP_DIR/dup-node.json" << 'EOF'
 {
@@ -519,6 +545,31 @@ assert_eq "real services.json: Verdandi protects legacy data and declares canoni
 
 assert_eq "real services.json: Verdandi deploy carries legacy data exclusion" \
   '["/data/"]' "$(deploy_field "$REPO_REGISTRY" verdandi rsync_excludes)"
+
+validate_field() {  # $1 = registry path, $2 = component name, $3 = zero-based field
+  REGISTRY_PATH="$1" QUERY=validate node --input-type=commonjs "$REGISTRY_JS" 2>/dev/null \
+    | COMPONENT_NAME="$2" COMPONENT_FIELD="$3" node --input-type=commonjs -e '
+        var input = "";
+        process.stdin.on("data", function (chunk) { input += chunk; });
+        process.stdin.on("end", function () {
+          var row = input.trim().split("\n").filter(Boolean)
+            .map(function (line) { return line.split("|"); })
+            .filter(function (fields) { return fields[0] === process.env.COMPONENT_NAME; })[0];
+          if (!row) process.exit(1);
+          process.stdout.write(row[Number(process.env.COMPONENT_FIELD)] || "");
+        });
+      '
+}
+assert_eq "Verdandi validation projection is intentionally stopped" "stopped" \
+  "$(validate_field "$REPO_REGISTRY" verdandi 7)"
+assert_eq "Verdandi remains deployment-marker managed" "true" \
+  "$(validate_field "$REPO_REGISTRY" verdandi 6)"
+assert_eq "Brokkr validation projection keeps active timers" "active" \
+  "$(validate_field "$REPO_REGISTRY" brokkr 7)"
+assert_eq "Brokkr validation projection skips deploy markers" "false" \
+  "$(validate_field "$REPO_REGISTRY" brokkr 6)"
+assert_eq "Fortnox has no managed runtime" "not-applicable" \
+  "$(validate_field "$REPO_REGISTRY" fortnox-mcp 7)"
 
 cat > "$TMP_DIR/order.json" << 'EOF'
 {

--- a/scripts/tests/runtime-state.test.sh
+++ b/scripts/tests/runtime-state.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# runtime-state.test.sh — desired runtime/deployment state regressions (#109)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/runtime-state.sh
+source "$SCRIPT_DIR/../lib/runtime-state.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — expected '$expected', got '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "desired runtime/deployment state tests"
+echo "======================================"
+
+# Active remains the strict default: anything except active is a failure (or
+# the existing bounded user-manager transport warning).
+assert_eq "active desired + active observed" pass \
+  "$(runtime_observation_severity active active system)"
+assert_eq "active desired + inactive observed" fail \
+  "$(runtime_observation_severity active inactive system)"
+assert_eq "active desired + unreachable user manager" warn \
+  "$(runtime_observation_severity active unreachable user)"
+
+# Intentionally stopped means cleanly inactive, never merely "not active".
+assert_eq "stopped desired + inactive observed" pass \
+  "$(runtime_observation_severity stopped inactive user)"
+assert_eq "stopped desired + active observed" fail \
+  "$(runtime_observation_severity stopped active user)"
+assert_eq "stopped desired + failed observed" fail \
+  "$(runtime_observation_severity stopped failed user)"
+
+assert_eq "not-applicable runtime skips unit checks" skip \
+  "$(runtime_observation_severity not-applicable active system)"
+
+# Runtime, health, and deployment are orthogonal. A non-deployed platform peer
+# can still have active timers, but it must never require a deploy marker.
+assert_eq "active runtime has unit checks" yes \
+  "$(runtime_checks_applicable active)"
+assert_eq "stopped runtime has unit checks" yes \
+  "$(runtime_checks_applicable stopped)"
+assert_eq "not-applicable runtime has no unit checks" no \
+  "$(runtime_checks_applicable not-applicable)"
+assert_eq "active runtime with a port has health checks" yes \
+  "$(health_check_applicable active 3030)"
+assert_eq "stopped runtime skips HTTP health" no \
+  "$(health_check_applicable stopped 3030)"
+assert_eq "active runtime without a port skips HTTP health" no \
+  "$(health_check_applicable active '')"
+assert_eq "deployed component requires marker validation" yes \
+  "$(deployment_check_applicable true)"
+assert_eq "non-deployed peer skips marker validation" no \
+  "$(deployment_check_applicable false)"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/services.json
+++ b/services.json
@@ -109,6 +109,7 @@
       "host": null,
       "port": null,
       "deploy": false,
+      "desired_runtime_state": "not-applicable",
       "scan": true,
       "needs_build": false,
       "systemd_units": []
@@ -134,6 +135,7 @@
       "host": "huginmunin.local",
       "port": 3036,
       "deploy": true,
+      "desired_runtime_state": "stopped",
       "scan": true,
       "deploy_path": "/home/magnus/repos/verdandi",
       "persistent_paths": [
@@ -152,6 +154,7 @@
       "host": "huginmunin.local",
       "port": null,
       "deploy": false,
+      "desired_runtime_state": "active",
       "scan": true,
       "deploy_path": "/home/magnus/repos/brokkr",
       "needs_build": false,


### PR DESCRIPTION
Closes #109.

## Summary
- add a bounded desired_runtime_state registry contract while preserving strict active-by-default behavior
- encode Verdandi as intentionally stopped and keep Brokkr active while making deploy-marker applicability follow deploy
- render stopped/N/A states honestly in validation and generated snapshots
- add red/green coverage for active, stopped, non-deployed, and invalid registry combinations

## Verification
- make test
- shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh
- bash -n scripts/generate-architecture.sh scripts/lib/runtime-state.sh scripts/tests/runtime-state.test.sh
- git diff --check

## M5 dogfood
mellum reviewed the bounded contract (ledger d1e891a7-eb25-4dcd-a483-bbf29228924e). Usefulness: wrong. Its findings incorrectly collapsed orthogonal runtime and deployment applicability; none were adopted.