### PR TITLE
fix(audit): detect stale canonical origins

### DIFF
--- a/docs/authority.md
+++ b/docs/authority.md
@@ -15,7 +15,7 @@
 | **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
 | **Global rsync safety exclusions** (`.env`, `.git`, dependencies, tests, deploy marker) | `scripts/deploy.sh` | deploy persistence tests |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |
-| **Repo names / GitHub ownership** | `docs/conventions.md` | `docs/architecture.md`, generator |
+| **Repo names / GitHub ownership / canonical local checkout mapping** | `services.json` (`components[].repo` plus `repository_authority`) | `docs/conventions.md`, worktree-hygiene audit |
 | **Service patterns / conventions** | `docs/conventions.md` | per-repo CLAUDE.md |
 | **Component roles (short)** | `docs/conventions.md` | `docs/architecture.md`, generator |
 | **System design philosophy / rationale** | `docs/architecture.md` | per-repo CLAUDE.md (may reference) |
@@ -94,6 +94,10 @@ The generator should warn on discrepancies it can detect:
 - Deploy path in `services.json` vs WorkingDirectory / EnvironmentFile paths in unit files
 - Git-pull checkout HEAD vs the exact live `origin/main` SHA (an unreachable origin is never current)
 - Missing, symlinked, or malformed rsync deployment markers
+
+The standalone worktree-hygiene audit additionally warns when a canonical
+local checkout's `origin` disagrees with the GitHub repository identity in
+`services.json.repository_authority`, including archived predecessors.
 
 ## Document boundary: `architecture.md` vs `snapshot.md`
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,12 +28,19 @@ Deploy all services from the laptop with `make deploy` (from the grimnir repo), 
 
 ## GitHub ownership
 
-- **Magnus-Gille** — owns all repos
-- **grimnir-bot** — dedicated machine account for Pi. Added as collaborator on repos Hugin pushes to. Pi authenticates to GitHub exclusively via grimnir-bot SSH key.
+> **Source of truth:** `services.json.repository_authority`, combined with
+> each component's `repo` field. It also records local checkout-name
+> exceptions for ecosystem repositories that are not deployed components.
+
+- **Magnus-Gille** — default owner
+- **grimnir-bot** — explicit owner exception for Skuld, and the dedicated
+  machine account for Pi. Added as collaborator on repos Hugin pushes to. Pi
+  authenticates to GitHub exclusively via grimnir-bot SSH key.
 
 ## Repo naming
 
-Repos are named after the component, lowercase. The GitHub org matches the operator:
+Repos are named after the component, lowercase. The GitHub org normally
+matches the operator:
 - `Magnus-Gille/munin-memory`
 - `Magnus-Gille/hugin`
 - `Magnus-Gille/heimdall`
@@ -41,6 +48,11 @@ Repos are named after the component, lowercase. The GitHub org matches the opera
 - `Magnus-Gille/fortnox-mcp`
 - `Magnus-Gille/ratatoskr`
 - `grimnir-bot/skuld` (exception: created by Hugin task under bot account)
+
+Ecosystem repositories that are not deployed components are listed in
+`repository_authority.additional_repositories`; their canonical local
+checkout name is explicit so the audit never infers authority from an old
+directory or remote name.
 
 ## Systemd timers
 

--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -2,7 +2,8 @@
 
 > Status: adopted. Extends the canonical-checkout guard from issue #47
 > (`docs/role-separation.md`, `scripts/lib/registry-checkout.sh`) to the full
-> worktree lifecycle, and adds a narrow deploy-target role check. Read-only
+> worktree lifecycle, adds a narrow deploy-target role check, and verifies
+> canonical local origins against repository authority. Read-only
 > audit; see `scripts/worktree-hygiene-audit.sh` and
 > `scripts/lib/worktree-hygiene.sh`.
 
@@ -32,6 +33,10 @@ this class of activity accumulates residue:
   components by the `.deployed-commit` marker check), or — the narrower gap
   this issue closes — an **rsync deploy target that has unexpectedly grown a
   `.git` directory**, meaning it is quietly doubling as an ad hoc checkout.
+- **Repository-authority drift** — a canonical local checkout's `origin`
+  still points at an archived predecessor, fork, or unrelated repository. A
+  plain fetch can then look successful while returning stale or
+  non-canonical history.
 
 An audit (2026-07, grimnir#87) found exactly this kind of residue: dozens of
 worktrees on the Hugin dispatcher host including prunable and dirty stale
@@ -67,6 +72,11 @@ tree and believing cross-repo work landed when only half of it did.
    issue #47's harness) both report hygiene state read-only. Findings are
    evidence for a human/agent to act on, not something the tooling fixes
    itself.
+6. **Treat remote reconciliation as an operator action.** The audit compares
+   normalized GitHub `owner/repo` identities from
+   `services.json.repository_authority`; it never changes fetch/push URLs.
+   Before reconciling a finding, inspect local branches and worktrees and
+   preserve a useful predecessor under an explicit archival remote name.
 
 ## Running the audit
 
@@ -86,10 +96,20 @@ prints one line per worktree that has a finding, followed by a summary line
 (`Summary: N ok, M issues`) and a non-destructive remediation recipe per
 finding. Exit code is `0` when nothing is flagged, `1` otherwise.
 
-It is also wired into `scripts/generate-architecture.sh --validate` (the
-`grimnir-validate` timer), where its findings fold into the existing
-`PASS`/`FAIL` tally and Munin-persisted validation report alongside the #47
-registry-checkout check and the per-component deployment-freshness checks.
+For canonical-origin checks, component checkout names come from
+`services.json.components[].repo`; the default GitHub owner, owner
+exceptions, and non-component/renamed checkout mappings come from
+`services.json.repository_authority`. A checkout absent on the current host
+is skipped because hosts intentionally carry only part of the ecosystem.
+When a checkout exists, a missing, non-GitHub, archived, or wrong `origin`
+is a finding. Output includes only normalized public GitHub identities (or
+`<missing>`/`<non-github>`), never the raw remote URL.
+
+The worktree-lifecycle portion is also wired into
+`scripts/generate-architecture.sh --validate` (the `grimnir-validate` timer),
+where its findings fold into the existing `PASS`/`FAIL` tally alongside the
+#47 registry-checkout check and per-component deployment-freshness checks.
+Origin-authority findings currently belong to the standalone local audit.
 
 Unit and fixture tests: `make test-worktree-hygiene` (also part of
 `make test`), exercised against constructed fixture git repos — never against
@@ -106,6 +126,7 @@ the real, live repos. See `scripts/tests/worktree-hygiene.test.sh`.
 | `prunable` | Administrative worktree entry present, but its working directory is gone | Reconcile the registration only: `git worktree prune` (does not touch any other worktree's files). |
 | `alert-branch` / `alert-dirty` / `alert-branch-dirty` (canonical only) | The canonical checkout itself has drifted off the default branch and/or gone dirty — the #47 poisoning class | Reconcile manually to the default branch; see `docs/role-separation.md`. |
 | `violation-unexpected-git` (deploy target) | A non-`git-pull` deploy target unexpectedly contains a `.git` directory | Investigate manually; do not delete `.git` automatically. |
+| `missing-origin` / `non-github-origin` / `archived-origin` / `wrong-origin` | The canonical checkout's `origin` does not match repository authority | Inspect branches, worktrees, and fetch/push URLs; reconcile manually while preserving useful predecessor history under an explicit archival remote. |
 
 `classify_deploy_target` trusts `services.json`'s declared `deploy_mode` as the
 intended contract, not something it infers from the filesystem. If a
@@ -122,6 +143,11 @@ the repo-wide git-safety rule that destroying uncommitted or untracked work
 is never automatic. If a destructive action is ever warranted (e.g. removing
 a confirmed-stale worktree), it is an explicit, opt-in, operator-run command
 — never something this tooling executes on your behalf.
+
+The same boundary applies to remotes: the audit reads
+`remote.origin.url`, normalizes supported GitHub transports for comparison,
+and reports a verdict. It never executes `git remote set-url`, adds/removes
+a remote, fetches, or pushes.
 
 ## Known heuristic limit
 

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -15,6 +15,7 @@
 //   all          — full JSON array of all components
 //   nodes        — infra/inference hosts (data.nodes): name|hostname|ssh_alias|role|status|llm|monitor per line
 //   nodes-json   — full JSON array of all nodes (data.nodes)
+//   repository-authority — canonical local checkout|GitHub owner/repo rows
 
 var fs = require('fs');
 var path = require('path');
@@ -156,6 +157,34 @@ switch (query) {
     process.stdout.write(JSON.stringify(Array.isArray(data.nodes) ? data.nodes : []) + '\n');
     break;
   }
+  case 'repository-authority': {
+    var authority = data.repository_authority;
+    if (!authority || typeof authority !== 'object' || Array.isArray(authority) ||
+        typeof authority.default_owner !== 'string') {
+      break;
+    }
+    var overrides = authority.owner_overrides &&
+      typeof authority.owner_overrides === 'object' &&
+      !Array.isArray(authority.owner_overrides)
+      ? authority.owner_overrides : {};
+    var rows = components.map(function (c) {
+      return { repo: c.repo, checkout: c.repo };
+    });
+    if (Array.isArray(authority.additional_repositories)) {
+      authority.additional_repositories.forEach(function (entry) {
+        rows.push(entry);
+      });
+    }
+    var seen = {};
+    rows.forEach(function (entry) {
+      if (!entry || typeof entry.repo !== 'string' || typeof entry.checkout !== 'string') return;
+      if (seen[entry.checkout]) return;
+      seen[entry.checkout] = true;
+      var owner = overrides[entry.repo] || authority.default_owner;
+      process.stdout.write(entry.checkout + '|' + owner + '/' + entry.repo + '\n');
+    });
+    break;
+  }
   default: {
     // json:<field>=<value> — filter and return JSON
     var match = query.match(/^json:(\w+)=(.+)$/);
@@ -169,7 +198,7 @@ switch (query) {
       process.stdout.write(JSON.stringify(filtered) + '\n');
     } else {
       process.stderr.write('ERROR: Unknown query: ' + query + '\n');
-      process.stderr.write('Valid queries: deploy, scan, components, systemd, ports, validate, all, nodes, nodes-json, json:<field>=<value>\n');
+      process.stderr.write('Valid queries: deploy, scan, components, systemd, ports, validate, all, nodes, nodes-json, repository-authority, json:<field>=<value>\n');
       process.exit(1);
     }
   }

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -50,6 +50,57 @@ if (!Array.isArray(data.components)) {
   printAndExit();
 }
 
+var VALID_REPOSITORY_PART = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+if (data.repository_authority !== undefined && !isPlainObject(data.repository_authority)) {
+  fail('top-level "repository_authority" must be an object when present');
+} else if (isPlainObject(data.repository_authority)) {
+  var authority = data.repository_authority;
+  if (typeof authority.default_owner !== 'string' ||
+      !VALID_REPOSITORY_PART.test(authority.default_owner)) {
+    fail('repository_authority.default_owner must be a safe GitHub owner');
+  }
+  if (!isPlainObject(authority.owner_overrides)) {
+    fail('repository_authority.owner_overrides must be an object');
+  } else {
+    Object.keys(authority.owner_overrides).forEach(function (repo) {
+      if (!VALID_REPOSITORY_PART.test(repo) ||
+          typeof authority.owner_overrides[repo] !== 'string' ||
+          !VALID_REPOSITORY_PART.test(authority.owner_overrides[repo])) {
+        fail('repository_authority.owner_overrides must map safe repo names to safe GitHub owners');
+      }
+    });
+  }
+  if (!Array.isArray(authority.additional_repositories)) {
+    fail('repository_authority.additional_repositories must be an array');
+  } else {
+    var seenAuthorityCheckouts = {};
+    data.components.forEach(function (component) {
+      if (isPlainObject(component) && typeof component.repo === 'string') {
+        seenAuthorityCheckouts[component.repo] = true;
+      }
+    });
+    authority.additional_repositories.forEach(function (entry, i) {
+      var label = 'repository_authority.additional_repositories[' + i + ']';
+      if (!isPlainObject(entry)) {
+        fail(label + ' must be an object');
+        return;
+      }
+      ['repo', 'checkout'].forEach(function (field) {
+        if (typeof entry[field] !== 'string' || !VALID_REPOSITORY_PART.test(entry[field])) {
+          fail(label + '.' + field + ' must be a safe repository/directory name');
+        }
+      });
+      if (typeof entry.checkout === 'string') {
+        if (seenAuthorityCheckouts[entry.checkout]) {
+          fail('duplicate repository-authority checkout: "' + entry.checkout + '"');
+        }
+        seenAuthorityCheckouts[entry.checkout] = true;
+      }
+    });
+  }
+}
+
 var VALID_UNIT_TYPES = ['service', 'timer'];
 var VALID_UNIT_SCOPES = ['system', 'user'];
 var VALID_TIMER_SEMANTICS = ['recurring', 'one-shot'];

--- a/scripts/lib/worktree-hygiene.sh
+++ b/scripts/lib/worktree-hygiene.sh
@@ -174,6 +174,125 @@ deploy_target_detail() {
   esac
 }
 
+# Convert supported GitHub remote transports to a disclosure-safe,
+# case-insensitive "owner/repo" identity. Raw remote URLs are deliberately
+# never returned: non-GitHub transports collapse to an empty string so an
+# audit finding cannot leak a private host or locator.
+normalize_github_remote() {
+  local remote="${1:-}" slug=""
+  case "$remote" in
+    https://github.com/*)
+      slug="${remote#https://github.com/}"
+      ;;
+    git@github.com:*)
+      slug="${remote#git@github.com:}"
+      ;;
+    ssh://git@github.com/*)
+      slug="${remote#ssh://git@github.com/}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  slug="${slug%/}"
+  slug="${slug%.git}"
+  case "$slug" in
+    */*)
+      local owner="${slug%%/*}" repo="${slug#*/}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+  [[ -n "$owner" && -n "$repo" && "$repo" != */* ]] || return 0
+  case "$owner$repo" in
+    *[!A-Za-z0-9_.-]*) return 0 ;;
+  esac
+  printf '%s/%s\n' "$owner" "$repo" | tr '[:upper:]' '[:lower:]'
+}
+
+classify_origin_authority() {
+  local expected="${1:-}" actual="${2:-}" has_origin="${3:-no}"
+  if [[ "$has_origin" != "yes" ]]; then
+    echo "missing-origin"
+  elif [[ -z "$actual" ]]; then
+    echo "non-github-origin"
+  elif [[ "$actual" == "$expected" ]]; then
+    echo "ok"
+  elif [[ "${actual#*/}" =~ (^|[-_.])(archive|archived|legacy|predecessor)([-_.]|$) ]]; then
+    echo "archived-origin"
+  else
+    echo "wrong-origin"
+  fi
+}
+
+origin_authority_is_alert() {
+  if [[ "${1:-ok}" == "ok" ]]; then
+    echo "no"
+  else
+    echo "yes"
+  fi
+}
+
+origin_authority_detail() {
+  local verdict="${1:-ok}" expected="${2:-<unknown>}" actual="${3:-<unknown>}"
+  case "$verdict" in
+    ok)
+      echo "origin matches repository authority ($expected)"
+      ;;
+    missing-origin)
+      echo "origin is missing; expected $expected"
+      ;;
+    non-github-origin)
+      echo "origin is not a recognized GitHub remote; expected $expected"
+      ;;
+    archived-origin)
+      echo "origin points to archived predecessor $actual; expected $expected"
+      ;;
+    wrong-origin)
+      echo "origin points to $actual; expected $expected"
+      ;;
+    *)
+      echo "unknown origin-authority verdict: $verdict; expected $expected"
+      ;;
+  esac
+}
+
+origin_authority_remediation() {
+  local verdict="${1:-ok}" expected="${2:-<unknown>}"
+  if [[ "$verdict" == "ok" ]]; then
+    echo ""
+  else
+    echo "Inspect local branches, worktrees, and both fetch/push URLs; then reconcile origin to $expected manually while preserving any useful predecessor under an explicit archival remote name. Nothing is changed by this audit."
+  fi
+}
+
+checkout_origin_authority() {
+  local repo_path="${1:-}" expected="${2:-}" remote="" actual="" has_origin="no"
+  [[ -n "$repo_path" && -n "$expected" ]] || return 0
+  if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+
+  remote="$(git -C "$repo_path" config --get remote.origin.url 2>/dev/null || true)"
+  if [[ -n "$remote" ]]; then
+    has_origin="yes"
+    actual="$(normalize_github_remote "$remote")"
+  fi
+
+  local verdict safe_actual
+  verdict="$(classify_origin_authority "$expected" "$actual" "$has_origin")"
+  if [[ "$has_origin" != "yes" ]]; then
+    safe_actual="<missing>"
+  elif [[ -z "$actual" ]]; then
+    safe_actual="<non-github>"
+  else
+    safe_actual="$actual"
+  fi
+  echo "$verdict|$safe_actual"
+}
+
 list_repo_worktrees() {
   local repo_path="${1:-}"
   [[ -n "$repo_path" ]] || return 0

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -91,6 +91,43 @@ assert_eq "valid registry -> exit 0" "0" "$(run_validator "$TMP_DIR/valid.json")
 REPO_REGISTRY="$SCRIPT_DIR/../../services.json"
 assert_eq "real services.json -> exit 0" "0" "$(run_validator "$REPO_REGISTRY")"
 
+# ── Repository authority is bounded and machine-readable (#112) ───────────
+cat > "$TMP_DIR/bad-repository-authority.json" << 'EOF'
+{
+  "repository_authority": {
+    "default_owner": "owner|unsafe",
+    "owner_overrides": [],
+    "additional_repositories": [
+      { "repo": "../escape", "checkout": "/absolute/path" }
+    ]
+  },
+  "components": []
+}
+EOF
+assert_eq "unsafe repository authority -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/bad-repository-authority.json")"
+
+cat > "$TMP_DIR/duplicate-repository-checkout.json" << 'EOF'
+{
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "owner_overrides": {},
+    "additional_repositories": [
+      { "repo": "other", "checkout": "alpha" }
+    ]
+  },
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": null, "port": null,
+      "deploy": false, "scan": false, "needs_build": false,
+      "systemd_units": []
+    }
+  ]
+}
+EOF
+assert_eq "repository authority cannot silently shadow a component checkout -> exit 1" "1" \
+  "$(run_validator "$TMP_DIR/duplicate-repository-checkout.json")"
+
 # ── rsync persistent-path safety ───────────────────────────────────────────
 cat > "$TMP_DIR/missing-persistent-paths.json" << 'EOF'
 {
@@ -493,6 +530,20 @@ assert_clean_failure "null entry in nodes" "$TMP_DIR/null-node.json"
 # appending units must never change the deploy row. Pin the real services.json
 # plus the ordering contract on a synthetic fixture.
 REGISTRY_JS="$SCRIPT_DIR/../lib/registry.js"
+repository_authority_rows="$(
+  REGISTRY_PATH="$REPO_REGISTRY" QUERY=repository-authority \
+    node --input-type=commonjs "$REGISTRY_JS"
+)"
+assert_eq "Heimdall checkout authority is canonical public repo" \
+  "heimdall|Magnus-Gille/heimdall" \
+  "$(printf '%s\n' "$repository_authority_rows" | grep '^heimdall|')"
+assert_eq "Skuld checkout retains its owner exception" \
+  "skuld|grimnir-bot/skuld" \
+  "$(printf '%s\n' "$repository_authority_rows" | grep '^skuld|')"
+assert_eq "Gille Inference canonical checkout maps to public authority" \
+  "gille-inference|Magnus-Gille/gille-inference" \
+  "$(printf '%s\n' "$repository_authority_rows" | grep '^gille-inference|')"
+
 deploy_field() {  # $1 = registry path, $2 = component name, $3 = field
   REGISTRY_PATH="$1" QUERY=deploy node --input-type=commonjs "$REGISTRY_JS" 2>/dev/null \
     | COMPONENT_NAME="$2" COMPONENT_FIELD="$3" node --input-type=commonjs -e '

--- a/scripts/tests/worktree-hygiene.test.sh
+++ b/scripts/tests/worktree-hygiene.test.sh
@@ -128,6 +128,37 @@ assert_eq "deploy_target_is_alert violation -> yes" \
 assert_contains "deploy_target_detail violation references role-separation doc" \
   "$(deploy_target_detail violation-unexpected-git)" "role-separation.md"
 
+# ── canonical origin authority ────────────────────────────────────────────
+assert_eq "normalize HTTPS GitHub origin" "magnus-gille/heimdall" \
+  "$(normalize_github_remote "https://github.com/Magnus-Gille/heimdall.git")"
+assert_eq "normalize SCP-style GitHub origin" "magnus-gille/heimdall" \
+  "$(normalize_github_remote "git@github.com:Magnus-Gille/heimdall.git")"
+assert_eq "normalize ssh:// GitHub origin" "grimnir-bot/skuld" \
+  "$(normalize_github_remote "ssh://git@github.com/grimnir-bot/skuld.git")"
+assert_eq "non-GitHub origin does not disclose or masquerade as authority" "" \
+  "$(normalize_github_remote "ssh://git@internal.example/private/repo.git")"
+
+assert_eq "matching canonical origin -> ok" "ok" \
+  "$(classify_origin_authority magnus-gille/heimdall magnus-gille/heimdall yes)"
+assert_eq "missing origin -> missing-origin" "missing-origin" \
+  "$(classify_origin_authority magnus-gille/heimdall "" no)"
+assert_eq "non-GitHub origin -> non-github-origin" "non-github-origin" \
+  "$(classify_origin_authority magnus-gille/heimdall "" yes)"
+assert_eq "archived predecessor origin -> archived-origin" "archived-origin" \
+  "$(classify_origin_authority magnus-gille/heimdall magnus-gille/heimdall-private-archive yes)"
+assert_eq "wrong live GitHub origin -> wrong-origin" "wrong-origin" \
+  "$(classify_origin_authority magnus-gille/heimdall someone/heimdall yes)"
+assert_eq "origin authority ok is not an alert" "no" \
+  "$(origin_authority_is_alert ok)"
+assert_eq "archived origin is an alert" "yes" \
+  "$(origin_authority_is_alert archived-origin)"
+assert_contains "archived origin detail names expected authority" \
+  "$(origin_authority_detail archived-origin magnus-gille/heimdall magnus-gille/heimdall-private-archive)" \
+  "expected magnus-gille/heimdall"
+assert_not_contains "origin remediation never mutates a remote automatically" \
+  "$(origin_authority_remediation archived-origin magnus-gille/heimdall)" \
+  "git remote set-url"
+
 echo ""
 echo "worktree-hygiene gatherer tests (real fixture repos)"
 echo "====================================================="
@@ -224,6 +255,28 @@ assert_eq "plain deploy dir -> no" "no" "$(check_deploy_target_git_dir "$TMP_DIR
 assert_eq "deploy dir with .git -> yes" "yes" "$(check_deploy_target_git_dir "$TMP_DIR/deploy-git")"
 assert_eq "no-arg check_deploy_target_git_dir -> no" "no" "$(check_deploy_target_git_dir)"
 
+# ── checkout_origin_authority ─────────────────────────────────────────────
+mk_repo "$TMP_DIR/origin-authority-ok" main
+git -C "$TMP_DIR/origin-authority-ok" remote add origin \
+  "git@github.com:Magnus-Gille/heimdall.git"
+assert_eq "matching fixture origin is classified ok" \
+  "ok|magnus-gille/heimdall" \
+  "$(checkout_origin_authority "$TMP_DIR/origin-authority-ok" magnus-gille/heimdall)"
+
+mk_repo "$TMP_DIR/origin-authority-archive" main
+git -C "$TMP_DIR/origin-authority-archive" remote add origin \
+  "https://github.com/Magnus-Gille/heimdall-private-archive.git"
+assert_eq "archived fixture origin is classified without exposing raw URL" \
+  "archived-origin|magnus-gille/heimdall-private-archive" \
+  "$(checkout_origin_authority "$TMP_DIR/origin-authority-archive" magnus-gille/heimdall)"
+
+mk_repo "$TMP_DIR/origin-authority-non-github" main
+git -C "$TMP_DIR/origin-authority-non-github" remote add origin \
+  "ssh://git@internal.example/private/heimdall.git"
+assert_eq "non-GitHub fixture origin is classified without exposing raw URL" \
+  "non-github-origin|<non-github>" \
+  "$(checkout_origin_authority "$TMP_DIR/origin-authority-non-github" magnus-gille/heimdall)"
+
 echo ""
 echo "audit_repo_worktrees end-to-end tests"
 echo "======================================"
@@ -298,9 +351,13 @@ mkdir -p "$FIXTURE_ROOT"
 
 # Repo A: fully clean (canonical only, on main).
 mk_repo "$FIXTURE_ROOT/repo-a" main
+git -C "$FIXTURE_ROOT/repo-a" remote add origin \
+  "https://github.com/Magnus-Gille/repo-a.git"
 
 # Repo B: seeds a stale merged worktree AND a dirty worktree, canonical clean.
 mk_repo "$FIXTURE_ROOT/repo-b" main
+git -C "$FIXTURE_ROOT/repo-b" remote add origin \
+  "https://github.com/Magnus-Gille/repo-b-private-archive.git"
 git -C "$FIXTURE_ROOT/repo-b" branch feature/merged-b
 git -C "$FIXTURE_ROOT/repo-b" worktree add -q "$TMP_DIR/repo-b-stale" feature/merged-b
 git -C "$FIXTURE_ROOT/repo-b" merge -q --no-ff -m "merge" feature/merged-b
@@ -319,16 +376,31 @@ mkdir -p "$TMP_DIR/deploy-drift-target/.git"
 FIXTURE_SERVICES_JSON="$TMP_DIR/services.json"
 cat > "$FIXTURE_SERVICES_JSON" << EOF
 {
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "additional_repositories": [],
+    "owner_overrides": {}
+  },
   "components": [
     {
-      "name": "fixture-component",
-      "repo": "fixture-component",
+      "name": "repo-a",
+      "repo": "repo-a",
       "host": null,
       "port": null,
       "deploy": true,
       "scan": false,
       "deploy_path": "$TMP_DIR/deploy-drift-target",
       "deploy_mode": "rsync",
+      "needs_build": false,
+      "systemd_units": []
+    },
+    {
+      "name": "repo-b",
+      "repo": "repo-b",
+      "host": null,
+      "port": null,
+      "deploy": false,
+      "scan": false,
       "needs_build": false,
       "systemd_units": []
     }
@@ -346,18 +418,39 @@ assert_eq "CLI exits 1 when fixture has issues" "1" "$dirty_rc"
 assert_contains "CLI flags repo-b stale worktree" "$dirty_output" "repo-b"
 assert_contains "CLI flags repo-b dirty worktree" "$dirty_output" "dirty"
 assert_contains "CLI flags repo-c canonical violation" "$dirty_output" "repo-c"
-assert_contains "CLI flags the deploy-target .git drift" "$dirty_output" "fixture-component"
+assert_contains "CLI flags the deploy-target .git drift" "$dirty_output" "repo-a"
 assert_contains "CLI flags deploy-target role-separation reference" "$dirty_output" "role-separation.md"
+assert_contains "CLI flags repo-b archived predecessor origin" "$dirty_output" "archived predecessor"
+assert_contains "CLI origin finding names expected repository" "$dirty_output" "magnus-gille/repo-b"
+assert_not_contains "CLI origin finding does not expose raw transport URL" \
+  "$dirty_output" "https://github.com"
 assert_not_contains "CLI output never instructs an unconditional delete" "$dirty_output" "rm -rf"
+assert_not_contains "CLI output never mutates a remote" "$dirty_output" "git remote set-url"
 assert_contains "CLI prints a summary line" "$dirty_output" "Summary:"
 
 # Clean-only fixture root: must report clean and exit 0.
 CLEAN_ROOT="$TMP_DIR/repos-root-clean"
 mkdir -p "$CLEAN_ROOT"
 mk_repo "$CLEAN_ROOT/repo-clean" main
+git -C "$CLEAN_ROOT/repo-clean" remote add origin \
+  "https://github.com/Magnus-Gille/repo-clean.git"
+
+CLEAN_SERVICES_JSON="$TMP_DIR/services-clean.json"
+cat > "$CLEAN_SERVICES_JSON" << EOF
+{
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "additional_repositories": [
+      { "repo": "repo-clean", "checkout": "repo-clean" }
+    ],
+    "owner_overrides": {}
+  },
+  "components": []
+}
+EOF
 
 set +e
-clean_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$CLEAN_ROOT" GRIMNIR_SERVICES_JSON="$TMP_DIR/no-such-services.json" \
+clean_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$CLEAN_ROOT" GRIMNIR_SERVICES_JSON="$CLEAN_SERVICES_JSON" \
   "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
 clean_rc=$?
 set -e

--- a/scripts/worktree-hygiene-audit.sh
+++ b/scripts/worktree-hygiene-audit.sh
@@ -8,6 +8,8 @@
 # reports:
 #   - a canonical checkout that is dirty or off its default branch (role
 #     violation per #47)
+#   - a canonical checkout whose origin disagrees with the repository
+#     authority declared in services.json, including archived predecessors
 #   - stale linked worktrees (branch merged into the default branch, or its
 #     upstream is gone) that were never cleaned up
 #   - dirty linked worktrees holding uncommitted work
@@ -105,6 +107,33 @@ for repo_dir in "$REPOS_ROOT"/*/; do
   done < <(audit_repo_worktrees "$repo_dir" "$DEFAULT_BRANCH")
 done
 shopt -u nullglob
+
+# Canonical-origin authority check (#112). The registry combines component
+# repo names with the explicit GitHub owner/checkout exceptions declared in
+# repository_authority. Missing local checkouts are skipped: this audit runs
+# on hosts that intentionally carry only part of the ecosystem. Existing
+# checkouts are inspected read-only and raw remote URLs are never printed.
+if [[ -f "$SERVICES_JSON" ]]; then
+  REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
+  while IFS='|' read -r checkout_name expected_authority; do
+    [[ -n "$checkout_name" && -n "$expected_authority" ]] || continue
+    checkout_path="$REPOS_ROOT/$checkout_name"
+    if ! git -C "$checkout_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      continue
+    fi
+    expected_authority="$(printf '%s' "$expected_authority" | tr '[:upper:]' '[:lower:]')"
+    origin_row="$(checkout_origin_authority "$checkout_path" "$expected_authority")"
+    origin_verdict="${origin_row%%|*}"
+    origin_actual="${origin_row#*|}"
+    if [[ "$(origin_authority_is_alert "$origin_verdict")" == "yes" ]]; then
+      OFFENDERS+="❌ $checkout_name canonical checkout origin: $(origin_authority_detail "$origin_verdict" "$expected_authority" "$origin_actual")\n"
+      RECIPES+="  - $checkout_name origin: $(origin_authority_remediation "$origin_verdict" "$expected_authority")\n"
+      ISSUES=$((ISSUES + 1))
+    else
+      PASS=$((PASS + 1))
+    fi
+  done < <(REGISTRY_PATH="$SERVICES_JSON" QUERY=repository-authority node --input-type=commonjs "$REGISTRY_JS")
+fi
 
 # Deploy-target role check (#47/#87): an rsync deploy target that has grown a
 # .git directory may be doubling as an ad hoc checkout. Only meaningful on the

--- a/services.json
+++ b/services.json
@@ -1,4 +1,16 @@
 {
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "owner_overrides": {
+      "skuld": "grimnir-bot"
+    },
+    "additional_repositories": [
+      {
+        "repo": "gille-inference",
+        "checkout": "gille-inference"
+      }
+    ]
+  },
   "components": [
     {
       "name": "munin-memory",


### PR DESCRIPTION
## Summary

- declare machine-readable GitHub repository authority for component checkouts plus Gille Inference
- extend the read-only worktree hygiene audit with missing, non-GitHub, archived, and wrong origin findings
- normalize only supported public GitHub identities and never print raw non-GitHub remote URLs
- validate authority configuration and pin the motivating Heimdall and Gille Inference mappings in tests
- document the manual-only reconciliation boundary

## Scope

This implements the durable detection and documentation portion of #112. It does not change any local remote, fetch, push, prune, or discard work. Missing checkouts are intentionally skipped because hosts carry different subsets of the ecosystem. No Munin calls or other repository mutations were made.

## Verification

- red/green: worktree-hygiene suite failed on the new origin cases before implementation, then passed 93/93
- red/green: duplicate authority shadowing fixture failed before validation, then passed
- make test: green
- shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh: green
- git diff --check: green

## Review evidence

- Root early review caught that the first Gille checkout mapping named the predecessor directory instead of the actual canonical gille-inference checkout. Fixed before commit and pinned with real-registry assertions for both Heimdall and Gille Inference.
- M5 full-patch review attempt was correctly refused by the local router as a frontier code-edit gap: cost trace 3b2147dd-74c4-4fd6-9517-7fb4defbd7fa; usefulness redo.
- M5 bounded design-risk classification ran locally on mellum: ledger fe5038c2-a795-40cc-a711-652b8443e58d, 462 prompt tokens, 187 completion tokens, 2.021 seconds, all seven safety claims PASS. Usefulness partial because it checked a self-contained design summary, not the repository diff.

Refs #112