### PR TITLE
docs: correct Skuld repository authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Runs on two Raspberry Pis, a MacBook, and a local M5 inference box. All data sta
 | **Mimir** | Authenticated file server | [mimir](https://github.com/Magnus-Gille/mimir) |
 | **Heimdall** | Monitoring dashboard | [heimdall](https://github.com/Magnus-Gille/heimdall) |
 | **Ratatoskr** | Telegram message router | [ratatoskr](https://github.com/Magnus-Gille/ratatoskr) |
-| **Skuld** | Daily intelligence briefing | [skuld](https://github.com/grimnir-bot/skuld) |
+| **Skuld** | Daily intelligence briefing | [skuld](https://github.com/Magnus-Gille/skuld) |
 | **Verdandi** | Tamper-evident audit log | [verdandi](https://github.com/Magnus-Gille/verdandi) |
 | **noxctl** | Fortnox accounting CLI + MCP | [fortnox-mcp](https://github.com/Magnus-Gille/fortnox-mcp) |
 | **Brokkr** | Platform / substrate — hardware park, OS, storage, network, backups | [brokkr](https://github.com/Magnus-Gille/brokkr) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ Three principles guide every decision:
 | **Hugin** | Task dispatcher | 3032 | Pi 1 | `hugin` |
 | **Heimdall** | Monitoring dashboard | 3033 | Pi 1 | `heimdall` |
 | **Ratatoskr** | Telegram router + concierge | 3034 | Pi 1 | `ratatoskr` |
-| **Skuld** | Daily intelligence briefing | — | Pi 1 | `skuld` (grimnir-bot) |
+| **Skuld** | Daily intelligence briefing | — | Pi 1 | `skuld` (Magnus-Gille) |
 | **Verdandi** | Tamper-evident audit log | 3036 | Pi 1 | `verdandi` |
 | **Mimir** | Authenticated file server | 3031 | Pi 2 (NAS) | `mimir` |
 | **noxctl** | Accounting CLI + MCP | — | Laptop (global) | `fortnox-mcp` |
@@ -573,7 +573,7 @@ Skuld is the oracle. Named after the Norn of the future, it generates a daily in
 - **AI:** @anthropic-ai/sdk (Claude API direct)
 - **Data sources:** Google Calendar (ICS), Munin (SQLite direct read), Fortnox (future via noxctl)
 - **Deployment:** Pi 1, co-located with Munin for low-latency SQLite reads
-- **Repo:** `grimnir-bot/skuld` (private, Magnus-Gille as admin collaborator)
+- **Repo:** `Magnus-Gille/skuld` (private)
 
 ### How it works
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -35,9 +35,9 @@ For owning-repository deploy commands outside the centrally deployable set, use 
 > exceptions for ecosystem repositories that are not deployed components.
 
 - **Magnus-Gille** — default owner
-- **grimnir-bot** — explicit owner exception for Skuld, and the dedicated
-  machine account for Pi. Added as collaborator on repos Hugin pushes to. Pi
-  authenticates to GitHub exclusively via grimnir-bot SSH key.
+- **grimnir-bot** — dedicated machine account for Pi. Added as collaborator
+  on repos Hugin pushes to. Pi authenticates to GitHub exclusively via its SSH
+  key; it is not repository authority for Skuld.
 
 ## Repo naming
 
@@ -49,7 +49,7 @@ matches the operator:
 - `Magnus-Gille/mimir`
 - `Magnus-Gille/fortnox-mcp`
 - `Magnus-Gille/ratatoskr`
-- `grimnir-bot/skuld` (exception: created by Hugin task under bot account)
+- `Magnus-Gille/skuld`
 
 Ecosystem repositories that are not deployed components are listed in
 `repository_authority.additional_repositories`; their canonical local

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -53,7 +53,7 @@ All scheduled tasks run on Pi 1 (huginmunin) via systemd timers, except where no
 |-------|-------|
 | **Schedule** | Daily 06:00 UTC (+5 min jitter) |
 | **Unit** | `skuld.timer` / `skuld.service` |
-| **Repo** | `skuld` (grimnir-bot org) |
+| **Repo** | `skuld` (Magnus-Gille) |
 | **Purpose** | Synthesize calendar, project state, and Munin context into a morning briefing via Claude API |
 | **Output** | Munin: `briefings/daily/{date}` and `briefings/latest`; Heimdall renders `/briefing` |
 | **Why it exists** | Morning orientation — what's on today, what changed overnight, what needs attention |

--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -185,14 +185,15 @@ anything.
    the configured name matches the registry. It is not a substitute for the
    ownership and ancestry preconditions above.
 
-#### Known unresolved authority discrepancy: Skuld
+#### Resolved authority discrepancy: Skuld
 
-As of 2026-07-23, `repository_authority.owner_overrides.skuld` declares
-`grimnir-bot/skuld`, but the active pull-request and issue history and the
-local checkout lineage are owned by `Magnus-Gille/skuld`. Treat this as an
-unresolved registry defect: do not retarget the active checkout to
-`grimnir-bot/skuld`, and do not call the audit clean until an owner-approved
-registry decision or deliberate history/workflow migration resolves it.
+On 2026-07-23, GitHub evidence showed that `Magnus-Gille/skuld` is the private
+active repository: it contains `grimnir-bot/skuld`'s `main` history and has the
+current pull-request workflow. `grimnir-bot/skuld` is also private and
+unarchived, but its `main` and GitHub activity stopped in March. The registry
+therefore names the active `Magnus-Gille/skuld` repository. Preserve the older
+remote as an explicitly named predecessor where it exists; do not retarget an
+active checkout toward the stale repository merely to satisfy an old registry.
 
 Never replace this procedure with `git remote remove`, an unrecorded
 `set-url`, a reset, or a checkout in a dirty canonical tree. Those operations

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -537,8 +537,8 @@ repository_authority_rows="$(
 assert_eq "Heimdall checkout authority is canonical public repo" \
   "heimdall|Magnus-Gille/heimdall" \
   "$(printf '%s\n' "$repository_authority_rows" | grep '^heimdall|')"
-assert_eq "Skuld checkout retains its owner exception" \
-  "skuld|grimnir-bot/skuld" \
+assert_eq "Skuld checkout uses the default canonical owner" \
+  "skuld|Magnus-Gille/skuld" \
   "$(printf '%s\n' "$repository_authority_rows" | grep '^skuld|')"
 assert_eq "Gille Inference canonical checkout maps to public authority" \
   "gille-inference|Magnus-Gille/gille-inference" \

--- a/services.json
+++ b/services.json
@@ -1,9 +1,7 @@
 {
   "repository_authority": {
     "default_owner": "Magnus-Gille",
-    "owner_overrides": {
-      "skuld": "grimnir-bot"
-    },
+    "owner_overrides": {},
     "additional_repositories": [
       {
         "repo": "gille-inference",


### PR DESCRIPTION
## What changed

Corrects Grimnir's canonical repository authority for Skuld from `grimnir-bot/skuld` to `Magnus-Gille/skuld`, and updates the system documentation and registry regression test accordingly.

## Why

The active private repository is `Magnus-Gille/skuld`: it contains the declared bot repository's `main` history and has the current PR workflow. `grimnir-bot/skuld` remains private and unarchived, but its activity stopped in March. No checkout remotes, repository visibility, history, or deployment configuration were changed.

## Evidence

- Local ancestry: `grimnir-bot/skuld` main (`48e026c`) is an ancestor of `Magnus-Gille/skuld` main (`f1ca836`); the reverse is false.
- GitHub activity: Magnus-Gille/skuld merged PRs #6–#10 through 2026-07-13; grimnir-bot/skuld has no PRs or issues and was last pushed 2026-03-23.
- M5 bounded evidence review (`mellum`) returned `PASS` (ledger `1c6ee43e-5e13-435d-ad70-34a406380e2a`); root review remains required.

## Verification

- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `git diff --check`

Related to #115.
