### PR TITLE
fix(audit): require canonical checkout paths

### DIFF
--- a/docs/authority.md
+++ b/docs/authority.md
@@ -128,14 +128,11 @@ The standalone worktree-hygiene audit additionally warns when a canonical
 local checkout's `origin` disagrees with the GitHub repository identity in
 `services.json.repository_authority`, including archived predecessors.
 
-`repository_authority.checkout_overrides` is deliberately limited to named
-component repositories. It is used when an archived predecessor must remain
-available beside a separate, clean canonical checkout. For example, Heimdall
-is audited at `heimdall-canonical`, whose authority is
-`Magnus-Gille/heimdall`; the older `heimdall` checkout remains an archive and
-is not silently retargeted. This mapping affects the read-only authority
-audit only. It does not change a component's repo identifier, deployment
-target, or any existing checkout.
+Canonical checkout names always equal their declared repository names. For
+example, Heimdall's canonical checkout is `heimdall` and is checked against
+`Magnus-Gille/heimdall`. Host-local archive layouts must not rewrite that
+global contract: preserve an archive in a separately named directory and make
+the local move explicitly, outside this read-only audit.
 
 ## Document boundary: `architecture.md` vs `snapshot.md`
 

--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -218,21 +218,19 @@ prints one line per worktree that has a finding, followed by a summary line
 (`Summary: N ok, M issues`) and a non-destructive remediation recipe per
 finding. Exit code is `0` when nothing is flagged, `1` otherwise.
 
-For canonical-origin checks, component checkout names come from
-`services.json.components[].repo`; the default GitHub owner, owner
-exceptions, and non-component/renamed checkout mappings come from
-`services.json.repository_authority`. A checkout absent on the current host
-is skipped because hosts intentionally carry only part of the ecosystem.
-When a checkout exists, a missing, non-GitHub, archived, or wrong `origin`
-is a finding. Output includes only normalized public GitHub identities (or
-`<missing>`/`<non-github>`), never the raw remote URL.
+For canonical-origin checks, component checkout names come directly from
+`services.json.components[].repo`; the default GitHub owner, owner exceptions,
+and non-component repositories come from `services.json.repository_authority`.
+A checkout absent on the current host is skipped because hosts intentionally
+carry only part of the ecosystem. When a checkout exists, a missing,
+non-GitHub, archived, or wrong `origin` is a finding. Output includes only
+normalized public GitHub identities (or `<missing>`/`<non-github>`), never raw
+remote URLs.
 
-When retaining an unrelated archive checkout is intentional, declare the
-separate active directory with `repository_authority.checkout_overrides`.
-The audit then inspects that named canonical directory and leaves the
-archive's remotes and history untouched. This is the Heimdall arrangement:
-`heimdall-canonical` is the clean public checkout, while `heimdall` remains
-the explicitly preserved private archive.
+When retaining an unrelated archive checkout is intentional, keep it in a
+separately named directory and preserve its remotes and history there. The
+declared canonical directory keeps its repository name; the audit never
+rewrites that global contract to suit one host.
 
 The worktree-lifecycle portion is also wired into
 `scripts/generate-architecture.sh --validate` (the `grimnir-validate` timer),

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -167,12 +167,8 @@ switch (query) {
       typeof authority.owner_overrides === 'object' &&
       !Array.isArray(authority.owner_overrides)
       ? authority.owner_overrides : {};
-    var checkoutOverrides = authority.checkout_overrides &&
-      typeof authority.checkout_overrides === 'object' &&
-      !Array.isArray(authority.checkout_overrides)
-      ? authority.checkout_overrides : {};
     var rows = components.map(function (c) {
-      return { repo: c.repo, checkout: checkoutOverrides[c.repo] || c.repo };
+      return { repo: c.repo, checkout: c.repo };
     });
     if (Array.isArray(authority.additional_repositories)) {
       authority.additional_repositories.forEach(function (entry) {

--- a/scripts/lib/validate-registry.js
+++ b/scripts/lib/validate-registry.js
@@ -71,36 +71,19 @@ if (data.repository_authority !== undefined && !isPlainObject(data.repository_au
       }
     });
   }
-  if (authority.checkout_overrides !== undefined && !isPlainObject(authority.checkout_overrides)) {
-    fail('repository_authority.checkout_overrides must be an object');
-  } else if (isPlainObject(authority.checkout_overrides)) {
-    var componentRepos = {};
-    data.components.forEach(function (component) {
-      if (isPlainObject(component) && typeof component.repo === 'string') {
-        componentRepos[component.repo] = true;
-      }
-    });
-    Object.keys(authority.checkout_overrides).forEach(function (repo) {
-      var checkout = authority.checkout_overrides[repo];
-      if (!VALID_REPOSITORY_PART.test(repo) || !componentRepos[repo] ||
-          typeof checkout !== 'string' || !VALID_REPOSITORY_PART.test(checkout)) {
-        fail('repository_authority.checkout_overrides must map declared component repos to safe checkout names');
-      }
-    });
+  if (authority.checkout_overrides !== undefined) {
+    fail('repository_authority.checkout_overrides is not supported; canonical checkout names equal repository names');
   }
   if (!Array.isArray(authority.additional_repositories)) {
     fail('repository_authority.additional_repositories must be an array');
   } else {
     var seenAuthorityCheckouts = {};
-    var checkoutOverrides = isPlainObject(authority.checkout_overrides)
-      ? authority.checkout_overrides : {};
     data.components.forEach(function (component) {
       if (isPlainObject(component) && typeof component.repo === 'string') {
-        var componentCheckout = checkoutOverrides[component.repo] || component.repo;
-        if (seenAuthorityCheckouts[componentCheckout]) {
-          fail('duplicate repository-authority checkout: "' + componentCheckout + '"');
+        if (seenAuthorityCheckouts[component.repo]) {
+          fail('duplicate repository-authority checkout: "' + component.repo + '"');
         }
-        seenAuthorityCheckouts[componentCheckout] = true;
+        seenAuthorityCheckouts[component.repo] = true;
       }
     });
     authority.additional_repositories.forEach(function (entry, i) {

--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -97,7 +97,6 @@ cat > "$TMP_DIR/bad-repository-authority.json" << 'EOF'
   "repository_authority": {
     "default_owner": "owner|unsafe",
     "owner_overrides": [],
-    "checkout_overrides": [],
     "additional_repositories": [
       { "repo": "../escape", "checkout": "/absolute/path" }
     ]
@@ -118,7 +117,7 @@ cat > "$TMP_DIR/legacy-repository-authority.json" << 'EOF'
   "components": []
 }
 EOF
-assert_eq "repository authority without checkout overrides remains valid" "0" \
+assert_eq "repository authority with canonical checkout names remains valid" "0" \
   "$(run_validator "$TMP_DIR/legacy-repository-authority.json")"
 
 cat > "$TMP_DIR/bad-repository-checkout-override.json" << 'EOF'
@@ -126,7 +125,7 @@ cat > "$TMP_DIR/bad-repository-checkout-override.json" << 'EOF'
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "owner_overrides": {},
-    "checkout_overrides": { "not-a-component": "elsewhere" },
+    "checkout_overrides": { "alpha": "elsewhere" },
     "additional_repositories": []
   },
   "components": [
@@ -138,7 +137,7 @@ cat > "$TMP_DIR/bad-repository-checkout-override.json" << 'EOF'
   ]
 }
 EOF
-assert_eq "repository checkout override must name a declared component" "1" \
+assert_eq "repository checkout overrides are rejected as host-specific authority" "1" \
   "$(run_validator "$TMP_DIR/bad-repository-checkout-override.json")"
 
 cat > "$TMP_DIR/duplicate-repository-checkout.json" << 'EOF'
@@ -146,7 +145,6 @@ cat > "$TMP_DIR/duplicate-repository-checkout.json" << 'EOF'
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "owner_overrides": {},
-    "checkout_overrides": {},
     "additional_repositories": [
       { "repo": "other", "checkout": "alpha" }
     ]
@@ -569,9 +567,9 @@ repository_authority_rows="$(
   REGISTRY_PATH="$REPO_REGISTRY" QUERY=repository-authority \
     node --input-type=commonjs "$REGISTRY_JS"
 )"
-assert_eq "Heimdall checkout authority is canonical public repo" \
-  "heimdall-canonical|Magnus-Gille/heimdall" \
-  "$(printf '%s\n' "$repository_authority_rows" | grep '/heimdall$')"
+assert_eq "Heimdall checkout authority uses its canonical repository name" \
+  "heimdall|Magnus-Gille/heimdall" \
+  "$(printf '%s\n' "$repository_authority_rows" | grep '^heimdall|')"
 assert_eq "Skuld checkout uses the default canonical owner" \
   "skuld|Magnus-Gille/skuld" \
   "$(printf '%s\n' "$repository_authority_rows" | grep '^skuld|')"

--- a/scripts/tests/worktree-hygiene.test.sh
+++ b/scripts/tests/worktree-hygiene.test.sh
@@ -380,8 +380,7 @@ cat > "$FIXTURE_SERVICES_JSON" << EOF
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "additional_repositories": [],
-    "owner_overrides": {},
-    "checkout_overrides": {}
+    "owner_overrides": {}
   },
   "components": [
     {
@@ -445,8 +444,7 @@ cat > "$CLEAN_SERVICES_JSON" << EOF
     "additional_repositories": [
       { "repo": "repo-clean", "checkout": "repo-clean" }
     ],
-    "owner_overrides": {},
-    "checkout_overrides": {}
+    "owner_overrides": {}
   },
   "components": []
 }
@@ -460,6 +458,61 @@ set -e
 
 assert_eq "CLI exits 0 on a fully clean fixture root" "0" "$clean_rc"
 assert_contains "CLI reports 0 issues on the clean fixture" "$clean_output" "0 issues"
+
+# Canonical authority is host-independent: ordinary `heimdall` checkouts are
+# audited on both Mac-like and control-host roots, while unrelated repositories
+# absent from either host remain outside that host's local audit.
+HEIMDALL_AUTHORITY_JSON="$TMP_DIR/services-heimdall-authority.json"
+cat > "$HEIMDALL_AUTHORITY_JSON" << 'EOF'
+{
+  "repository_authority": {
+    "default_owner": "Magnus-Gille",
+    "additional_repositories": [
+      { "repo": "unrelated", "checkout": "unrelated" }
+    ],
+    "owner_overrides": {}
+  },
+  "components": [
+    {
+      "name": "heimdall",
+      "repo": "heimdall",
+      "host": null,
+      "port": null,
+      "deploy": false,
+      "scan": false,
+      "needs_build": false,
+      "systemd_units": []
+    }
+  ]
+}
+EOF
+
+MAC_ROOT="$TMP_DIR/repos-root-mac"
+mkdir -p "$MAC_ROOT"
+mk_repo "$MAC_ROOT/heimdall" main
+git -C "$MAC_ROOT/heimdall" remote add origin \
+  "https://github.com/Magnus-Gille/heimdall.git"
+set +e
+mac_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$MAC_ROOT" GRIMNIR_SERVICES_JSON="$HEIMDALL_AUTHORITY_JSON" \
+  "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
+mac_rc=$?
+set -e
+assert_eq "Mac fixture accepts ordinary canonical heimdall checkout" "0" "$mac_rc"
+assert_contains "Mac fixture audits the present Heimdall checkout" "$mac_output" "Summary: 2 ok, 0 issues"
+
+CONTROL_ROOT="$TMP_DIR/repos-root-control"
+mkdir -p "$CONTROL_ROOT"
+mk_repo "$CONTROL_ROOT/heimdall" main
+git -C "$CONTROL_ROOT/heimdall" remote add origin \
+  "https://github.com/Magnus-Gille/heimdall.git"
+set +e
+control_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$CONTROL_ROOT" GRIMNIR_SERVICES_JSON="$HEIMDALL_AUTHORITY_JSON" \
+  "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
+control_rc=$?
+set -e
+assert_eq "control fixture accepts ordinary canonical Heimdall checkout" "0" "$control_rc"
+assert_contains "control fixture audits present Heimdall despite absent unrelated repo" \
+  "$control_output" "Summary: 2 ok, 0 issues"
 
 # ── Canonical-origin reconciliation runbook ───────────────────────────────
 # The ancestry preflight must run against the checkout being reconciled, not

--- a/scripts/worktree-hygiene-audit.sh
+++ b/scripts/worktree-hygiene-audit.sh
@@ -110,9 +110,9 @@ shopt -u nullglob
 
 # Canonical-origin authority check (#112). The registry combines component
 # repo names with the explicit GitHub owner/checkout exceptions declared in
-# repository_authority. Missing local checkouts are skipped: this audit runs
-# on hosts that intentionally carry only part of the ecosystem. Existing
-# checkouts are inspected read-only and raw remote URLs are never printed.
+# repository_authority. Hosts intentionally carry only a subset of the
+# ecosystem, so absent local checkouts are skipped. Existing checkouts are
+# inspected read-only and raw remote URLs are never printed.
 if [[ -f "$SERVICES_JSON" ]]; then
   REGISTRY_JS="$SCRIPT_DIR/lib/registry.js"
   while IFS='|' read -r checkout_name expected_authority; do

--- a/services.json
+++ b/services.json
@@ -2,9 +2,6 @@
   "repository_authority": {
     "default_owner": "Magnus-Gille",
     "owner_overrides": {},
-    "checkout_overrides": {
-      "heimdall": "heimdall-canonical"
-    },
     "additional_repositories": [
       {
         "repo": "gille-inference",


### PR DESCRIPTION
Closes #128

## What changed
- Removes the global `repository_authority.checkout_overrides` mechanism and rejects it if reintroduced.
- Keeps canonical authority rows at the declared repository name (for example `heimdall`).
- Retains the multi-host audit boundary: absent local checkouts are skipped, while present canonical checkouts are audited read-only.
- Adds hermetic Mac/control fixtures proving ordinary `heimdall` checkouts are audited and an unrelated absent checkout does not create a false failure.

## Safety
No live directory, remote, repository visibility, history, host, or deployment state is changed. Archive preservation and any local migration remain separate, manual post-merge work.

## Verification
- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `git diff --check`

## M5 review
Attempted a bounded `mellum` contract review through the M5 gateway, but the Keychain owner token is absent (`m5-auth: no token in Keychain`), so no M5 verdict was produced. Root review remains required.