### PR TITLE
Fix security scan Munin namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -20,6 +20,9 @@ test-security-delta: ## Unit tests for the scan_escalated/parse_prev_counts help
 
 test-security-completeness: ## Fail closed when npm audit or repository coverage is incomplete
 	@bash scripts/tests/security-scan-completeness.test.sh
+
+test-security-namespace: ## Keep security scan writes in canonical Munin namespaces (issue #98)
+	@bash scripts/tests/security-scan-namespace.test.sh
 
 test-munin-rpc: ## Reject HTTP, JSON-RPC, and MCP tool errors from scheduled writes
 	@bash scripts/tests/munin-rpc.test.sh
@@ -54,7 +57,7 @@ test-runtime-state: ## Desired runtime and deployment-state validation (issue #1
 test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
 	@bash scripts/tests/worktree-hygiene.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -730,7 +730,7 @@ OUTDIR="$SCAN_TMP" SCAN_DATE="$SCAN_DATE" TIMESTAMP="$TIMESTAMP" HOST="$HOSTNAME
 scan_summary_json="$(cat "$SCAN_TMP/_scan_summary_json")"
 
 # Write 1: Full scan summary
-echo "  Writing scan summary to security/scans/${SCAN_DATE}..."
+echo "  Writing scan summary to security/scans (${SCAN_DATE})..."
 summary_content="## Security Scan Summary
 
 Scan date: ${SCAN_DATE}
@@ -757,7 +757,7 @@ Incomplete repositories: ${INCOMPLETE_REPOS:-none}
 ${scan_summary_json}
 \`\`\`"
 
-summary_args="$(NAMESPACE_VAL="security/scans/${SCAN_DATE}" KEY_VAL="summary" \
+summary_args="$(NAMESPACE_VAL="security/scans" KEY_VAL="${SCAN_DATE}" \
   CONTENT_VAL="$summary_content" node --input-type=commonjs -e '
     console.log(JSON.stringify({
       namespace: process.env.NAMESPACE_VAL,
@@ -823,7 +823,7 @@ done
 # Write 3: Scan event log
 echo "  Logging scan event..."
 log_content="Security scan completed at ${TIMESTAMP} on ${HOSTNAME_VAL}. Overall:${OVERALL_STATUS}; findings:${FINDING_STATUS}; complete:${SCAN_COMPLETE}; incomplete_repos:${INCOMPLETE_REPOS:-none}. Totals — critical:${TOTAL_CRITICAL} high:${TOTAL_HIGH} moderate:${TOTAL_MODERATE} low:${TOTAL_LOW} secrets:${TOTAL_SECRETS}. Scanner v${SCANNER_VERSION}."
-log_args="$(NAMESPACE_VAL="security/" CONTENT_VAL="$log_content" node --input-type=commonjs -e '
+log_args="$(NAMESPACE_VAL="security" CONTENT_VAL="$log_content" node --input-type=commonjs -e '
   console.log(JSON.stringify({
     namespace: process.env.NAMESPACE_VAL,
     content: process.env.CONTENT_VAL,

--- a/scripts/tests/security-scan-namespace.test.sh
+++ b/scripts/tests/security-scan-namespace.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regression tests for the Munin namespaces written by security-scan.sh (#98).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="$SCRIPT_DIR/../security-scan.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+  local description=$1 expected=$2
+  if grep -Fq "$expected" "$SCANNER"; then
+    pass "$description"
+  else
+    fail "$description (missing: $expected)"
+  fi
+}
+
+assert_not_contains() {
+  local description=$1 unexpected=$2
+  if grep -Fq "$unexpected" "$SCANNER"; then
+    fail "$description (found: $unexpected)"
+  else
+    pass "$description"
+  fi
+}
+
+echo "security scan namespace tests"
+echo "============================="
+
+# shellcheck disable=SC2016 # Assertions intentionally match literal shell syntax.
+assert_contains "scan summaries use one stable namespace" 'NAMESPACE_VAL="security/scans" KEY_VAL="${SCAN_DATE}"'
+# shellcheck disable=SC2016 # Assertions intentionally match literal shell syntax.
+assert_not_contains "scan dates are not namespace segments" 'NAMESPACE_VAL="security/scans/${SCAN_DATE}" KEY_VAL="summary"'
+# shellcheck disable=SC2016 # Assertions intentionally match literal shell syntax.
+assert_contains "scan log uses canonical security namespace" 'NAMESPACE_VAL="security" CONTENT_VAL="$log_content"'
+# shellcheck disable=SC2016 # Assertions intentionally match literal shell syntax.
+assert_not_contains "scan log has no trailing namespace slash" 'NAMESPACE_VAL="security/" CONTENT_VAL="$log_content"'
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #98

## Summary
- write scan summaries under the stable `security/scans` namespace keyed by scan date
- write scan events under canonical `security` (without a trailing slash)
- add focused regression coverage for both namespace contracts

## Verification
- `make test` (suite invoked; focused scanner and systemd-render suites passed)
- `shellcheck scripts/security-scan.sh scripts/tests/security-scan-namespace.test.sh`

## M5 dogfood evidence
- bounded review via `POST /delegate`: local model `mellum`, task type `classify`
- ledger ID: `82eb03dc-154e-46a3-b23e-fdee2d9da353`; cost trace: `5207b9e5-07e4-4c92-bd04-05038408b25a`
- result: `pass`; useful as a quick confirmation, independently verified against the exact write arguments and regression test
- gateway policy was shadow/unverified, so it was not used as the final review gate.