### PR TITLE
CI: move pinned actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: shellcheck scripts/
         run: shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
       - name: Run test suites


### PR DESCRIPTION
Closes #127

## Change
- Updates immutable `actions/checkout` pins to v7.0.1 (`3d3c42e5aac5ba805825da76410c181273ba90b1`).
- Updates immutable `actions/setup-node` pin to v7.0.0 (`820762786026740c76f36085b0efc47a31fe5020`).
- Preserves CI triggers, job shape, and permissions (no permissions were added).

## Evidence
- Official action manifests at the selected tags declare `runs.using: node24`; this replaces the Node 20-runtime v4 revisions that produced the runner deprecation annotation.
- Official release metadata inspected: checkout v7.0.1 and setup-node v7.0.0.
- Local: YAML parse, immutable-pin assertion, `make test`, and shellcheck pass.
- M5 mellum classification: `safe` (bounded evidence check; delegation `a816cd79-4fe8-4277-a891-3e3a2a21dee8`).

CI must confirm the prior Node.js 20 runner annotation is absent.