### PR TITLE
docs: define NAS network operating policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-network-operating-model test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -42,6 +42,9 @@ test-failure-recovery-doc: ## Regression test: assert docs/failure-recovery.md d
 test-learning-task-contract-doc: ## Regression test: assert the learning seam and improvement-scope contract (issue #86)
 	@bash tests/scripts/test-learning-task-contract-doc.sh
 
+test-network-operating-model: ## Regression test: assert the NAS/control network operating policy (issue #12)
+	@bash scripts/tests/network-operating-model.test.sh
+
 test-registry-checkout: ## Unit tests for the registry-checkout integrity helpers (issue #47)
 	@bash scripts/tests/registry-checkout.test.sh
 
@@ -54,7 +57,7 @@ test-runtime-state: ## Desired runtime and deployment-state validation (issue #1
 test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
 	@bash scripts/tests/worktree-hygiene.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-munin-rpc test-registry-smoke test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-network-operating-model test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is the system-level documentation and operations repository. No service cod
 What's here:
 
 - **[docs/architecture.md](docs/architecture.md)** — Full system architecture (topology, components, security, data flow)
+- **[docs/network-operating-model.md](docs/network-operating-model.md)** — Safe operating contract for the Wi-Fi NAS, dual-homed control Pi, and Tailscale telemetry path
 - **[docs/conventions.md](docs/conventions.md)** — Naming, ports, service patterns, GitHub ownership
 - **[docs/vision.md](docs/vision.md)** — Where the project is heading
 - **[docs/learning-task-contract.md](docs/learning-task-contract.md)** — Versioned Hugin↔M5 learning-evidence seam, field ownership, compatibility, and measurable loop milestones

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,9 @@ Both Pis are Raspberry Pi 5 units (8 GB RAM) in Flirc passive-cooling aluminum c
 - **Tailscale** provides encrypted Pi-to-Pi and laptop-to-Pi communication for rsync, SSH, and backups.
 - **Public endpoints:** `munin-memory.gille.ai`, `heimdall.gille.ai`, `mimir.gille.ai`
 
+The operational interface and transport policy for the intentionally Wi-Fi NAS
+and dual-homed control Pi lives in [Network operating model](network-operating-model.md).
+
 ---
 
 ## Munin — Memory

--- a/docs/network-operating-model.md
+++ b/docs/network-operating-model.md
@@ -16,14 +16,15 @@ turning an intentional layout into an outage.
 
 | Node | LAN role | Cross-node service/observability role |
 |---|---|---|
-| NAS | **NAS Wi-Fi is the current intentional primary LAN path.** Ethernet may be physically disconnected and must not be treated as a failed service. | Use Tailscale/MagicDNS to reach the control host for service-to-service traffic and Heimdall telemetry. |
+| NAS | **NAS Wi-Fi is the current intentional primary LAN path.** Ethernet may be physically disconnected and must not be treated as a failed service. | Use the control host's stable Tailscale identity from the owner-only runtime overlay for service-to-service traffic and Heimdall telemetry. |
 | Control Pi (`huginmunin`) | Both Ethernet and Wi-Fi may be up; the **control host's Ethernet remains the preferred default route**. Wi-Fi is retained as a live resilience path. | Accept NAS-originated traffic on the Tailscale identity, rather than assuming one particular LAN address is reachable. |
 
 **Tailscale is the required transport for NAS-to-control observability.** In
-particular, producers on the NAS must target the control host's Tailscale
-MagicDNS name (for example `huginmunin`), not a `.local` name or hard-coded LAN
-address. The service owner is responsible for its endpoint configuration;
-Grimnir records the cross-component transport rule.
+particular, producers on the NAS must target the stable Tailscale identity
+provided by the owner-only runtime overlay: either its MagicDNS name or Tailnet
+address, not a `.local` name or hard-coded LAN address. The service owner is
+responsible for its endpoint configuration; Grimnir records the cross-component
+transport rule without publishing the private locator.
 
 This policy does not require Mimir itself to listen on the LAN. Its local
 loopback listener and its separately configured ingress are deliberate service
@@ -41,7 +42,8 @@ health:
    `curl -fsS http://127.0.0.1:3031/health`; this proves Mimir's listener is
    healthy without assuming it should bind to Wi-Fi.
 3. From the NAS, check the control-plane health through Tailscale, for example
-   `curl -fsS http://huginmunin:3033/health`. An HTTP response proves the
+   `curl -fsS http://<control-tailnet-host>:3033/health`, substituting the
+   owner-only MagicDNS name or Tailnet address. An HTTP response proves the
    transport path even if a protected endpoint later requires credentials.
 4. On the control Pi, inspect both routes and confirm the Ethernet default has
    the preferred metric. Check the declared Grimnir timers independently of

--- a/docs/network-operating-model.md
+++ b/docs/network-operating-model.md
@@ -1,0 +1,65 @@
+# Network operating model
+
+> **Status:** adopted for the current hardware layout after a read-only check on
+> 2026-07-23 (grimnir#12). This is an operating contract, not a request to
+> reconfigure either host.
+
+## Purpose
+
+The NAS was deliberately moved to a location where it connects over Wi-Fi. A
+disconnected Ethernet cable on that host is therefore expected, rather than an
+incident. The control Pi is deliberately dual-homed while services and
+maintenance continue to run. This document prevents a well-meaning repair from
+turning an intentional layout into an outage.
+
+## Current transport policy
+
+| Node | LAN role | Cross-node service/observability role |
+|---|---|---|
+| NAS | **NAS Wi-Fi is the current intentional primary LAN path.** Ethernet may be physically disconnected and must not be treated as a failed service. | Use Tailscale/MagicDNS to reach the control host for service-to-service traffic and Heimdall telemetry. |
+| Control Pi (`huginmunin`) | Both Ethernet and Wi-Fi may be up; the **control host's Ethernet remains the preferred default route**. Wi-Fi is retained as a live resilience path. | Accept NAS-originated traffic on the Tailscale identity, rather than assuming one particular LAN address is reachable. |
+
+**Tailscale is the required transport for NAS-to-control observability.** In
+particular, producers on the NAS must target the control host's Tailscale
+MagicDNS name (for example `huginmunin`), not a `.local` name or hard-coded LAN
+address. The service owner is responsible for its endpoint configuration;
+Grimnir records the cross-component transport rule.
+
+This policy does not require Mimir itself to listen on the LAN. Its local
+loopback listener and its separately configured ingress are deliberate service
+boundaries, not proof that NAS Wi-Fi is unhealthy.
+
+## Safe verification
+
+These checks are read-only and intentionally distinguish transport from service
+health:
+
+1. On the NAS, inspect `ip -br addr`, `ip route show default`, and
+   `tailscale status --self`. A carrier-less NAS `eth0`, an active `wlan0`, and
+   an active Tailscale address match the intended layout.
+2. On the NAS, check the local service boundary with
+   `curl -fsS http://127.0.0.1:3031/health`; this proves Mimir's listener is
+   healthy without assuming it should bind to Wi-Fi.
+3. From the NAS, check the control-plane health through Tailscale, for example
+   `curl -fsS http://huginmunin:3033/health`. An HTTP response proves the
+   transport path even if a protected endpoint later requires credentials.
+4. On the control Pi, inspect both routes and confirm the Ethernet default has
+   the preferred metric. Check the declared Grimnir timers independently of
+   interface state.
+
+If the Tailscale probe fails while the local Mimir probe passes, investigate the
+telemetry endpoint, name resolution, and tailnet state first. Do not change
+NAS Wi-Fi or Mimir's bind address as a first response.
+
+## Change boundary
+
+Network routing is substrate work owned by Brokkr; service endpoint changes are
+owned by the affected service repository. A Grimnir runbook may coordinate the
+contract, but it must not silently mutate live interfaces.
+
+Do not disable, reprioritize, or restart either host's network interfaces
+outside an approved maintenance window with a reachable-console and rollback
+plan. Before such a window, record the existing addresses, default routes,
+Tailscale state, and the verification commands above. Afterward, prove both
+local Mimir health and NAS-to-control Tailscale reachability before declaring
+the change complete.

--- a/scripts/tests/network-operating-model.test.sh
+++ b/scripts/tests/network-operating-model.test.sh
@@ -22,6 +22,7 @@ require_text() {
 
 require_text "NAS Wi-Fi is the current intentional primary LAN path"
 require_text "Tailscale is the required transport for NAS-to-control observability"
+require_text "MagicDNS name or Tailnet"
 require_text "Do not disable, reprioritize, or restart either host's network interfaces"
 require_text "control host's Ethernet remains the preferred default route"
 

--- a/scripts/tests/network-operating-model.test.sh
+++ b/scripts/tests/network-operating-model.test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regression guard for the deliberate NAS Wi-Fi and Tailscale observability policy
+# established by grimnir#12.  This is a documentation contract, so validate the
+# required operational claims rather than attempting to inspect a live network in CI.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOC="$ROOT/docs/network-operating-model.md"
+
+if [[ ! -f "$DOC" ]]; then
+  echo "FAIL: missing docs/network-operating-model.md" >&2
+  exit 1
+fi
+
+require_text() {
+  local expected="$1"
+  if ! grep -Fq -- "$expected" "$DOC"; then
+    echo "FAIL: network operating model is missing: $expected" >&2
+    exit 1
+  fi
+}
+
+require_text "NAS Wi-Fi is the current intentional primary LAN path"
+require_text "Tailscale is the required transport for NAS-to-control observability"
+require_text "Do not disable, reprioritize, or restart either host's network interfaces"
+require_text "control host's Ethernet remains the preferred default route"
+
+echo "PASS: network operating model preserves #12 safety invariants"


### PR DESCRIPTION
## Summary

Documents the intentional Wi-Fi NAS / dual-homed control-Pi layout and makes Tailscale the explicit NAS-to-control observability transport. Adds a small regression guard for the operating invariants.

## Evidence

Read-only checks on 2026-07-23: NAS Wi-Fi + Tailscale up; Ethernet has no carrier; Mimir active with local health 200; control Ethernet remains preferred default; NAS reaches Heimdall through Tailscale while LAN endpoint assumptions fail.

M5 mellum classified the evidence-only decision as `DOC_PR` (ledger `93818d47-5e8b-4d46-8ed0-7eb524fea254`, verifier pass).

## Verification

- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `git diff --check`