### PR TITLE
fix: resolve worktree default branches safely

### DIFF
--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -242,6 +242,17 @@ Unit and fixture tests: `make test-worktree-hygiene` (also part of
 `make test`), exercised against constructed fixture git repos — never against
 the real, live repos. See `scripts/tests/worktree-hygiene.test.sh`.
 
+### Default-branch resolution
+
+The audit resolves each repository's default branch independently. It reads
+the local `refs/remotes/origin/HEAD` first and, when that is absent, performs
+only the read-only `git ls-remote --symref origin HEAD` query. It never fetches,
+switches branches, or updates refs while auditing. If neither source can prove
+the branch, it reports an unresolved default branch rather than assuming
+`main`. Operators that need a deterministic compatibility fallback may supply
+`--default-branch <safe-branch>` (or `GRIMNIR_DEFAULT_BRANCH`); the output marks
+that choice as a fallback.
+
 ## What the audit reports (and never does)
 
 | Verdict | Meaning | Suggested manual remediation |

--- a/docs/worktree-hygiene.md
+++ b/docs/worktree-hygiene.md
@@ -251,7 +251,9 @@ switches branches, or updates refs while auditing. If neither source can prove
 the branch, it reports an unresolved default branch rather than assuming
 `main`. Operators that need a deterministic compatibility fallback may supply
 `--default-branch <safe-branch>` (or `GRIMNIR_DEFAULT_BRANCH`); the output marks
-that choice as a fallback.
+that choice as a fallback. Remote resolution is bounded to eight seconds by
+default (`GRIMNIR_WORKTREE_REMOTE_TIMEOUT_SECONDS`, valid range 1–60): timeout
+is reported as unresolved and never allows the validation timer to hang.
 
 ## What the audit reports (and never does)
 

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -400,14 +400,23 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     wt_repo_dir="${wt_repo_dir%/}"
     [[ -d "$wt_repo_dir/.git" ]] || continue
     wt_repo_name="$(basename "$wt_repo_dir")"
+    wt_default_row="$(resolve_repo_default_branch "$wt_repo_dir")"
+    wt_default_branch="${wt_default_row%%|*}"
+    wt_default_source="${wt_default_row#*|}"
+    wt_audit_default="$wt_default_branch"
+    [[ -n "$wt_audit_default" ]] || wt_audit_default="__unknown_default_branch__"
 
     while IFS='|' read -r wt_path wt_role wt_verdict wt_branch; do
       [[ -n "$wt_path" ]] || continue
       if [[ "$wt_role" == "canonical" ]]; then
-        if [[ "$(registry_checkout_is_alert "$wt_verdict")" == "yes" ]]; then
-          RESULTS+="❌ worktree:$wt_repo_name (canonical): $(registry_checkout_detail "$wt_verdict" "$REGISTRY_DEFAULT_BRANCH") ($wt_path)\n"
+        if [[ -z "$wt_default_branch" ]]; then
+          RESULTS+="❌ worktree:$wt_repo_name (canonical): default branch unresolved ($wt_default_source); refusing to guess ($wt_path)\n"
+          WT_FAIL=$((WT_FAIL + 1))
+        elif [[ "$(registry_checkout_is_alert "$wt_verdict")" == "yes" ]]; then
+          RESULTS+="❌ worktree:$wt_repo_name (canonical): $(registry_checkout_detail "$wt_verdict" "$wt_default_branch") (default resolved via $wt_default_source) ($wt_path)\n"
           WT_FAIL=$((WT_FAIL + 1))
         else
+          RESULTS+="✅ worktree:$wt_repo_name (canonical): on $wt_default_branch, clean (default resolved via $wt_default_source) ($wt_path)\n"
           WT_PASS=$((WT_PASS + 1))
         fi
       else
@@ -418,7 +427,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
           WT_PASS=$((WT_PASS + 1))
         fi
       fi
-    done < <(audit_repo_worktrees "$wt_repo_dir" "$REGISTRY_DEFAULT_BRANCH")
+    done < <(audit_repo_worktrees "$wt_repo_dir" "$wt_audit_default")
   done
   shopt -u nullglob
 

--- a/scripts/lib/worktree-hygiene.sh
+++ b/scripts/lib/worktree-hygiene.sh
@@ -63,6 +63,15 @@
 # worktree_upstream_gone <repo_path> <branch>
 #   "yes"/"no" staleness signals for a linked worktree's branch.
 #
+# resolve_repo_default_branch <repo_path> [<fallback_branch>]
+#   Resolves the repository's default branch without changing local refs or
+#   working-tree state. Emits "<branch>|<source>", where source is
+#   "origin/HEAD", "remote-HEAD", "fallback", or an explicit
+#   "unknown-*" reason. A locally cached origin/HEAD is preferred; when it is
+#   absent, a read-only `git ls-remote --symref origin HEAD` lookup is used.
+#   A fallback is used only when both sources are unavailable. Invalid or
+#   malicious branch data fails closed and is never passed on as a ref.
+#
 # check_deploy_target_git_dir <path>
 #   "yes" if <path>/.git exists, else "no".
 #
@@ -339,6 +348,104 @@ worktree_is_dirty() {
     echo "yes"
   else
     echo "no"
+  fi
+}
+
+# Return success only for conservative, shell-safe Git branch names. Git's
+# own check-ref-format protects ref semantics; the ASCII allow-list additionally
+# keeps audit output and downstream ref use unambiguous. This audit need not
+# support exotic branch names to safely inspect a production checkout.
+worktree_safe_branch_name() {
+  local branch="${1:-}"
+  [[ "$branch" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] || return 1
+  [[ "$branch" != *".."* && "$branch" != */./* && "$branch" != */../* ]] || return 1
+  git check-ref-format --branch "$branch" >/dev/null 2>&1
+}
+
+# Parse only the exact symbolic-ref line emitted by `git ls-remote --symref
+# origin HEAD`: "ref: refs/heads/<branch>\tHEAD". Everything else is unknown.
+worktree_parse_remote_head() {
+  local line branch=""
+  while IFS= read -r line; do
+    case "$line" in
+      $'ref: refs/heads/'*$'\tHEAD')
+        branch="${line#ref: refs/heads/}"
+        branch="${branch%$'\tHEAD'}"
+        worktree_safe_branch_name "$branch" || return 1
+        printf '%s\n' "$branch"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+# Only query ordinary Git transports by URL. In particular, reject ext:: and
+# other helper transports: an audit must not execute a repository-controlled
+# remote helper merely to label a branch. Local paths are retained for
+# hermetic fixtures and on-host bare remotes.
+worktree_safe_remote_url() {
+  local remote_url="${1:-}"
+  case "$remote_url" in
+    https://*|http://*|ssh://*|git://*|file://*|/*|./*|../*|git@*:* ) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+resolve_repo_default_branch() {
+  local repo_path="${1:-}" fallback="${2:-}" ref="" branch="" remote_output="" remote_url=""
+  [[ -n "$repo_path" ]] || { echo "|unknown-no-repo"; return 0; }
+  if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "|unknown-not-git"
+    return 0
+  fi
+
+  # symbolic-ref only reads the local tracking ref; it never fetches, checks
+  # out, or otherwise mutates the repository.
+  ref="$(git -C "$repo_path" symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [[ -n "$ref" ]]; then
+    case "$ref" in
+      refs/remotes/origin/*)
+        branch="${ref#refs/remotes/origin/}"
+        if worktree_safe_branch_name "$branch"; then
+          printf '%s|origin/HEAD\n' "$branch"
+        else
+          echo "|unknown-invalid-origin-head"
+        fi
+        return 0
+        ;;
+      *)
+        echo "|unknown-invalid-origin-head"
+        return 0
+        ;;
+    esac
+  fi
+
+  # `ls-remote --symref` is a read-only protocol query. Do not use fetch:
+  # resolving an audit label must never update refs or alter checkout state.
+  remote_url="$(git -C "$repo_path" remote get-url origin 2>/dev/null || true)"
+  if [[ -n "$remote_url" ]] && worktree_safe_remote_url "$remote_url"; then
+    remote_output="$(GIT_TERMINAL_PROMPT=0 git -c protocol.ext.allow=never -C "$repo_path" ls-remote --symref "$remote_url" HEAD 2>/dev/null || true)"
+    branch="$(printf '%s\n' "$remote_output" | worktree_parse_remote_head 2>/dev/null || true)"
+    if [[ -n "$branch" ]]; then
+      printf '%s|remote-HEAD\n' "$branch"
+      return 0
+    fi
+    if [[ "$remote_output" == *"ref: refs/heads/"* ]]; then
+      echo "|unknown-invalid-remote-head"
+      return 0
+    fi
+  elif [[ -n "$remote_url" ]]; then
+    echo "|unknown-unsafe-origin-url"
+    return 0
+  fi
+
+  if [[ -n "$fallback" ]] && worktree_safe_branch_name "$fallback"; then
+    printf '%s|fallback\n' "$fallback"
+  elif [[ -n "$fallback" ]]; then
+    echo "|unknown-invalid-fallback"
+  else
+    echo "|unknown-unavailable"
   fi
 }
 

--- a/scripts/lib/worktree-hygiene.sh
+++ b/scripts/lib/worktree-hygiene.sh
@@ -69,6 +69,8 @@
 #   "origin/HEAD", "remote-HEAD", "fallback", or an explicit
 #   "unknown-*" reason. A locally cached origin/HEAD is preferred; when it is
 #   absent, a read-only `git ls-remote --symref origin HEAD` lookup is used.
+#   The remote lookup has a bounded process timeout (default eight seconds),
+#   including SSH connect/keepalive and HTTP connect/low-speed limits.
 #   A fallback is used only when both sources are unavailable. Invalid or
 #   malicious branch data fails closed and is never passed on as a ref.
 #
@@ -392,8 +394,40 @@ worktree_safe_remote_url() {
   esac
 }
 
+worktree_remote_timeout_seconds() {
+  local seconds="${GRIMNIR_WORKTREE_REMOTE_TIMEOUT_SECONDS:-8}"
+  if [[ ! "$seconds" =~ ^[1-9][0-9]?$ ]] || [[ "$seconds" -gt 60 ]]; then
+    seconds=8
+  fi
+  printf '%s\n' "$seconds"
+}
+
+# Run a bounded command without assuming GNU coreutils. `timeout` is present
+# on the control host; macOS installations that lack it use Perl's alarm as a
+# safe fallback. If neither is available, refuse the network lookup rather
+# than silently allowing a validation timer to hang.
+worktree_run_with_timeout() {
+  local seconds="${1:-8}" rc=0
+  shift || true
+  if command -v timeout >/dev/null 2>&1; then
+    if timeout "$seconds" "$@"; then return 0; else rc=$?; fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    if gtimeout "$seconds" "$@"; then return 0; else rc=$?; fi
+  elif command -v perl >/dev/null 2>&1; then
+    if perl -e 'alarm shift @ARGV; exec @ARGV' "$seconds" "$@"; then return 0; else rc=$?; fi
+  else
+    return 124
+  fi
+  # GNU timeout returns 124. Perl normally reports SIGALRM as 142; normalize
+  # timeout-like exits so callers can fail closed with a stable verdict.
+  case "$rc" in
+    124|137|142|143) return 124 ;;
+    *) return "$rc" ;;
+  esac
+}
+
 resolve_repo_default_branch() {
-  local repo_path="${1:-}" fallback="${2:-}" ref="" branch="" remote_output="" remote_url=""
+  local repo_path="${1:-}" fallback="${2:-}" ref="" branch="" remote_output="" remote_url="" timeout_seconds="" remote_rc=0 ssh_command=""
   [[ -n "$repo_path" ]] || { echo "|unknown-no-repo"; return 0; }
   if ! git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "|unknown-not-git"
@@ -425,7 +459,17 @@ resolve_repo_default_branch() {
   # resolving an audit label must never update refs or alter checkout state.
   remote_url="$(git -C "$repo_path" remote get-url origin 2>/dev/null || true)"
   if [[ -n "$remote_url" ]] && worktree_safe_remote_url "$remote_url"; then
-    remote_output="$(GIT_TERMINAL_PROMPT=0 git -c protocol.ext.allow=never -C "$repo_path" ls-remote --symref "$remote_url" HEAD 2>/dev/null || true)"
+    timeout_seconds="$(worktree_remote_timeout_seconds)"
+    ssh_command="ssh -o BatchMode=yes -o ConnectTimeout=${timeout_seconds} -o ConnectionAttempts=1 -o ServerAliveInterval=${timeout_seconds} -o ServerAliveCountMax=1"
+    if remote_output="$(worktree_run_with_timeout "$timeout_seconds" env GIT_TERMINAL_PROMPT=0 "GIT_SSH_COMMAND=$ssh_command" git -c protocol.ext.allow=never -c "http.connectTimeout=$timeout_seconds" -c http.lowSpeedLimit=1 -c "http.lowSpeedTime=$timeout_seconds" -C "$repo_path" ls-remote --symref "$remote_url" HEAD 2>/dev/null)"; then
+      remote_rc=0
+    else
+      remote_rc=$?
+    fi
+    if [[ "$remote_rc" -eq 124 ]]; then
+      echo "|unknown-remote-timeout"
+      return 0
+    fi
     branch="$(printf '%s\n' "$remote_output" | worktree_parse_remote_head 2>/dev/null || true)"
     if [[ -n "$branch" ]]; then
       printf '%s|remote-HEAD\n' "$branch"

--- a/scripts/tests/worktree-hygiene.test.sh
+++ b/scripts/tests/worktree-hygiene.test.sh
@@ -25,6 +25,7 @@ FAIL=0
 TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS_DIR="$(dirname "$TEST_DIR")"
 RUNBOOK_DOC="$SCRIPTS_DIR/../docs/worktree-hygiene.md"
+GENERATE_ARCHITECTURE_SCRIPT="$SCRIPTS_DIR/generate-architecture.sh"
 
 # shellcheck source=scripts/lib/worktree-hygiene.sh
 # shellcheck disable=SC1091
@@ -224,6 +225,20 @@ mk_repo "$TMP_DIR/default-unsafe-url" main
 git -C "$TMP_DIR/default-unsafe-url" remote add origin "ext::echo should-not-run"
 assert_eq "unsafe helper origin fails closed instead of executing or falling back" \
   "|unknown-unsafe-origin-url" "$(resolve_repo_default_branch "$TMP_DIR/default-unsafe-url" main)"
+
+set +e
+worktree_run_with_timeout 1 sh -c 'sleep 2'
+timeout_rc=$?
+set -e
+assert_eq "bounded remote helper normalizes a hanging command to timeout" "124" "$timeout_rc"
+assert_eq "invalid timeout configuration falls back to a safe bound" "8" \
+  "$(GRIMNIR_WORKTREE_REMOTE_TIMEOUT_SECONDS='bad' worktree_remote_timeout_seconds)"
+
+validate_worktree_block="$(sed -n '/# ─── Worktree hygiene audit/,/# Print results/p' "$GENERATE_ARCHITECTURE_SCRIPT")"
+assert_contains "validate mode uses the per-repository resolver" "$validate_worktree_block" \
+  "resolve_repo_default_branch \"\$wt_repo_dir\""
+assert_not_contains "validate mode does not reuse global main fallback for worktree audit" \
+  "$validate_worktree_block" "audit_repo_worktrees \"\$wt_repo_dir\" \"\$REGISTRY_DEFAULT_BRANCH\""
 
 # ── list_repo_worktrees ────────────────────────────────────────────────────
 mk_repo "$TMP_DIR/wt-repo" main
@@ -546,6 +561,7 @@ mkdir -p "$MAC_ROOT"
 mk_repo "$MAC_ROOT/heimdall" main
 git -C "$MAC_ROOT/heimdall" remote add origin \
   "https://github.com/Magnus-Gille/heimdall.git"
+set_local_origin_head "$MAC_ROOT/heimdall" main
 set +e
 mac_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$MAC_ROOT" GRIMNIR_SERVICES_JSON="$HEIMDALL_AUTHORITY_JSON" \
   "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
@@ -559,6 +575,7 @@ mkdir -p "$CONTROL_ROOT"
 mk_repo "$CONTROL_ROOT/heimdall" main
 git -C "$CONTROL_ROOT/heimdall" remote add origin \
   "https://github.com/Magnus-Gille/heimdall.git"
+set_local_origin_head "$CONTROL_ROOT/heimdall" main
 set +e
 control_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$CONTROL_ROOT" GRIMNIR_SERVICES_JSON="$HEIMDALL_AUTHORITY_JSON" \
   "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"

--- a/scripts/tests/worktree-hygiene.test.sh
+++ b/scripts/tests/worktree-hygiene.test.sh
@@ -177,6 +177,54 @@ mk_repo() {  # $1 = dir, $2 = branch
     git -C "$dir" commit -q -m "seed"
 }
 
+set_local_origin_head() {  # $1 = repo dir, $2 = safe branch name
+  git -C "$1" symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$2"
+}
+
+# ── default-branch resolution (hermetic real-repository fixtures) ──────────
+mk_repo "$TMP_DIR/default-main" main
+git -C "$TMP_DIR/default-main" remote add origin "$TMP_DIR/no-network-needed.git"
+set_local_origin_head "$TMP_DIR/default-main" main
+assert_eq "local origin/HEAD resolves main without a network query" \
+  "main|origin/HEAD" "$(resolve_repo_default_branch "$TMP_DIR/default-main")"
+
+mk_repo "$TMP_DIR/default-master" master
+git -C "$TMP_DIR/default-master" remote add origin "$TMP_DIR/no-network-needed.git"
+set_local_origin_head "$TMP_DIR/default-master" master
+assert_eq "local origin/HEAD resolves master without assuming main" \
+  "master|origin/HEAD" "$(resolve_repo_default_branch "$TMP_DIR/default-master")"
+
+git init -q --bare "$TMP_DIR/default-remote-head.git"
+mk_repo "$TMP_DIR/default-remote-query" master
+git -C "$TMP_DIR/default-remote-query" remote add origin "$TMP_DIR/default-remote-head.git"
+git -C "$TMP_DIR/default-remote-query" push -q origin master
+git -C "$TMP_DIR/default-remote-head.git" symbolic-ref HEAD refs/heads/master
+assert_eq "read-only remote HEAD query resolves master when local origin/HEAD is absent" \
+  "master|remote-HEAD" "$(resolve_repo_default_branch "$TMP_DIR/default-remote-query")"
+
+mk_repo "$TMP_DIR/default-missing" main
+assert_eq "missing origin/HEAD and no fallback fails unknown" \
+  "|unknown-unavailable" "$(resolve_repo_default_branch "$TMP_DIR/default-missing")"
+assert_eq "missing origin/HEAD uses an explicit safe fallback only" \
+  "main|fallback" "$(resolve_repo_default_branch "$TMP_DIR/default-missing" main)"
+
+mk_repo "$TMP_DIR/default-unreachable" master
+git -C "$TMP_DIR/default-unreachable" remote add origin "$TMP_DIR/does-not-exist.git"
+assert_eq "unreachable origin and no fallback fails unknown" \
+  "|unknown-unavailable" "$(resolve_repo_default_branch "$TMP_DIR/default-unreachable")"
+
+mk_repo "$TMP_DIR/default-malicious" main
+git -C "$TMP_DIR/default-malicious" remote add origin "$TMP_DIR/no-network-needed.git"
+git -C "$TMP_DIR/default-malicious" symbolic-ref refs/remotes/origin/HEAD \
+  "refs/remotes/origin/master;not-a-branch"
+assert_eq "malicious origin/HEAD fails closed instead of falling back" \
+  "|unknown-invalid-origin-head" "$(resolve_repo_default_branch "$TMP_DIR/default-malicious" main)"
+
+mk_repo "$TMP_DIR/default-unsafe-url" main
+git -C "$TMP_DIR/default-unsafe-url" remote add origin "ext::echo should-not-run"
+assert_eq "unsafe helper origin fails closed instead of executing or falling back" \
+  "|unknown-unsafe-origin-url" "$(resolve_repo_default_branch "$TMP_DIR/default-unsafe-url" main)"
+
 # ── list_repo_worktrees ────────────────────────────────────────────────────
 mk_repo "$TMP_DIR/wt-repo" main
 git -C "$TMP_DIR/wt-repo" branch feature/done
@@ -354,11 +402,13 @@ mkdir -p "$FIXTURE_ROOT"
 mk_repo "$FIXTURE_ROOT/repo-a" main
 git -C "$FIXTURE_ROOT/repo-a" remote add origin \
   "https://github.com/Magnus-Gille/repo-a.git"
+set_local_origin_head "$FIXTURE_ROOT/repo-a" main
 
 # Repo B: seeds a stale merged worktree AND a dirty worktree, canonical clean.
 mk_repo "$FIXTURE_ROOT/repo-b" main
 git -C "$FIXTURE_ROOT/repo-b" remote add origin \
   "https://github.com/Magnus-Gille/repo-b-private-archive.git"
+set_local_origin_head "$FIXTURE_ROOT/repo-b" main
 git -C "$FIXTURE_ROOT/repo-b" branch feature/merged-b
 git -C "$FIXTURE_ROOT/repo-b" worktree add -q "$TMP_DIR/repo-b-stale" feature/merged-b
 git -C "$FIXTURE_ROOT/repo-b" merge -q --no-ff -m "merge" feature/merged-b
@@ -368,6 +418,8 @@ echo "uncommitted" > "$TMP_DIR/repo-b-dirty/scratch.txt"
 
 # Repo C: canonical checkout itself is dirty AND off the default branch.
 mk_repo "$FIXTURE_ROOT/repo-c" main
+git -C "$FIXTURE_ROOT/repo-c" remote add origin "$TMP_DIR/no-network-needed.git"
+set_local_origin_head "$FIXTURE_ROOT/repo-c" main
 git -C "$FIXTURE_ROOT/repo-c" checkout -q -b task/stray-session
 echo "stray" > "$FIXTURE_ROOT/repo-c/leftover.tmp"
 
@@ -428,6 +480,7 @@ assert_not_contains "CLI origin finding does not expose raw transport URL" \
 assert_not_contains "CLI output never instructs an unconditional delete" "$dirty_output" "rm -rf"
 assert_not_contains "CLI output never mutates a remote" "$dirty_output" "git remote set-url"
 assert_contains "CLI prints a summary line" "$dirty_output" "Summary:"
+assert_contains "CLI names the origin/HEAD default-resolution source" "$dirty_output" "default resolved via origin/HEAD"
 
 # Clean-only fixture root: must report clean and exit 0.
 CLEAN_ROOT="$TMP_DIR/repos-root-clean"
@@ -435,6 +488,7 @@ mkdir -p "$CLEAN_ROOT"
 mk_repo "$CLEAN_ROOT/repo-clean" main
 git -C "$CLEAN_ROOT/repo-clean" remote add origin \
   "https://github.com/Magnus-Gille/repo-clean.git"
+set_local_origin_head "$CLEAN_ROOT/repo-clean" main
 
 CLEAN_SERVICES_JSON="$TMP_DIR/services-clean.json"
 cat > "$CLEAN_SERVICES_JSON" << EOF
@@ -529,6 +583,37 @@ unscoped_step_three_git="$(
     grep -v 'git -C /path/to/checkout' || true
 )"
 assert_eq "runbook ancestry commands never use the operator cwd" "" "$unscoped_step_three_git"
+
+# A clean master repository must not be false-flagged just because another
+# repository in the root happens to use main.
+MASTER_ROOT="$TMP_DIR/repos-root-master"
+mkdir -p "$MASTER_ROOT"
+mk_repo "$MASTER_ROOT/repo-master" master
+git -C "$MASTER_ROOT/repo-master" remote add origin "$TMP_DIR/no-network-needed.git"
+set_local_origin_head "$MASTER_ROOT/repo-master" master
+set +e
+master_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$MASTER_ROOT" GRIMNIR_SERVICES_JSON="$TMP_DIR/no-services.json" \
+  "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
+master_rc=$?
+set -e
+assert_eq "CLI accepts a clean master default branch" "0" "$master_rc"
+assert_contains "CLI reports the resolved master default branch" "$master_output" \
+  "repo-master: master (origin/HEAD)"
+
+# No origin/HEAD plus an unreachable origin is an explicit finding, not an
+# excuse to check out or silently assume a branch.
+UNKNOWN_ROOT="$TMP_DIR/repos-root-unknown"
+mkdir -p "$UNKNOWN_ROOT"
+mk_repo "$UNKNOWN_ROOT/repo-unknown" master
+git -C "$UNKNOWN_ROOT/repo-unknown" remote add origin "$TMP_DIR/no-such-origin.git"
+set +e
+unknown_output="$(GRIMNIR_WORKTREE_AUDIT_ROOT="$UNKNOWN_ROOT" GRIMNIR_SERVICES_JSON="$TMP_DIR/no-services.json" \
+  "$SCRIPTS_DIR/worktree-hygiene-audit.sh" 2>&1)"
+unknown_rc=$?
+set -e
+assert_eq "CLI fails when the default branch cannot be proved" "1" "$unknown_rc"
+assert_contains "CLI reports unresolved default branch" "$unknown_output" "default branch unresolved"
+assert_not_contains "CLI never switches branches while resolving unknown default" "$unknown_output" "git checkout"
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/scripts/worktree-hygiene-audit.sh
+++ b/scripts/worktree-hygiene-audit.sh
@@ -30,7 +30,8 @@
 #
 # Env overrides (mirrors scripts/lib/registry-checkout.sh conventions):
 #   GRIMNIR_WORKTREE_AUDIT_ROOT   repos root to scan (default: $HOME/repos)
-#   GRIMNIR_DEFAULT_BRANCH        default branch name (default: main)
+#   GRIMNIR_DEFAULT_BRANCH        explicit fallback branch when a repository's
+#                                 origin/HEAD cannot be resolved (default: none)
 #   GRIMNIR_SERVICES_JSON         services.json path for the deploy-target
 #                                 check (default: <this repo>/services.json)
 #
@@ -47,7 +48,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/worktree-hygiene.sh"
 
 REPOS_ROOT="${GRIMNIR_WORKTREE_AUDIT_ROOT:-$HOME/repos}"
-DEFAULT_BRANCH="${GRIMNIR_DEFAULT_BRANCH:-main}"
+DEFAULT_BRANCH="${GRIMNIR_DEFAULT_BRANCH:-}"
 SERVICES_JSON="${GRIMNIR_SERVICES_JSON:-$SCRIPT_DIR/../services.json}"
 
 while [[ $# -gt 0 ]]; do
@@ -63,8 +64,14 @@ PASS=0
 ISSUES=0
 OFFENDERS=""
 RECIPES=""
+RESOLUTIONS=""
 
-echo "Worktree Hygiene Audit — root: $REPOS_ROOT (default branch: $DEFAULT_BRANCH)"
+if [[ -n "$DEFAULT_BRANCH" ]]; then
+  default_label="fallback: $DEFAULT_BRANCH"
+else
+  default_label="per repository (origin/HEAD)"
+fi
+echo "Worktree Hygiene Audit — root: $REPOS_ROOT (default branch: $default_label)"
 echo "=============================================================="
 echo ""
 
@@ -80,14 +87,29 @@ for repo_dir in "$REPOS_ROOT"/*/; do
   repo_dir="${repo_dir%/}"
   [[ -d "$repo_dir/.git" ]] || continue
   repo_name="$(basename "$repo_dir")"
+  default_row="$(resolve_repo_default_branch "$repo_dir" "$DEFAULT_BRANCH")"
+  repo_default_branch="${default_row%%|*}"
+  repo_default_source="${default_row#*|}"
+  audit_default_branch="$repo_default_branch"
+  [[ -n "$audit_default_branch" ]] || audit_default_branch="__unknown_default_branch__"
+  if [[ -n "$repo_default_branch" ]]; then
+    RESOLUTIONS+="  - $repo_name: $repo_default_branch ($repo_default_source)\n"
+  else
+    RESOLUTIONS+="  - $repo_name: <unresolved> ($repo_default_source)\n"
+  fi
 
   while IFS='|' read -r w_path w_role w_verdict w_branch; do
     [[ -n "$w_path" ]] || continue
     if [[ "$w_role" == "canonical" ]]; then
-      if [[ "$(registry_checkout_is_alert "$w_verdict")" == "yes" ]]; then
-        detail="$(registry_checkout_detail "$w_verdict" "$DEFAULT_BRANCH")"
+      if [[ -z "$repo_default_branch" ]]; then
+        OFFENDERS+="❌ $repo_name (canonical checkout, $w_path): default branch unresolved ($repo_default_source); refusing to guess\n"
+        RECIPES+="  - $repo_name canonical checkout ($w_path): inspect origin/HEAD and the remote default branch manually. The audit made no checkout or ref changes.\n"
+        ISSUES=$((ISSUES + 1))
+      elif [[ "$(registry_checkout_is_alert "$w_verdict")" == "yes" ]]; then
+        detail="$(registry_checkout_detail "$w_verdict" "$repo_default_branch")"
+        detail+=" (default resolved via $repo_default_source)"
         OFFENDERS+="❌ $repo_name (canonical checkout, $w_path): $detail\n"
-        RECIPES+="  - $repo_name canonical checkout ($w_path): reconcile manually to $DEFAULT_BRANCH — 'git status' / 'git checkout $DEFAULT_BRANCH' / commit or stash, as appropriate. Never auto-fixed. See docs/role-separation.md.\n"
+        RECIPES+="  - $repo_name canonical checkout ($w_path): reconcile manually to $repo_default_branch — 'git status' / 'git checkout $repo_default_branch' / commit or stash, as appropriate. Never auto-fixed. See docs/role-separation.md.\n"
         ISSUES=$((ISSUES + 1))
       else
         PASS=$((PASS + 1))
@@ -104,9 +126,14 @@ for repo_dir in "$REPOS_ROOT"/*/; do
         PASS=$((PASS + 1))
       fi
     fi
-  done < <(audit_repo_worktrees "$repo_dir" "$DEFAULT_BRANCH")
+  done < <(audit_repo_worktrees "$repo_dir" "$audit_default_branch")
 done
 shopt -u nullglob
+
+if [[ -n "$RESOLUTIONS" ]]; then
+  echo "Resolved default branches:"
+  echo -e "$RESOLUTIONS"
+fi
 
 # Canonical-origin authority check (#112). The registry combines component
 # repo names with the explicit GitHub owner/checkout exceptions declared in


### PR DESCRIPTION
Closes #130

## What changed
- Resolve every audited repository default branch from local `origin/HEAD`, then a read-only `ls-remote --symref` query.
- Treat unresolved, invalid, or unsafe remote data as an explicit finding; never fetch, switch branches, or update refs.
- Preserve an opt-in, marked fallback (`--default-branch` / `GRIMNIR_DEFAULT_BRANCH`) only after resolution is unavailable.
- Wire the same behavior into `generate-architecture.sh --validate` and document it.

## Verification
- `bash scripts/tests/worktree-hygiene.test.sh` — 107 passed
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- `make test`
- `git diff --check`

## M5 learning
Bounded M5 `mellum` safety review: `PASS` (ledger delegation `69934dcc-f1bd-4007-883a-76f626cc7d67`, unverified). Root review added the unsafe-transport rejection and exact remote-HEAD fixture afterward.