### PR TITLE
fix(audit): separate Heimdall canonical checkout

### DIFF
--- a/docs/authority.md
+++ b/docs/authority.md
@@ -100,6 +100,15 @@ The standalone worktree-hygiene audit additionally warns when a canonical
 local checkout's `origin` disagrees with the GitHub repository identity in
 `services.json.repository_authority`, including archived predecessors.
 
+`repository_authority.checkout_overrides` is deliberately limited to named
+component repositories. It is used when an archived predecessor must remain
+available beside a separate, clean canonical checkout. For example, Heimdall
+is audited at `heimdall-canonical`, whose authority is
+`Magnus-Gille/heimdall`; the older `heimdall` checkout remains an archive and
+is not silently retargeted. This mapping affects the read-only authority
+audit only. It does not change a component's repo identifier, deployment
+target, or any existing checkout.
+
 ## Document boundary: `architecture.md` vs `snapshot.md`
 
 The generator assembles `full-architecture.md` from two sources. This table defines what belongs where.

--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -227,6 +227,13 @@ When a checkout exists, a missing, non-GitHub, archived, or wrong `origin`
 is a finding. Output includes only normalized public GitHub identities (or
 `<missing>`/`<non-github>`), never the raw remote URL.
 
+When retaining an unrelated archive checkout is intentional, declare the
+separate active directory with `repository_authority.checkout_overrides`.
+The audit then inspects that named canonical directory and leaves the
+archive's remotes and history untouched. This is the Heimdall arrangement:
+`heimdall-canonical` is the clean public checkout, while `heimdall` remains
+the explicitly preserved private archive.
+
 The worktree-lifecycle portion is also wired into
 `scripts/generate-architecture.sh --validate` (the `grimnir-validate` timer),
 where its findings fold into the existing `PASS`/`FAIL` tally alongside the

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -167,8 +167,12 @@ switch (query) {
       typeof authority.owner_overrides === 'object' &&
       !Array.isArray(authority.owner_overrides)
       ? authority.owner_overrides : {};
+    var checkoutOverrides = authority.checkout_overrides &&
+      typeof authority.checkout_overrides === 'object' &&
+      !Array.isArray(authority.checkout_overrides)
+      ? authority.checkout_overrides : {};
     var rows = components.map(function (c) {
-      return { repo: c.repo, checkout: c.repo };
+      return { repo: c.repo, checkout: checkoutOverrides[c.repo] || c.repo };
     });
     if (Array.isArray(authority.additional_repositories)) {
       authority.additional_repositories.forEach(function (entry) {

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -71,13 +71,36 @@ if (data.repository_authority !== undefined && !isPlainObject(data.repository_au
       }
     });
   }
+  if (authority.checkout_overrides !== undefined && !isPlainObject(authority.checkout_overrides)) {
+    fail('repository_authority.checkout_overrides must be an object');
+  } else if (isPlainObject(authority.checkout_overrides)) {
+    var componentRepos = {};
+    data.components.forEach(function (component) {
+      if (isPlainObject(component) && typeof component.repo === 'string') {
+        componentRepos[component.repo] = true;
+      }
+    });
+    Object.keys(authority.checkout_overrides).forEach(function (repo) {
+      var checkout = authority.checkout_overrides[repo];
+      if (!VALID_REPOSITORY_PART.test(repo) || !componentRepos[repo] ||
+          typeof checkout !== 'string' || !VALID_REPOSITORY_PART.test(checkout)) {
+        fail('repository_authority.checkout_overrides must map declared component repos to safe checkout names');
+      }
+    });
+  }
   if (!Array.isArray(authority.additional_repositories)) {
     fail('repository_authority.additional_repositories must be an array');
   } else {
     var seenAuthorityCheckouts = {};
+    var checkoutOverrides = isPlainObject(authority.checkout_overrides)
+      ? authority.checkout_overrides : {};
     data.components.forEach(function (component) {
       if (isPlainObject(component) && typeof component.repo === 'string') {
-        seenAuthorityCheckouts[component.repo] = true;
+        var componentCheckout = checkoutOverrides[component.repo] || component.repo;
+        if (seenAuthorityCheckouts[componentCheckout]) {
+          fail('duplicate repository-authority checkout: "' + componentCheckout + '"');
+        }
+        seenAuthorityCheckouts[componentCheckout] = true;
       }
     });
     authority.additional_repositories.forEach(function (entry, i) {

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -97,6 +97,7 @@ cat > "$TMP_DIR/bad-repository-authority.json" << 'EOF'
   "repository_authority": {
     "default_owner": "owner|unsafe",
     "owner_overrides": [],
+    "checkout_overrides": [],
     "additional_repositories": [
       { "repo": "../escape", "checkout": "/absolute/path" }
     ]
@@ -107,11 +108,45 @@ EOF
 assert_eq "unsafe repository authority -> exit 1" "1" \
   "$(run_validator "$TMP_DIR/bad-repository-authority.json")"
 
+cat > "$TMP_DIR/legacy-repository-authority.json" << 'EOF'
+{
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "owner_overrides": {},
+    "additional_repositories": []
+  },
+  "components": []
+}
+EOF
+assert_eq "repository authority without checkout overrides remains valid" "0" \
+  "$(run_validator "$TMP_DIR/legacy-repository-authority.json")"
+
+cat > "$TMP_DIR/bad-repository-checkout-override.json" << 'EOF'
+{
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "owner_overrides": {},
+    "checkout_overrides": { "not-a-component": "elsewhere" },
+    "additional_repositories": []
+  },
+  "components": [
+    {
+      "name": "alpha", "repo": "alpha", "host": null, "port": null,
+      "deploy": false, "scan": false, "needs_build": false,
+      "systemd_units": []
+    }
+  ]
+}
+EOF
+assert_eq "repository checkout override must name a declared component" "1" \
+  "$(run_validator "$TMP_DIR/bad-repository-checkout-override.json")"
+
 cat > "$TMP_DIR/duplicate-repository-checkout.json" << 'EOF'
 {
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "owner_overrides": {},
+    "checkout_overrides": {},
     "additional_repositories": [
       { "repo": "other", "checkout": "alpha" }
     ]
@@ -535,8 +570,8 @@ repository_authority_rows="$(
     node --input-type=commonjs "$REGISTRY_JS"
 )"
 assert_eq "Heimdall checkout authority is canonical public repo" \
-  "heimdall|Magnus-Gille/heimdall" \
-  "$(printf '%s\n' "$repository_authority_rows" | grep '^heimdall|')"
+  "heimdall-canonical|Magnus-Gille/heimdall" \
+  "$(printf '%s\n' "$repository_authority_rows" | grep '/heimdall$')"
 assert_eq "Skuld checkout uses the default canonical owner" \
   "skuld|Magnus-Gille/skuld" \
   "$(printf '%s\n' "$repository_authority_rows" | grep '^skuld|')"

--- a/scripts/tests/worktree-hygiene.test.sh
+++ b/scripts/tests/worktree-hygiene.test.sh
@@ -380,7 +380,8 @@ cat > "$FIXTURE_SERVICES_JSON" << EOF
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "additional_repositories": [],
-    "owner_overrides": {}
+    "owner_overrides": {},
+    "checkout_overrides": {}
   },
   "components": [
     {
@@ -444,7 +445,8 @@ cat > "$CLEAN_SERVICES_JSON" << EOF
     "additional_repositories": [
       { "repo": "repo-clean", "checkout": "repo-clean" }
     ],
-    "owner_overrides": {}
+    "owner_overrides": {},
+    "checkout_overrides": {}
   },
   "components": []
 }

--- a/services.json
+++ b/services.json
@@ -2,6 +2,9 @@
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "owner_overrides": {},
+    "checkout_overrides": {
+      "heimdall": "heimdall-canonical"
+    },
     "additional_repositories": [
       {
         "repo": "gille-inference",


### PR DESCRIPTION
Closes #112.

The existing Heimdall checkout is an unrelated private archive, so this preserves it untouched and records heimdall-canonical as the public authority-audit checkout. The mapping is read-only-audit only: no deploy path, origin, branch, history, or visibility is changed.

Evidence: the public checkout is clean and equals origin/main; the archive and public histories have no common ancestor.

Validation: make test; shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh; M5/mellum bounded review PASS (ledger d5c50bef-42ad-42cf-a607-2dfc0f2c066b).