### PR TITLE
Bind deployments to explicit source revisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,8 @@ Roadmap → tickets → implementation → review, with grimnir as the orchestra
 
 | Script | Purpose | Run with |
 |--------|---------|----------|
-| `scripts/deploy.sh` | Deploy services to Pi hosts (all or selective) | `make deploy` or `make deploy ARGS="munin-memory"` |
+| `scripts/deploy.sh` | Deploy registered services from explicitly bound revisions | `make deploy ARGS="service=/absolute/worktree@FULL_COMMIT_SHA"` |
+| `scripts/guarded-deploy.sh` | Bind arbitrary owning-repo deploy commands to an expected worktree + revision | See `docs/deployment-source-binding.md` |
 | `scripts/generate-architecture.sh` | Generate deployment snapshot + full-architecture.md | `make docs` (Pi only) |
 | `scripts/output-audit.py` | Audit owner+AI repository output over a date window | `python3 scripts/output-audit.py` (reads an untracked local identities config; see `scripts/output-audit-identities.example.json`) |
 | `scripts/security-scan.sh` | Scan all repos for vulnerabilities and secrets | `make security` |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -9,7 +9,7 @@ security: ## Run security scan across all Grimnir repos
 security-dry: ## Run security scan (dry run, no Munin writes)
 	@./scripts/security-scan.sh --dry-run
 
-deploy: ## Deploy all services to Pi (or: make deploy ARGS="munin-memory hugin")
+deploy: ## Deploy bound sources (ARGS="service=/absolute/worktree@FULL_COMMIT_SHA [...]")
 	@./scripts/deploy.sh $(ARGS)
 
 test-security-skip: ## Regression test: assert security-scan skips test/eval fixtures (issue #22)
@@ -26,6 +26,9 @@ test-munin-rpc: ## Reject HTTP, JSON-RPC, and MCP tool errors from scheduled wri
 
 test-registry-smoke: ## Schema/consistency smoke check for services.json (issue #48)
 	@bash scripts/tests/registry-smoke.test.sh
+
+test-deploy-source-revision: ## Bind every deploy source to an explicit immutable revision (issue #114)
+	@bash scripts/tests/deploy-source-revision.test.sh
 
 test-deploy-persistent-paths: ## Fail closed before rsync can delete an in-target runtime path
 	@bash scripts/tests/deploy-persistent-paths.test.sh
@@ -51,7 +54,7 @@ test-runtime-state: ## Desired runtime and deployment-state validation (issue #1
 test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
 	@bash scripts/tests/worktree-hygiene.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -14,6 +14,7 @@
 | **Host systemd runtime identity, home, deploy target, private-environment paths and exact external sandbox dependencies** | `services.json` | `deploy.sh`, `render-systemd-units.sh` |
 | **Persistent/runtime paths and component-specific rsync exclusions** | `services.json` | `deploy.sh`, registry validation |
 | **Global rsync safety exclusions** (`.env`, `.git`, dependencies, tests, deploy marker) | `scripts/deploy.sh` | deploy persistence tests |
+| **Deployment source identity** (expected worktree + immutable revision) | `scripts/lib/deploy-source.sh` | deploy source-revision tests |
 | **Component inventory** | `services.json` | all scripts, `docs/conventions.md` (references it) |
 | **Repo names / GitHub ownership / canonical local checkout mapping** | `services.json` (`components[].repo` plus `repository_authority`) | `docs/conventions.md`, worktree-hygiene audit |
 | **Service patterns / conventions** | `docs/conventions.md` | per-repo CLAUDE.md |

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,7 +24,9 @@ All components are named after figures from Norse mythology, reflecting their ro
 
 Remote install paths live in `services.json` as `deploy_path`. Most services live under `~/repos/<service-name>/`, but a few have intentional exceptions such as `munin-memory` (`~/munin-memory`) and `mimir` (`~/mimir-server`).
 
-Deploy all services from the laptop with `make deploy` (from the grimnir repo), or selectively with `make deploy ARGS="munin-memory hugin"`. The centralized script deploys the local working tree via rsync, runs a local build when `needs_build: true`, installs production dependencies on the target host, and restarts primary service units. Declared units are install-ready by default. A component may opt into the bounded host renderer with `systemd_runtime`; see [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md) for the registry contract, preflight, migration, and rollback procedure. For worktree-based deploys, pass an explicit source override such as `make deploy ARGS="munin-memory=/tmp/munin-memory-awesome"`.
+Deploy selectively from the laptop with an explicitly bound source and full commit SHA, for example `make deploy ARGS="heimdall=/private/tmp/heimdall-release@<accepted-full-sha>"`. Bare service names and no-argument deploys fail closed. The centralized script validates every selected source before any component mutation, deploys via rsync or the registered git-pull mode, runs a local build when `needs_build: true`, installs production dependencies on the target host, and restarts primary service units. Declared units are install-ready by default. A component may opt into the bounded host renderer with `systemd_runtime`; see [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md) for the registry contract, preflight, migration, and rollback procedure.
+
+For owning-repository deploy commands outside the centrally deployable set, use `scripts/guarded-deploy.sh` as the outer source-identity boundary. See [`deployment-source-binding.md`](deployment-source-binding.md) for both contracts and examples.
 
 ## GitHub ownership
 
@@ -77,4 +79,4 @@ Every Grimnir service follows these patterns:
 - systemd for process management (Restart=always)
 - `/health` endpoint for Heimdall monitoring
 - `.env` file on Pi for secrets (never in git, never overwritten by deploy)
-- Centralized deploy via `grimnir/scripts/deploy.sh` is preferred; per-repo deploy scripts remain for bootstrap or repo-specific extras
+- Centralized deploy via `grimnir/scripts/deploy.sh` is preferred; per-repo deploy scripts remain for bootstrap or repo-specific extras and must be invoked through Grimnir's `scripts/guarded-deploy.sh`

--- a/docs/deployment-source-binding.md
+++ b/docs/deployment-source-binding.md
@@ -1,0 +1,73 @@
+# Deployment source binding
+
+Every deployment invocation must name the source selected by the orchestrator
+and its immutable full commit SHA. A clean checkout is necessary but not
+sufficient: it can still be the wrong worktree or a stale commit.
+
+The expected SHA must come from the accepted release decision (for example the
+merged PR result), not from `git rev-parse HEAD` in whichever checkout happens
+to be current at deploy time.
+
+## Centrally deployable components
+
+`scripts/deploy.sh` requires one bound request for every selected component:
+
+```text
+component[=/absolute/worktree]@FULL_COMMIT_SHA
+```
+
+Use the registered checkout with `component@FULL_COMMIT_SHA`, or bind an
+isolated worktree explicitly:
+
+```sh
+make deploy ARGS="heimdall=/private/tmp/heimdall-release@<accepted-full-sha>"
+```
+
+Multiple components may be selected, but each gets its own source and SHA:
+
+```sh
+make deploy ARGS="heimdall=/private/tmp/heimdall-release@<heimdall-full-sha> mimir=/private/tmp/mimir-release@<mimir-full-sha>"
+```
+
+Bare component names and no-argument deploys fail closed. Before any selected
+component builds, invalidates a marker, syncs, pulls, or restarts, Grimnir
+validates the complete request set. It prints:
+
+```text
+Expected source: /absolute/worktree @ <expected-sha>
+Actual source: /absolute/worktree @ <actual-sha>
+```
+
+The selected directory must itself be the resolved Git worktree root; a
+subdirectory is rejected. Detached worktrees are supported. Existing
+component cleanliness, unit-source, rendering, marker, restart, and health
+checks remain additional gates.
+
+For `deploy_mode: git-pull`, Grimnir also resolves `origin/main` read-only with
+`git ls-remote` and requires it to equal the expected SHA before remote marker
+invalidation. The remote checkout repeats the equality check after fetch and
+requires its final `HEAD` to equal the same expected SHA.
+
+## Owning-repository deploy commands
+
+Some repositories use their own deploy entry point and are intentionally not
+in the centrally deployable component set. Run those commands through
+Grimnir's generic guard:
+
+```sh
+cd /private/tmp/owning-repo-release
+/absolute/path/to/grimnir/scripts/guarded-deploy.sh \
+  /private/tmp/owning-repo-release \
+  <accepted-full-sha> \
+  -- ./scripts/deploy.sh
+```
+
+The guard compares the explicit expected path and SHA with the caller's
+physical current directory, resolved Git worktree root, and actual `HEAD`.
+The command after `--` is executed only when all identities match. This keeps
+the owning repository's own deploy checks intact; the Grimnir guard is an
+outer source-identity boundary, not a replacement for them.
+
+Use this wrapper for any component-local deployment, including repositories
+listed only under `repository_authority.additional_repositories` and peers
+with `deploy: false`.

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -117,6 +117,12 @@ then invalidates that acceptance marker before the first rsync or git-pull tree 
 the new SHA only after dependency, unit, restart, and health gates succeed. A failed deployment is
 therefore deliberately markerless/unknown, never certified by the old SHA.
 
+Before marker invalidation, every selected source must match the orchestrator's explicit worktree
+path and full commit SHA. Git-pull deployments additionally resolve `origin/main` read-only and
+require it to equal that SHA. Owning-repository deploy entry points outside the centrally deployable
+set use `scripts/guarded-deploy.sh` for the same outer identity boundary; see
+[`deployment-source-binding.md`](deployment-source-binding.md).
+
 - **Reversal recipe:** perform a clean selective redeploy of the captured prior SHA. Rsync is not
   transactional, so marker absence is the signal to rollback or finish a verified redeploy—not a
   claim that the old files are still intact.

--- a/docs/role-separation.md
+++ b/docs/role-separation.md
@@ -18,7 +18,7 @@ three roles that want incompatible things from it:
 
 | Role | Who drives it | What it wants the tree to be |
 |------|---------------|------------------------------|
-| **Deploy target** | `scripts/deploy.sh` (`make deploy grimnir`) rsyncs the laptop working tree here with `--delete` | An exact mirror of whatever local working tree was deployed |
+| **Deploy target** | `scripts/deploy.sh` (`make deploy ARGS="grimnir=/absolute/worktree@FULL_COMMIT_SHA"`) advances this checkout only after source binding | A clean `main` checkout matching the explicitly expected `origin/main` revision |
 | **Canonical git checkout** | Registry consumers read `services.json` from here; the `grimnir-security-scan` and `grimnir-validate` timers run *from* here | Pristine: on the default branch (`main`), clean, matching `origin/main` |
 | **Hugin task workspace** | Hugin (task dispatcher) has historically used this checkout as a working tree, checking out branches per task | A scratch tree it can check out arbitrary branches into and mutate |
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Grimnir deploy script — deploys services to Pi hosts via SSH.
-# Usage: ./scripts/deploy.sh [service[=/abs/path/to/worktree] ...]
-# No args = deploy all services. Pass one or more names to deploy selectively.
-# Use name=/path to deploy from a specific local worktree instead of $HOME/repos/<repo>.
+# Usage: ./scripts/deploy.sh service[=/abs/path/to/worktree]@FULL_COMMIT_SHA [...]
+# Every selected source requires its immutable expected revision. Use name@SHA
+# for $HOME/repos/<repo>, or name=/path@SHA for an explicit worktree.
 #
 # Service list is read from services.json (the single source of truth).
 
@@ -16,6 +16,8 @@ REGISTRY_VALIDATOR="$SCRIPT_DIR/lib/validate-registry.js"
 SYSTEMD_RENDER_HELPER="$SCRIPT_DIR/lib/render-systemd-units.sh"
 # shellcheck source=scripts/lib/deploy-safety.sh
 source "$SCRIPT_DIR/lib/deploy-safety.sh"
+# shellcheck source=scripts/lib/deploy-source.sh
+source "$SCRIPT_DIR/lib/deploy-source.sh"
 
 # Validate the full registry before producing JSON Lines deploy records. No
 # network or filesystem mutation occurs before this gate passes.
@@ -110,18 +112,140 @@ build_locally() {
 
 resolve_local_path() {
   local service_name=$1 repo=$2
-  local req
+  local req req_name source_override
 
   # ${arr[@]+...} idiom: bash 3.2 (macOS) treats an empty array's "${arr[@]}"
-  # as unbound under set -u — this crashed every no-args `make deploy`.
+  # as unbound under set -u. Keep the required no-args failure deterministic.
   for req in ${requested[@]+"${requested[@]}"}; do
-    if [[ "$req" == "${service_name}="* ]]; then
-      echo "${req#*=}"
-      return
+    req_name=$(deployment_request_name "$req")
+    if [[ "$req_name" == "$service_name" ]]; then
+      source_override=$(deployment_request_source_override "$req")
+      if [[ -n "$source_override" ]]; then
+        echo "$source_override"
+        return
+      fi
     fi
   done
 
   echo "${LOCAL_REPOS_ROOT}/${repo}"
+}
+
+deployment_request_without_revision() {
+  local request=$1
+  if [[ "$request" == *@* ]]; then
+    echo "${request%@*}"
+  else
+    echo "$request"
+  fi
+}
+
+deployment_request_name() {
+  local request_without_revision
+  request_without_revision=$(deployment_request_without_revision "$1")
+  if [[ "$request_without_revision" == *=* ]]; then
+    echo "${request_without_revision%%=*}"
+  else
+    echo "$request_without_revision"
+  fi
+}
+
+deployment_request_source_override() {
+  local request_without_revision
+  request_without_revision=$(deployment_request_without_revision "$1")
+  if [[ "$request_without_revision" == *=* ]]; then
+    echo "${request_without_revision#*=}"
+  fi
+}
+
+deployment_request_expected_revision() {
+  local request=$1
+  if [[ "$request" == *@* ]]; then
+    echo "${request##*@}"
+  fi
+}
+
+request_matches_service() {
+  local service_name=$1 req
+  for req in ${requested[@]+"${requested[@]}"}; do
+    if [[ "$(deployment_request_name "$req")" == "$service_name" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+expected_revision_for_service() {
+  local service_name=$1 req
+  for req in ${requested[@]+"${requested[@]}"}; do
+    if [[ "$(deployment_request_name "$req")" == "$service_name" ]]; then
+      deployment_request_expected_revision "$req"
+      return
+    fi
+  done
+}
+
+preflight_deploy_sources() {
+  local req req_name expected_revision entry name repo deploy_mode local_path known duplicate seen_names=""
+
+  if [[ ${#requested[@]} -eq 0 ]]; then
+    echo "ERROR: deploy requires at least one service bound to an explicit full commit SHA" >&2
+    echo "Usage: ./scripts/deploy.sh service[=/absolute/worktree]@FULL_COMMIT_SHA [...]" >&2
+    return 1
+  fi
+
+  for req in ${requested[@]+"${requested[@]}"}; do
+    req_name=$(deployment_request_name "$req")
+    expected_revision=$(deployment_request_expected_revision "$req")
+    if [[ -z "$req_name" ]] || ! is_full_commit_sha "$expected_revision"; then
+      echo "ERROR: deploy source requires an explicit full commit SHA: $req" >&2
+      echo "Usage: ./scripts/deploy.sh service[=/absolute/worktree]@FULL_COMMIT_SHA [...]" >&2
+      return 1
+    fi
+
+    known=false
+    for entry in "${SERVICES[@]}"; do
+      name=$(service_field "$entry" name)
+      if [[ "$name" == "$req_name" ]]; then
+        known=true
+        break
+      fi
+    done
+    if [[ "$known" != "true" ]]; then
+      echo "ERROR: unknown deployable service in request: $req_name" >&2
+      return 1
+    fi
+
+    duplicate=false
+    case " $seen_names " in
+      *" $req_name "*) duplicate=true ;;
+    esac
+    if [[ "$duplicate" == "true" ]]; then
+      echo "ERROR: duplicate deployment source request: $req_name" >&2
+      return 1
+    fi
+    seen_names="${seen_names} ${req_name}"
+  done
+
+  # Validate the entire invocation before the first selected component can
+  # build, invalidate a remote marker, sync, pull, or restart.
+  for entry in "${SERVICES[@]}"; do
+    name=$(service_field "$entry" name)
+    request_matches_service "$name" || continue
+    repo=$(service_field "$entry" repo)
+    deploy_mode=$(service_field "$entry" deploy_mode)
+    local_path=$(resolve_local_path "$name" "$repo")
+    expected_revision=$(expected_revision_for_service "$name")
+    if ! verify_deploy_source_revision "$local_path" "$expected_revision" true; then
+      echo "ERROR: refusing deployment before any component mutation" >&2
+      return 1
+    fi
+    if [[ "${deploy_mode:-rsync}" == "git-pull" ]] &&
+       ! verify_expected_remote_revision \
+         "$local_path" origin refs/heads/main "$expected_revision" true; then
+      echo "ERROR: refusing git-pull deployment before marker invalidation" >&2
+      return 1
+    fi
+  done
 }
 
 unit_rows() {
@@ -248,6 +372,7 @@ deploy_service() {
   local name=$1 repo=$2 host=$3 deploy_path=$4 unit_type=$5 needs_build=$6 unit_scope=${7:-system} deploy_mode=${8:-rsync} units_json=${9:-[]}
   local rsync_excludes_json=${10:-[]} health_port=${11:-}
   local persistent_paths_json=${12:-[]} systemd_runtime_json=${13:-null} health_check_json=${14:-null}
+  local expected_revision=${15:-}
   local local_path
   local remote_host
   local remote
@@ -274,16 +399,9 @@ deploy_service() {
 
   local_path=$(resolve_local_path "$name" "$repo")
 
-  if [[ ! -d "$local_path" ]]; then
-    echo "ERROR: Local repo not found: $local_path" >&2
-    echo -e "${RED}FAILED${NC}"
-    results+=("${RED}✗${NC} ${name}")
-    fail=$((fail + 1))
-    return
-  fi
-
-  if ! git -C "$local_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    echo "ERROR: Local source is not a git worktree: $local_path" >&2
+  # Re-check at the per-component boundary to narrow the gap between the
+  # invocation-wide preflight and any local build or remote mutation.
+  if ! verify_deploy_source_revision "$local_path" "$expected_revision"; then
     results+=("${RED}✗${NC} ${name}")
     fail=$((fail + 1))
     return
@@ -295,6 +413,12 @@ deploy_service() {
     # git-pull mode ships origin/main on the remote — the local tree is not
     # the source, so its branch/dirtiness is informational only.
     echo "Source: origin/main (deploy_mode=git-pull — local tree not shipped; local: ${branch} @ ${commit})"
+    if ! verify_expected_remote_revision \
+        "$local_path" origin refs/heads/main "$expected_revision"; then
+      results+=("${RED}✗${NC} ${name}")
+      fail=$((fail + 1))
+      return
+    fi
   else
     if [[ -n "$(git -C "$local_path" status --porcelain 2>/dev/null)" ]]; then
       echo "ERROR: Refusing rsync deploy from a dirty working tree: $local_path" >&2
@@ -356,10 +480,11 @@ deploy_service() {
     # fail the deploy loudly instead.
     local pull_cmd
     pull_cmd="git -C ${q_deploy_path} fetch --quiet origin && "
+    pull_cmd+="if [ \"\$(git -C ${q_deploy_path} rev-parse origin/main)\" != $(posix_shell_quote "$expected_revision") ]; then echo 'ERROR: origin/main != expected deployment revision after fetch' >&2; exit 1; fi && "
     pull_cmd+="git -C ${q_deploy_path} checkout --quiet main && "
     pull_cmd+="git -C ${q_deploy_path} pull --ff-only --quiet origin main && "
     pull_cmd+="if [ -n \"\$(git -C ${q_deploy_path} status --porcelain)\" ]; then echo 'ERROR: checkout dirty after pull' >&2; exit 1; fi && "
-    pull_cmd+="if [ \"\$(git -C ${q_deploy_path} rev-parse HEAD)\" != \"\$(git -C ${q_deploy_path} rev-parse origin/main)\" ]; then echo 'ERROR: HEAD != origin/main after pull (stray local commits?)' >&2; exit 1; fi"
+    pull_cmd+="if [ \"\$(git -C ${q_deploy_path} rev-parse HEAD)\" != $(posix_shell_quote "$expected_revision") ]; then echo 'ERROR: HEAD != expected deployment revision after pull' >&2; exit 1; fi"
     # shellcheck disable=SC2029 # deploy_path is a local var; intentional client-side expansion
     if ! ssh -o ConnectTimeout=10 "$remote" "$pull_cmd"; then
       report_markerless_failure
@@ -640,8 +765,12 @@ deploy_service() {
   fi
 }
 
-# Filter to requested services, or deploy all
+# Validate and deploy only the explicitly revision-bound requests.
 requested=("$@")
+
+if ! preflight_deploy_sources; then
+  exit 1
+fi
 
 for entry in "${SERVICES[@]}"; do
   name=$(service_field "$entry" name)
@@ -659,15 +788,10 @@ for entry in "${SERVICES[@]}"; do
   systemd_runtime_json=$(service_field "$entry" systemd_runtime)
   health_check_json=$(service_field "$entry" health_check)
 
-  if [[ ${#requested[@]} -gt 0 ]]; then
-    match=false
-    for req in ${requested[@]+"${requested[@]}"}; do
-      [[ "$req" == "$name" || "$req" == "${name}="* ]] && match=true && break
-    done
-    $match || continue
-  fi
+  request_matches_service "$name" || continue
 
-  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}" "${health_port:-}" "${persistent_paths_json:-[]}" "${systemd_runtime_json:-null}" "${health_check_json:-null}"
+  expected_revision=$(expected_revision_for_service "$name")
+  deploy_service "$name" "$repo" "$host" "$deploy_path" "$unit_type" "$needs_build" "${unit_scope:-system}" "${deploy_mode:-rsync}" "${units_json:-[]}" "${rsync_excludes_json:-[]}" "${health_port:-}" "${persistent_paths_json:-[]}" "${systemd_runtime_json:-null}" "${health_check_json:-null}" "$expected_revision"
 done
 
 # Summary

--- a/scripts/guarded-deploy.sh
+++ b/scripts/guarded-deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Execute any owning-repository deploy entry point only from the explicitly
+# expected Git worktree and immutable revision.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/deploy-source.sh
+source "$SCRIPT_DIR/lib/deploy-source.sh"
+
+if [[ $# -lt 4 || "$3" != "--" ]]; then
+  echo "ERROR: usage: guarded-deploy.sh EXPECTED_SOURCE FULL_COMMIT_SHA -- COMMAND [ARG ...]" >&2
+  exit 2
+fi
+
+expected_source=$1
+expected_revision=$2
+shift 3
+
+verify_deploy_source_identity "$expected_source" "$expected_revision" "$PWD"
+exec "$@"

--- a/scripts/lib/deploy-source.sh
+++ b/scripts/lib/deploy-source.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Reusable local deployment-source identity guard.
+
+is_full_commit_sha() {
+  local revision=${1:-}
+  [[ "$revision" =~ ^[0-9a-f]{40}([0-9a-f]{24})?$ ]]
+}
+
+verify_deploy_source_identity() {
+  local requested_source=${1:-} expected_revision=${2:-}
+  local invocation_source=${3:-$PWD} quiet_success=${4:-false}
+  local expected_source invocation_path actual_source actual_revision mismatch=false
+
+  if ! is_full_commit_sha "$expected_revision"; then
+    echo "ERROR: deploy source requires an explicit full commit SHA (40 or 64 lowercase hex characters)" >&2
+    return 1
+  fi
+
+  if ! expected_source=$(cd "$requested_source" 2>/dev/null && pwd -P); then
+    echo "Expected source: $requested_source @ $expected_revision"
+    echo "Actual source: unresolved @ unknown"
+    echo "ERROR: deployment source directory does not exist or is not accessible" >&2
+    return 1
+  fi
+
+  if ! invocation_path=$(cd "$invocation_source" 2>/dev/null && pwd -P); then
+    echo "Expected source: $expected_source @ $expected_revision"
+    echo "Actual source: unresolved @ unknown"
+    echo "ERROR: deployment invocation directory does not exist or is not accessible" >&2
+    return 1
+  fi
+
+  if ! actual_source=$(git -C "$invocation_path" rev-parse --show-toplevel 2>/dev/null); then
+    echo "Expected source: $expected_source @ $expected_revision"
+    echo "Actual source: $invocation_path @ not-a-git-worktree"
+    echo "ERROR: deployment invocation source is not a git worktree" >&2
+    return 1
+  fi
+  if ! actual_source=$(cd "$actual_source" 2>/dev/null && pwd -P); then
+    echo "Expected source: $expected_source @ $expected_revision"
+    echo "Actual source: unresolved-git-root @ unknown"
+    echo "ERROR: deployment source Git root cannot be resolved" >&2
+    return 1
+  fi
+  actual_revision=$(git -C "$actual_source" rev-parse --verify HEAD 2>/dev/null || echo unknown)
+
+  [[ "$expected_source" == "$invocation_path" ]] || mismatch=true
+  [[ "$invocation_path" == "$actual_source" ]] || mismatch=true
+  [[ "$expected_revision" == "$actual_revision" ]] || mismatch=true
+
+  if [[ "$quiet_success" != "true" || "$mismatch" == "true" ]]; then
+    echo "Expected source: $expected_source @ $expected_revision"
+    echo "Actual source: $actual_source @ $actual_revision"
+  fi
+
+  if [[ "$expected_source" != "$invocation_path" ]]; then
+    echo "ERROR: deployment command ran from a different directory than the expected source" >&2
+    return 1
+  fi
+  if [[ "$invocation_path" != "$actual_source" ]]; then
+    echo "ERROR: deployment invocation directory is not the resolved Git worktree root" >&2
+    return 1
+  fi
+  if [[ "$expected_revision" != "$actual_revision" ]]; then
+    echo "ERROR: deployment source revision does not match the orchestrator's expected revision" >&2
+    return 1
+  fi
+}
+
+verify_deploy_source_revision() {
+  local requested_source=${1:-} expected_revision=${2:-} quiet_success=${3:-false}
+  verify_deploy_source_identity \
+    "$requested_source" "$expected_revision" "$requested_source" "$quiet_success"
+}
+
+verify_expected_remote_revision() {
+  local source=${1:-} remote=${2:-origin} ref=${3:-refs/heads/main}
+  local expected_revision=${4:-} quiet_success=${5:-false}
+  local actual_revision output
+
+  if ! is_full_commit_sha "$expected_revision"; then
+    echo "ERROR: remote source check requires an explicit full commit SHA" >&2
+    return 1
+  fi
+  if ! output=$(git -C "$source" ls-remote --exit-code "$remote" "$ref" 2>/dev/null); then
+    echo "Expected remote source: $remote/$ref @ $expected_revision"
+    echo "Actual remote source: unresolved @ unknown"
+    echo "ERROR: expected deployment revision could not be resolved from the source remote" >&2
+    return 1
+  fi
+  actual_revision=${output%%[[:space:]]*}
+  if [[ "$quiet_success" != "true" || "$actual_revision" != "$expected_revision" ]]; then
+    echo "Expected remote source: $remote/$ref @ $expected_revision"
+    echo "Actual remote source: $remote/$ref @ $actual_revision"
+  fi
+  if [[ "$actual_revision" != "$expected_revision" ]]; then
+    echo "ERROR: remote source revision does not match the orchestrator's expected revision" >&2
+    return 1
+  fi
+}

--- a/scripts/tests/deploy-persistent-paths.test.sh
+++ b/scripts/tests/deploy-persistent-paths.test.sh
@@ -266,9 +266,23 @@ commit_fixture_repo() {
 
 assert_rejected_before_remote() {
   local desc=$1 fixture=$2 expected_error=${3:-}
+  local fixture_name fixture_repo fixture_source fixture_revision fixture_request
+  fixture_name=$(REGISTRY_PATH="$fixture" node -e '
+    var data = require(process.env.REGISTRY_PATH);
+    process.stdout.write(String(data.components[0].name));
+  ')
+  fixture_repo=$(REGISTRY_PATH="$fixture" node -e '
+    var data = require(process.env.REGISTRY_PATH);
+    process.stdout.write(String(data.components[0].repo));
+  ')
+  fixture_source="$TMP_DIR/repos/$fixture_repo"
+  fixture_revision=$(git -C "$fixture_source" rev-parse HEAD 2>/dev/null ||
+    printf '%040d' 0)
+  fixture_request="${fixture_name}=${fixture_source}@${fixture_revision}"
   rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$BUILD_CAPTURE"
   if REGISTRY_PATH="$fixture" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
-      PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/rejected.out" 2>&1; then
+      PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "$fixture_request" \
+        >"$TMP_DIR/rejected.out" 2>&1; then
     fail "$desc: deploy must fail"
   else
     pass "$desc: deploy fails"
@@ -514,11 +528,14 @@ cat > "$TMP_DIR/repos/alpha/alpha-recurring.service" << 'EOF'
 ExecStart=/bin/true
 EOF
 commit_fixture_repo "$TMP_DIR/repos/alpha"
+ALPHA_SHA=$(git -C "$TMP_DIR/repos/alpha" rev-parse HEAD)
+ALPHA_REQUEST="alpha=$TMP_DIR/repos/alpha@$ALPHA_SHA"
 
 rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
 printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
 if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
-    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/safe.out" 2>&1; then
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "$ALPHA_REQUEST" \
+      >"$TMP_DIR/safe.out" 2>&1; then
   pass "safe registry completes mocked deploy"
 else
   fail "safe registry completes mocked deploy"
@@ -660,7 +677,8 @@ assert_markerless_failure() {
   rc=0
   SSH_FAIL_MODE="$ssh_fail" RSYNC_FAIL_MODE="$rsync_fail" \
     REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
-    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/failure.out" 2>&1 || rc=$?
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "$ALPHA_REQUEST" \
+      >"$TMP_DIR/failure.out" 2>&1 || rc=$?
   if [[ "$rc" == 1 && ! -e "$REMOTE_MARKER_STATE" ]] &&
      grep -Fq "markerless/unknown" "$TMP_DIR/failure.out"; then
     pass "$desc leaves the deployment markerless"
@@ -679,7 +697,7 @@ printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
 rc=0
 SSH_FAIL_MODE=invalidate REGISTRY_PATH="$TMP_DIR/safe.json" \
   LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
-  bash "$DEPLOY" alpha >"$TMP_DIR/invalidation-fail.out" 2>&1 || rc=$?
+  bash "$DEPLOY" "$ALPHA_REQUEST" >"$TMP_DIR/invalidation-fail.out" 2>&1 || rc=$?
 if [[ "$rc" == 1 && ! -e "$RSYNC_CAPTURE" ]] &&
    [[ "$(tr '\n' ' ' < "$ORDER_CAPTURE")" == "invalidate " ]]; then
   pass "uncertain marker invalidation stops before code mutation"
@@ -691,7 +709,8 @@ fi
 echo stray > "$TMP_DIR/repos/alpha/untracked.txt"
 rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
 if REGISTRY_PATH="$TMP_DIR/safe.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
-    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/dirty.out" 2>&1; then
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "$ALPHA_REQUEST" \
+      >"$TMP_DIR/dirty.out" 2>&1; then
   fail "dirty source must fail"
 else
   pass "dirty source fails"
@@ -716,9 +735,13 @@ cat > "$TMP_DIR/git-pull.json" << 'EOF'
 }
 EOF
 rm -f "$TMP_DIR/repos/alpha/untracked.txt" "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+git init -q --bare "$TMP_DIR/alpha-origin.git"
+git -C "$TMP_DIR/repos/alpha" remote add origin "$TMP_DIR/alpha-origin.git"
+git -C "$TMP_DIR/repos/alpha" push -q -u origin main
 printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
 if REGISTRY_PATH="$TMP_DIR/git-pull.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
-    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" alpha >"$TMP_DIR/git-pull.out" 2>&1; then
+    PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "$ALPHA_REQUEST" \
+      >"$TMP_DIR/git-pull.out" 2>&1; then
   pass "git-pull deployment completes with mocked remote"
 else
   fail "git-pull deployment completes with mocked remote"
@@ -755,12 +778,43 @@ printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
 rc=0
 SSH_FAIL_MODE=pull REGISTRY_PATH="$TMP_DIR/git-pull.json" \
   LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
-  bash "$DEPLOY" alpha >"$TMP_DIR/pull-fail.out" 2>&1 || rc=$?
+  bash "$DEPLOY" "$ALPHA_REQUEST" >"$TMP_DIR/pull-fail.out" 2>&1 || rc=$?
 if [[ "$rc" == 1 && ! -e "$REMOTE_MARKER_STATE" ]] &&
    grep -Fq "markerless/unknown" "$TMP_DIR/pull-fail.out"; then
   pass "failed git pull leaves the deployment markerless"
 else
   fail "failed git pull must leave the deployment markerless"
+fi
+
+# The source remote is read before accepted-marker invalidation. If main has
+# advanced past the explicitly expected revision, fail with the marker intact
+# and make no SSH deployment call.
+git clone -q -b main "$TMP_DIR/alpha-origin.git" "$TMP_DIR/origin-updater"
+printf '%s\n' advanced > "$TMP_DIR/origin-updater/advanced.txt"
+git -C "$TMP_DIR/origin-updater" add advanced.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/origin-updater" commit -q -m advanced
+git -C "$TMP_DIR/origin-updater" push -q origin main
+ADVANCED_SHA=$(git -C "$TMP_DIR/origin-updater" rev-parse HEAD)
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE" "$ORDER_CAPTURE"
+printf '%s\n' "$PRIOR_SHA" > "$REMOTE_MARKER_STATE"
+rc=0
+REGISTRY_PATH="$TMP_DIR/git-pull.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+  PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "$ALPHA_REQUEST" \
+  >"$TMP_DIR/upstream-mismatch.out" 2>&1 || rc=$?
+if [[ "$rc" == 1 && "$(cat "$REMOTE_MARKER_STATE")" == "$PRIOR_SHA" ]] &&
+   [[ ! -e "$SSH_CAPTURE" && ! -e "$RSYNC_CAPTURE" ]]; then
+  pass "git-pull upstream mismatch fails before marker invalidation or pull"
+else
+  fail "git-pull upstream mismatch must fail before marker invalidation or pull"
+fi
+if grep -Fq "Expected remote source: origin/refs/heads/main @ $ALPHA_SHA" \
+    "$TMP_DIR/upstream-mismatch.out" &&
+   grep -Fq "Actual remote source: origin/refs/heads/main @ $ADVANCED_SHA" \
+    "$TMP_DIR/upstream-mismatch.out"; then
+  pass "git-pull upstream mismatch reports expected and actual revisions"
+else
+  fail "git-pull upstream mismatch must report expected and actual revisions"
 fi
 
 echo ""

--- a/scripts/tests/deploy-source-revision.test.sh
+++ b/scripts/tests/deploy-source-revision.test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Proves every centrally orchestrated deploy is bound to an explicit immutable
+# source commit before any build or remote mutation.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY="$SCRIPT_DIR/../deploy.sh"
+GUARDED_DEPLOY="$SCRIPT_DIR/../guarded-deploy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_no_mutation() {
+  local desc=$1
+  if [[ -e "$MUTATION_CAPTURE" ]]; then
+    fail "$desc: must not invoke build, ssh, or rsync"
+  else
+    pass "$desc: invokes neither build, ssh, nor rsync"
+  fi
+}
+
+run_rejected() {
+  local desc=$1 output=$2
+  shift 2
+  rm -f "$MUTATION_CAPTURE"
+  if REGISTRY_PATH="$REGISTRY" PATH="$TMP_DIR/bin:$PATH" \
+      bash "$DEPLOY" "$@" >"$output" 2>&1; then
+    fail "$desc: deploy must fail"
+  else
+    pass "$desc: deploy fails"
+  fi
+  assert_no_mutation "$desc"
+}
+
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/source/systemd" "$TMP_DIR/source/subdir"
+
+cat > "$TMP_DIR/bin/ssh" <<'EOF'
+#!/usr/bin/env bash
+printf 'ssh:%s\n' "$*" >> "$MUTATION_CAPTURE"
+command=${*: -1}
+if [[ "$command" == *"DEPLOY_MARKER_INVALIDATED"* ]]; then
+  printf '%s\n' DEPLOY_MARKER_INVALIDATED:unknown
+elif [[ "$command" == *"DEPLOY_OK"* ]]; then
+  printf '%s\n' DEPLOY_OK
+fi
+EOF
+
+cat > "$TMP_DIR/bin/rsync" <<'EOF'
+#!/usr/bin/env bash
+printf 'rsync:%s\n' "$*" >> "$MUTATION_CAPTURE"
+EOF
+
+cat > "$TMP_DIR/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+printf 'npm:%s\n' "$*" >> "$MUTATION_CAPTURE"
+EOF
+
+cat > "$TMP_DIR/bin/local-deploy" <<'EOF'
+#!/usr/bin/env bash
+printf 'local-deploy:%s\n' "$*" >> "$GUARDED_CAPTURE"
+EOF
+
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/npm" \
+  "$TMP_DIR/bin/local-deploy"
+MUTATION_CAPTURE="$TMP_DIR/mutations"
+GUARDED_CAPTURE="$TMP_DIR/guarded-command"
+export MUTATION_CAPTURE GUARDED_CAPTURE
+
+cat > "$TMP_DIR/source/systemd/alpha.service" <<'EOF'
+[Service]
+ExecStart=/bin/true
+EOF
+cat > "$TMP_DIR/source/systemd/beta.service" <<'EOF'
+[Service]
+ExecStart=/bin/true
+EOF
+printf '%s\n' '{"name":"source"}' > "$TMP_DIR/source/package.json"
+printf '%s\n' keep > "$TMP_DIR/source/subdir/keep.txt"
+
+git init -q -b main "$TMP_DIR/source"
+git -C "$TMP_DIR/source" add .
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/source" commit -q -m stale
+STALE_SHA=$(git -C "$TMP_DIR/source" rev-parse HEAD)
+
+printf '%s\n' current > "$TMP_DIR/source/current.txt"
+git -C "$TMP_DIR/source" add current.txt
+GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+  git -C "$TMP_DIR/source" commit -q -m current
+EXPECTED_SHA=$(git -C "$TMP_DIR/source" rev-parse HEAD)
+
+CORRECT_WORKTREE="$TMP_DIR/correct-detached"
+STALE_WORKTREE="$TMP_DIR/stale-detached"
+git -C "$TMP_DIR/source" worktree add -q --detach "$CORRECT_WORKTREE" "$EXPECTED_SHA"
+git -C "$TMP_DIR/source" worktree add -q --detach "$STALE_WORKTREE" "$STALE_SHA"
+CORRECT_WORKTREE=$(cd "$CORRECT_WORKTREE" && pwd -P)
+STALE_WORKTREE=$(cd "$STALE_WORKTREE" && pwd -P)
+
+if git -C "$CORRECT_WORKTREE" symbolic-ref -q HEAD >/dev/null; then
+  fail "correct fixture must be a detached worktree"
+else
+  pass "correct fixture is a detached worktree"
+fi
+if [[ -x "$GUARDED_DEPLOY" ]]; then
+  pass "generic deploy guard is executable"
+else
+  fail "generic deploy guard must be executable"
+fi
+
+# The generic wrapper is the orchestration path for owning-repository deploy
+# commands outside services.json's centrally deployable component set.
+rm -f "$GUARDED_CAPTURE"
+if (
+  cd "$STALE_WORKTREE"
+  PATH="$TMP_DIR/bin:$PATH" "$GUARDED_DEPLOY" \
+    "$CORRECT_WORKTREE" "$EXPECTED_SHA" -- local-deploy wrong-cwd
+) >"$TMP_DIR/guard-wrong-cwd.out" 2>&1; then
+  fail "generic guard must reject a deploy command run from the wrong cwd"
+else
+  pass "generic guard rejects a deploy command run from the wrong cwd"
+fi
+if [[ ! -e "$GUARDED_CAPTURE" ]] &&
+   grep -Fq "Expected source: $CORRECT_WORKTREE @ $EXPECTED_SHA" \
+    "$TMP_DIR/guard-wrong-cwd.out" &&
+   grep -Fq "Actual source: $STALE_WORKTREE @ $STALE_SHA" \
+    "$TMP_DIR/guard-wrong-cwd.out"; then
+  pass "generic wrong-cwd failure precedes command execution with diagnostics"
+else
+  fail "generic wrong-cwd failure must precede command execution with diagnostics"
+fi
+
+rm -f "$GUARDED_CAPTURE"
+if (
+  cd "$STALE_WORKTREE"
+  PATH="$TMP_DIR/bin:$PATH" "$GUARDED_DEPLOY" \
+    "$STALE_WORKTREE" "$EXPECTED_SHA" -- local-deploy stale
+) >"$TMP_DIR/guard-stale.out" 2>&1; then
+  fail "generic guard must reject a stale clean checkout"
+else
+  pass "generic guard rejects a stale clean checkout"
+fi
+if [[ ! -e "$GUARDED_CAPTURE" ]] &&
+   grep -Fq "Actual source: $STALE_WORKTREE @ $STALE_SHA" \
+    "$TMP_DIR/guard-stale.out"; then
+  pass "generic stale-checkout failure precedes command execution"
+else
+  fail "generic stale-checkout failure must precede command execution"
+fi
+
+rm -f "$GUARDED_CAPTURE"
+if (
+  cd "$CORRECT_WORKTREE"
+  PATH="$TMP_DIR/bin:$PATH" "$GUARDED_DEPLOY" \
+    "$CORRECT_WORKTREE" "$EXPECTED_SHA" -- local-deploy detached
+) >"$TMP_DIR/guard-correct.out" 2>&1; then
+  pass "generic guard executes from the correct detached worktree"
+else
+  fail "generic guard must execute from the correct detached worktree"
+fi
+if grep -Fxq "local-deploy:detached" "$GUARDED_CAPTURE"; then
+  pass "generic guard reaches the owning-repository deploy entry point"
+else
+  fail "generic guard must reach the owning-repository deploy entry point"
+fi
+
+REGISTRY="$TMP_DIR/services.json"
+cat > "$REGISTRY" <<'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "source", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    },
+    {
+      "name": "beta", "repo": "source", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/beta",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "beta", "type": "service" }]
+    }
+  ]
+}
+EOF
+
+run_rejected "no-argument deploy" "$TMP_DIR/no-arguments.out"
+if grep -Fq "requires at least one service bound to an explicit full commit SHA" \
+    "$TMP_DIR/no-arguments.out"; then
+  pass "no-argument deploy reports the bound-source requirement"
+else
+  fail "no-argument deploy must report the bound-source requirement"
+fi
+
+run_rejected "missing expected revision" "$TMP_DIR/missing.out" \
+  "alpha=$CORRECT_WORKTREE"
+if grep -Fq "requires an explicit full commit SHA" "$TMP_DIR/missing.out"; then
+  pass "missing revision reports the immutable revision requirement"
+else
+  fail "missing revision must report the immutable revision requirement"
+fi
+
+run_rejected "wrong directory" "$TMP_DIR/wrong-directory.out" \
+  "alpha=$CORRECT_WORKTREE/subdir@$EXPECTED_SHA"
+if grep -Fq "Expected source: $CORRECT_WORKTREE/subdir @ $EXPECTED_SHA" \
+    "$TMP_DIR/wrong-directory.out" &&
+   grep -Fq "Actual source: $CORRECT_WORKTREE @ $EXPECTED_SHA" \
+    "$TMP_DIR/wrong-directory.out"; then
+  pass "wrong directory reports expected and actual source identity"
+else
+  fail "wrong directory must report expected and actual source identity"
+fi
+
+run_rejected "stale clean checkout" "$TMP_DIR/stale.out" \
+  "alpha=$STALE_WORKTREE@$EXPECTED_SHA"
+if [[ -z "$(git -C "$STALE_WORKTREE" status --porcelain)" ]] &&
+   grep -Fq "Expected source: $STALE_WORKTREE @ $EXPECTED_SHA" "$TMP_DIR/stale.out" &&
+   grep -Fq "Actual source: $STALE_WORKTREE @ $STALE_SHA" "$TMP_DIR/stale.out"; then
+  pass "stale clean checkout reports expected and actual revisions"
+else
+  fail "stale clean checkout must fail with expected/actual diagnostics"
+fi
+
+# All selected sources must pass before the first service mutates anything.
+run_rejected "multi-service source preflight" "$TMP_DIR/multi.out" \
+  "alpha=$CORRECT_WORKTREE@$EXPECTED_SHA" \
+  "beta=$STALE_WORKTREE@$EXPECTED_SHA"
+
+rm -f "$MUTATION_CAPTURE"
+if REGISTRY_PATH="$REGISTRY" PATH="$TMP_DIR/bin:$PATH" \
+    bash "$DEPLOY" "alpha=$CORRECT_WORKTREE@$EXPECTED_SHA" \
+      >"$TMP_DIR/correct.out" 2>&1; then
+  pass "correct detached worktree completes mocked deploy"
+else
+  fail "correct detached worktree must complete mocked deploy"
+  sed -n '1,160p' "$TMP_DIR/correct.out"
+fi
+if grep -Fq "Expected source: $CORRECT_WORKTREE @ $EXPECTED_SHA" \
+    "$TMP_DIR/correct.out" &&
+   grep -Fq "Actual source: $CORRECT_WORKTREE @ $EXPECTED_SHA" \
+    "$TMP_DIR/correct.out"; then
+  pass "correct detached worktree reports bound source identity"
+else
+  fail "correct detached worktree must report bound source identity"
+fi
+if grep -Fq "ssh:" "$MUTATION_CAPTURE" &&
+   grep -Fq "rsync:" "$MUTATION_CAPTURE"; then
+  pass "correct detached worktree reaches mocked remote mutation"
+else
+  fail "correct detached worktree must reach mocked remote mutation"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/tests/deploy-systemd-render.test.sh
+++ b/scripts/tests/deploy-systemd-render.test.sh
@@ -355,6 +355,8 @@ git init -q -b main "$REPO"
 git -C "$REPO" add .
 GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
   git -C "$REPO" commit -q -m seed
+REPO_SHA=$(git -C "$REPO" rev-parse HEAD)
+ALPHA_REQUEST="alpha=$REPO@$REPO_SHA"
 
 registry="$TMP_DIR/services.json"
 RUNTIME_HOME="$RUNTIME_HOME" PRIVATE_ENV="$PRIVATE_ENV" SANDBOX_PATH="$SANDBOX_PATH" \
@@ -438,7 +440,7 @@ chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/curl"
 
 rc=0
 SSH_SYSTEMD_VERIFY_FAIL=true REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
-  bash "$DEPLOY" alpha >"$TMP_DIR/deploy.out" 2>&1 || rc=$?
+  bash "$DEPLOY" "$ALPHA_REQUEST" >"$TMP_DIR/deploy.out" 2>&1 || rc=$?
 if [[ "$rc" == 1 ]]; then
   pass "systemd verification failure fails deployment"
 else
@@ -473,7 +475,7 @@ NODE
 rm -f "$ORDER_CAPTURE" "$SSH_CAPTURE" "$REMOTE_MARKER_STATE"
 printf '%040d\n' 2 > "$REMOTE_MARKER_STATE"
 if REGISTRY_PATH="$registry" LOCAL_REPOS_ROOT="$TMP_DIR/repos" PATH="$TMP_DIR/bin:$PATH" \
-    bash "$DEPLOY" alpha >"$TMP_DIR/deploy-success.out" 2>&1; then
+    bash "$DEPLOY" "$ALPHA_REQUEST" >"$TMP_DIR/deploy-success.out" 2>&1; then
   pass "rendered deployment passes network-boundary health"
 else
   fail "rendered deployment must pass network-boundary health"


### PR DESCRIPTION
## What changed

- require every centralized deploy request to bind a component checkout to a full immutable commit SHA (`service[=/worktree]@FULL_SHA`)
- preflight the complete request set before any build, marker invalidation, rsync, pull, or restart
- add a reusable `scripts/guarded-deploy.sh` boundary for owning-repository deploy commands outside the centrally deployable service set
- resolve git-pull `origin/main` read-only before marker invalidation and repeat the equality check after remote fetch
- preserve the existing dirty-tree, unit-source, rendering, marker, restart, and health gates
- document the new canonical deployment contracts and fail-closed no-argument behavior

## Why

A clean checkout can still be the wrong worktree or a stale revision. During the stabilization sweep, deployment commands could run from a valid but unintended checkout because source identity was not bound to the revision selected by the orchestrator.

This change makes the expected path and revision explicit, reports expected/actual identity, and prevents the wrapped or centralized deploy command from reaching mutation when they differ.

Direct owning-repository adoption is routed to [gille-inference#69](https://github.com/Magnus-Gille/gille-inference/issues/69) and [brokkr#24](https://github.com/Magnus-Gille/brokkr/issues/24).

## Validation

- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `bash -n` on all changed shell scripts
- source-binding regressions: 25 passed
- deploy persistence/safety regressions: 85 passed
- systemd rendering regressions: 39 passed
- `git diff --check`
- GitHub Actions: `test` and `shellcheck` green

Independent review: Codex Terra, high effort, reviewed exact commit `cb1c2a1` and found no actionable issues. It reran the three focused suites on macOS Bash 3.2.57. Residual risk: `origin/main` can advance after the read-only precheck and before remote fetch; the post-fetch equality check prevents deployment of the wrong revision but deliberately leaves the accepted marker absent if that race occurs.

## M5 evidence

M5 bounded classification used `mellum`, ledger `5d48866b-743a-425b-bfb0-144d75549a2a`. It selected the per-service immutable CLI contract. Usefulness: **partial** — that choice was useful for multi-service binding, but the model missed that both observed incident paths were outside the centrally deployable set. Root review required the generic guarded-command wrapper; all M5 claims used here were independently verified.

Closes #114