### PR TITLE
docs(skuld): record trial dates and verified deployment state (#69)

### DIFF
--- a/docs/skuld-trial-decision.md
+++ b/docs/skuld-trial-decision.md
@@ -6,10 +6,20 @@
 
 ## Trial record
 
-- **First successful briefing:** _record when observed_
-- **Day-28 review due:** _first successful briefing + 28 days_
+- **First successful briefing:** 2026-07-11 06:00 CEST
+- **Day-28 review due:** 2026-08-08
 - **Owner:** Magnus
 - **Outcome:** _pending — keep or cut_
+
+> **Verified live 2026-07-25.** Skuld is deployed and running: `skuld.timer` is active in **user
+> scope** on `huginmunin` (`systemctl --user`), last run 2026-07-25 06:01:36 CEST with
+> `Result=success`, `ExecMainStatus=0`, next run 06:03 the following day. `services.json` describes
+> it accurately, including `scope: user`. Dates above are sourced from the component-side ledger at
+> `skuld/docs/TRIAL-EVIDENCE.md`, which is the authoritative record of delivery; this file remains
+> authoritative for the keep/cut decision itself.
+>
+> A system-scope `systemctl` check reports zero units for Skuld and looks like absence. It is not —
+> see grimnir#69, which was filed on exactly that false negative.
 
 For each scheduled day, capture only:
 


### PR DESCRIPTION
Closes the documentation half of #69. **No `services.json` change is needed** — see below.

## What was actually wrong

#69 claims *"Skuld declared deployed in services.json but not installed / never run."* Both halves are false, verified against the host on 2026-07-25:

- `skuld.timer` is **active in user scope** on huginmunin. Last run **2026-07-25 06:01:36 CEST**, `Result=success`, `ExecMainStatus=0`; next run 06:03 tomorrow.
- `services.json` already describes it correctly, including the part that matters: `{"name": "skuld", "type": "timer", "scope": "user"}`, `deploy_path: /home/magnus/repos/skuld` (matches the unit's `WorkingDirectory`), and `port: null` (correct — it is a oneshot timer).

The issue was almost certainly filed on a **system-scope** check. `systemctl list-units 'skuld*'` returns *"0 loaded units listed"* and reads as absence; only `systemctl --user` shows it. I made the same mistake myself before checking both scopes.

## What genuinely was wrong

`docs/skuld-trial-decision.md` still carried unfilled placeholders:

```
- **First successful briefing:** _record when observed_
- **Day-28 review due:** _first successful briefing + 28 days_
```

Because the trial is defined as *"first successful briefing + 28 days"*, a blank start date means **the gate could never come due** — the decision would have drifted indefinitely. The component-side ledger `skuld/docs/TRIAL-EVIDENCE.md` had already recorded them: first briefing **2026-07-11**, review due **2026-08-08**.

This PR fills those in and records the verified deployment state, including the user-scope gotcha so the false negative is not re-derived later.

## Not in scope
- The keep/cut decision itself. The trial is legitimately mid-flight — day 14 of 28, due 2026-08-08.
- `TRIAL-EVIDENCE.md` stopped being appended after 2026-07-13 (3 rows, ~12 scheduled days missing) despite the timer succeeding daily. Filed separately against skuld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)