### PR TITLE
Close ecosystem stabilization sweep status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -5,18 +5,22 @@
 
 ## The headline
 
-Eleven stability PRs across Grimnir, Gille Inference, Brokkr, Heimdall, and Mimir are merged,
+Thirteen stability PRs across Grimnir, Gille Inference, Brokkr, Heimdall, and Mimir are merged,
 deployed, and live-verified. The sweep focused on explicit runtime identity, fail-closed
 deployment boundaries, preserved state, truthful health checks, and visible repository drift.
 Munin Memory implementation was explicitly excluded.
 
 ## Completed this session
 
-- Gille Inference PRs #67/#68: preserve the approved cache while rejecting unknown deploy
-  residue; reject truncated judge output before verification. M5 gateway is active on the exact
-  accepted revision, with its timer, hook, health endpoint, and cache verified.
-- Brokkr PRs #21/#23: explicit NAS runtime/deploy identity and truthful environment-state
-  handling. NAS timers are active, push health is 200, and no units are failed.
+- Gille Inference PRs #67/#68/#70: preserve the approved cache while rejecting unknown deploy
+  residue; reject truncated judge output before verification; bind deploys to the selected
+  physical checkout and immutable revision, then materialize only committed bytes. M5 gateway is
+  active at merge `07185658`, with its exact marker, timer, hook, health/capability endpoints, and
+  cache verified.
+- Brokkr PRs #21/#23/#25: explicit NAS runtime/deploy identity, truthful environment-state
+  handling, and repository-native source/script/revision binding. NAS deploys now exclude ignored
+  live files by materializing the accepted commit, preserve executable bits without leaking source
+  permissions, and enforce release-root mode `0750`. Timers are active and push health is 200.
 - Heimdall PRs #12/#14 and Grimnir PR #110: Node-compatible systemd hardening, rendered runtime
   paths, full-set preflight validation, rollback, and explicit network health authority.
   Maintenance completed successfully and the database quick-check returned `ok`.
@@ -28,15 +32,21 @@ Munin Memory implementation was explicitly excluded.
 - Grimnir PR #117: centralized and arbitrary owning-repository deploy commands now bind the
   physical worktree and immutable expected revision before mutation. Its own production deploy
   passed the new expected/actual source and `origin/main` gates.
-- Follow-ups: #115 safely reconciles origin-authority findings; gille-inference#69 and brokkr#24
-  adopt the same expected-revision requirement directly at their owning-repo entry points.
+- Follow-up #115 safely reconciles origin-authority findings. Gille Inference #69 and Brokkr #24
+  are closed by merged PRs #70 and #25.
 
 ## Important incidents and learnings
 
 - Deployment source identity was not sufficiently bound to the orchestrator's intended revision.
-  The resulting procedure change and durable fix are tracked in high-priority issue #114.
+  The resulting procedure change landed centrally in Grimnir #117 and directly in the Gille and
+  Brokkr entry points. Review also showed that a correct SHA is insufficient if rsync still reads
+  mutable or ignored worktree bytes, so both owning repos now deploy commit snapshots.
 - Release-directory replaceability proved to be an important deployment contract; persistent data
   and protected configuration remained outside that boundary.
+- The first Gille certification run deployed healthy bytes but correctly withheld its marker when
+  the fresh checkout's auth helper lacked machine-local Keychain locators. Re-running through the
+  installed secret-safe helper completed the authenticated probe and exact marker without another
+  restart.
 - An early delegated task crossed the explicit Munin exclusion with a metadata write. No Munin
   code changed, the violation was surfaced, and all later work avoided Munin.
 - M5 was useful for narrow, grounded checks and found one exact portability defect. It was not
@@ -45,12 +55,12 @@ Munin Memory implementation was explicitly excluded.
 
 ## Next steps (priority order)
 
-1. Adopt the source-binding contract directly in Gille Inference #69 and Brokkr #24.
-2. Inspect and reconcile repository origins reported by Grimnir #115, preserving predecessor history.
-3. Schedule the pending M5 kernel reboot and Raspberry Pi firmware updates when active work can
+1. Inspect and reconcile repository origins reported by Grimnir #115, preserving predecessor history.
+2. Schedule the pending M5 kernel reboot and Raspberry Pi firmware updates when active work can
    tolerate interruption.
-4. Watch NAS storage (86% used, 261 GB free) and confirm Time Machine completion from the client.
-5. Finish the separate Gemma4 serving half of Gille Inference #60.
+3. Watch NAS storage (86% used, 249 GB free in the latest snapshot) and confirm Time Machine
+   completion from the client.
+4. Finish the separate Gemma4 serving half of Gille Inference #60.
 
 ## Blockers / owner input
 
@@ -59,10 +69,12 @@ agents and services were active.
 
 ## Verification at close
 
-- All eleven PRs merged with green CI and independent root review; M5 was attempted on every lane.
+- All thirteen PRs merged with green CI and independent root review; M5 was attempted on every lane.
 - Grimnir control Pi: exact checkout/marker equality verified after the status-only closeout;
   validation timer active.
-- Gille/M5: exact accepted marker; system gateway and autonomy timer active; health green.
+- Gille/M5: merge `07185658` equals the accepted marker; system gateway and autonomy timer active;
+  public health and authenticated capability probes green.
 - Heimdall: four runtime units/timers active; manual maintenance successful; database healthy.
-- Brokkr/NAS: maintenance timers active, push health 200, no failed units.
+- Brokkr/NAS: merge `57f59714` deployed from a detached exact checkout; three payload hashes match,
+  release root is `0750`, ignored live files are absent, timers are active, and push health is 200.
 - Mimir: service active, exact marker, health green, no recent reporter errors.


### PR DESCRIPTION
## Summary

- record all thirteen merged stability PRs and their live verification
- close the Gille and Brokkr owning-repo source-binding follow-ups
- capture immutable payload, deployment-auth, NAS mode, and M5 review learnings
- retain the remaining owner-timed maintenance and backlog tails

## Verification

- `make test`
- `git diff --check`

Status-only follow-up to the already reviewed and deployed stabilization work.