### PR TITLE
fix(validate): exit status reports audit health, not fleet cleanliness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -75,7 +75,10 @@ test-runtime-state: ## Desired runtime and deployment-state validation (issue #1
 test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene audit (issue #87)
 	@bash scripts/tests/worktree-hygiene.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene ## Run all test suites
+test-validate-exit: ## Unit tests for the audit exit-status contract (findings vs. audit failure)
+	@bash scripts/tests/validate-exit.test.sh
+
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -137,6 +137,15 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   # shellcheck source=scripts/lib/notify.sh
   # shellcheck disable=SC1091
   source "$SCRIPT_DIR/lib/notify.sh"
+  # Exit-status contract: audit success vs. fleet cleanliness are different
+  # questions — see scripts/lib/validate-exit.sh for the rationale.
+  # shellcheck source=scripts/lib/validate-exit.sh
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/lib/validate-exit.sh"
+
+  # Set to a non-empty reason string the moment the audit itself (not a
+  # finding) cannot do its job — see scripts/lib/validate-exit.sh.
+  AUDIT_ERROR=""
 
   # Find Munin token (same logic as main mode)
   if [[ -z "$MUNIN_TOKEN" ]]; then
@@ -161,7 +170,14 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   FAIL=0
   RESULTS=""
 
-  # Read host-aware registry data
+  # Read host-aware registry data. Captured (not piped via process
+  # substitution) so a registry.js failure — malformed services.json, node
+  # crash — is an explicit AUDIT_ERROR instead of silently yielding zero rows
+  # and a false-clean "0 issues" report (issue: exit-status semantics).
+  if ! validate_rows="$(REGISTRY_PATH="$REGISTRY" QUERY=validate node --input-type=commonjs "$REGISTRY_JS")"; then
+    AUDIT_ERROR="cannot read registry ($REGISTRY) via $REGISTRY_JS"
+  fi
+
   while IFS='|' read -r v_name v_host v_port v_repo v_deploy_path v_deploy_mode v_deploy v_runtime_state v_units_json; do
     [[ -z "$v_name" ]] && continue
 
@@ -336,7 +352,7 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
       RESULTS+="✅ $v_name:$STATUS_LINE\n"
       PASS=$((PASS + 1))
     fi
-  done < <(REGISTRY_PATH="$REGISTRY" QUERY=validate node --input-type=commonjs "$REGISTRY_JS")
+  done <<< "$validate_rows"
 
   # ─── Registry checkout integrity (#47) ───────────────────
   # The canonical grimnir checkout on huginmunin is the source every registry
@@ -395,6 +411,9 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
 
   WT_PASS=0
   WT_FAIL=0
+  if [[ ! -d "$REPOS_DIR" ]]; then
+    AUDIT_ERROR="${AUDIT_ERROR:-cannot enumerate worktrees ($REPOS_DIR not found)}"
+  fi
   shopt -s nullglob
   for wt_repo_dir in "$REPOS_DIR"/*/; do
     wt_repo_dir="${wt_repo_dir%/}"
@@ -443,7 +462,19 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   echo "Summary: $PASS ok, $FAIL issues, $WARN warnings"
   echo ""
 
-  # Write to Munin if token available
+  # Severity token for consumers (Munin content, Heimdall) that want a single
+  # field to render rather than re-deriving it from counts.
+  if [[ "$FAIL" -gt 0 ]]; then
+    SEVERITY="issues"
+  elif [[ "$WARN" -gt 0 ]]; then
+    SEVERITY="warnings"
+  else
+    SEVERITY="clean"
+  fi
+
+  # Write to Munin if token available. This IS the reporting channel: whether
+  # findings above actually reach the owner depends on this succeeding, not
+  # on the FAIL count — see scripts/lib/validate-exit.sh.
   VALIDATION_PERSISTED=false
   if [[ -n "$MUNIN_TOKEN" ]]; then
     # Munin helpers (inline — validation mode is self-contained)
@@ -452,6 +483,8 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
     }
 
     validation_content="## Registry Validation — $TIMESTAMP
+
+findings: $FAIL, warnings: $WARN, severity: $SEVERITY
 
 $PASS ok, $FAIL issues, $WARN warnings
 
@@ -477,14 +510,21 @@ $(echo -e "$RESULTS")"
       echo "⚠ Failed to write validation results to Munin"
     fi
 
-    # Also log the event
-    log_payload="$(CONTENT_VAL="Registry validation: $PASS ok, $FAIL issues at $TIMESTAMP" node --input-type=commonjs -e '
+    # Also log the event. Root cause of the historical "Failed to append
+    # validation event to Munin" failure: this namespace was "validation/"
+    # (trailing slash). Munin's write-target grammar rejects trailing/doubled
+    # slashes as ambiguous (confirmed live: {"ok":false,"error":"validation_error",
+    # "message":"Invalid namespace \"validation/\" ... Did you mean \"validation\"?"}).
+    # memory_write's "validation/registry" call above was never affected because
+    # it has no trailing slash — only this memory_log call broke, silently
+    # amputating the one channel meant to carry findings to the owner.
+    log_payload="$(CONTENT_VAL="Registry validation: $PASS ok, $FAIL issues, $WARN warnings at $TIMESTAMP (severity=$SEVERITY)" node --input-type=commonjs -e '
       console.log(JSON.stringify({
         jsonrpc: "2.0", id: 1, method: "tools/call",
         params: {
           name: "memory_log",
           arguments: {
-            namespace: "validation/",
+            namespace: "validation",
             content: process.env.CONTENT_VAL,
             tags: ["validation", "registry", "automated"]
           }
@@ -497,18 +537,24 @@ $(echo -e "$RESULTS")"
     fi
 
     if [[ "$VALIDATION_PERSISTED" == "true" ]]; then
-      echo "📡 Results written to Munin (validation/registry/latest)"
+      echo "📡 Results written to Munin (validation/registry/latest, findings=$FAIL severity=$SEVERITY)"
     fi
   else
     echo "⚠ No Munin token — results printed to stdout only"
   fi
 
-  # A systemd-successful run means both the live checks and their durable
-  # operator-facing record succeeded. Findings remain in stdout/Munin first.
-  if [[ "$FAIL" -gt 0 ]] || [[ "$VALIDATION_PERSISTED" != "true" ]]; then
-    exit 1
-  fi
-  exit 0
+  # ─── Exit contract ─────────────────────────────────────────
+  # Exit status reports whether the AUDIT ran to completion and could report
+  # its findings — NOT whether the fleet is clean. See
+  # scripts/lib/validate-exit.sh for the full rationale and the pure decision
+  # functions under test. A non-zero exit here means systemd should alarm
+  # because the audit itself is broken (couldn't read its inputs, couldn't
+  # enumerate what it needed to check, or couldn't durably report what it
+  # found) — never because it found problems. Findings remain visible in
+  # stdout/journal always, and in Munin whenever the reporting channel above
+  # is healthy.
+  audit_status_line "$FAIL" "$WARN" "$AUDIT_ERROR" "$VALIDATION_PERSISTED"
+  exit "$(audit_exit_code "$AUDIT_ERROR" "$VALIDATION_PERSISTED")"
 fi
 
 # ─── Detect environment (normal mode) ────────────────────────

--- a/scripts/lib/validate-exit.sh
+++ b/scripts/lib/validate-exit.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# validate-exit.sh — the audit exit-status contract.
+#
+# Owner directive (2026-07-25, live evidence from huginmunin):
+#   grimnir-validate ran perfectly and found exactly what it exists to find
+#   (a stale worktree registration, a dirty canonical checkout) — then exited
+#   1 because of those findings. systemd marked the unit `failed`, Heimdall
+#   rendered `status: fail`, and because that had been true for so long,
+#   nobody read it — a genuine crash would look identical. Meanwhile the
+#   REAL reporting channel (appending the validation event to Munin) was
+#   silently broken, so findings could not reach the owner through any
+#   working channel — exit-1-as-alarm had become the de facto channel.
+#
+# Contract:
+#   Exit status must describe whether the AUDIT WORKED, not whether the
+#   fleet is clean.
+#     - 0 when the audit ran to completion, regardless of how many findings
+#       it produced. Findings are data.
+#     - non-zero only when the audit itself could not do its job: it
+#       couldn't read its inputs (e.g. services.json), couldn't enumerate
+#       what it needed to check (e.g. the worktrees directory), or — the
+#       load-bearing case — could not report its findings through a durable
+#       channel.
+#
+# audit_exit_code <audit_error> <reporting_ok>
+#   audit_error   non-empty string describing a structural failure (registry
+#                 unreadable, worktree enumeration failed, precondition
+#                 unmet), or "" when the audit ran cleanly.
+#   reporting_ok  "true" if findings were durably reported (e.g. written AND
+#                 logged to Munin), anything else (including "false" or
+#                 missing) means the reporting channel did not confirm.
+#   Echoes "0" or "1". Deliberately does NOT accept a finding/fail count —
+#   findings must never re-enter the exit decision, on purpose, so a future
+#   call site cannot silently wire them back in.
+audit_exit_code() {
+  local audit_error="${1:-}" reporting_ok="${2:-false}"
+
+  if [[ -n "$audit_error" ]]; then
+    echo "1"
+    return 0
+  fi
+
+  if [[ "$reporting_ok" != "true" ]]; then
+    echo "1"
+    return 0
+  fi
+
+  echo "0"
+}
+
+# audit_status_line <fail_count> <warn_count> <audit_error> <reporting_ok>
+#   Human-readable one-line summary for the script's own stdout/journal
+#   output, so "N findings" (data) and "audit failed" (systemd-alarm-worthy)
+#   are never visually conflated. Mirrors audit_exit_code's decision order.
+audit_status_line() {
+  local fail_count="${1:-0}" warn_count="${2:-0}" audit_error="${3:-}" reporting_ok="${4:-false}"
+
+  if [[ -n "$audit_error" ]]; then
+    echo "AUDIT FAILED: ${audit_error}"
+    return 0
+  fi
+
+  if [[ "$reporting_ok" != "true" ]]; then
+    echo "AUDIT FAILED: findings could not be durably reported"
+    return 0
+  fi
+
+  echo "AUDIT OK: ran to completion — ${fail_count} finding(s), ${warn_count} warning(s)"
+}

--- a/scripts/tests/validate-exit.test.sh
+++ b/scripts/tests/validate-exit.test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# validate-exit.test.sh — unit tests for the audit exit-status contract
+# (owner directive, 2026-07-25: "exit status must describe whether the AUDIT
+# WORKED, not whether the fleet is clean").
+#
+# grimnir-validate's live incident: it found exactly what it exists to find
+# (a stale worktree entry, a dirty verdandi checkout) and exited 1 because of
+# those findings, indistinguishable from a genuine crash. Meanwhile the real
+# reporting channel — appending the validation event to Munin — was silently
+# broken, so findings never reached the owner through any channel except the
+# systemd "failed" state.
+#
+# audit_exit_code/audit_status_line in lib/validate-exit.sh are the pure
+# decision functions extracted from scripts/generate-architecture.sh's
+# --validate mode so this contract is unit-testable without live
+# infrastructure (SSH, Munin, systemd). Deliberately narrow inputs: a finding
+# count is NEVER accepted as an argument, so a future call site cannot
+# accidentally wire findings back into the exit decision.
+#
+# Usage: bash scripts/tests/validate-exit.test.sh
+# Exit codes: 0 = all assertions passed, 1 = at least one failed.
+# Compatible with bash 3.2+ (macOS default).
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+# shellcheck source=scripts/lib/validate-exit.sh
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../lib/validate-exit.sh"
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc — expected '$expected', got '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "validate-exit contract tests"
+echo "============================="
+
+# ── audit_exit_code: findings alone must NEVER cause a non-zero exit ───────
+assert_eq "clean audit, reported -> 0" \
+  "0" "$(audit_exit_code '' true)"
+assert_eq "findings present, reported -> 0 (findings are data, not audit failure)" \
+  "0" "$(audit_exit_code '' true)"
+
+# ── audit_exit_code: reporting-channel failure IS an audit failure ─────────
+assert_eq "clean audit, NOT reported -> 1" \
+  "1" "$(audit_exit_code '' false)"
+assert_eq "no Munin token available -> 1" \
+  "1" "$(audit_exit_code '' unknown)"
+
+# ── audit_exit_code: structural audit failures win regardless of reporting ─
+assert_eq "registry unreadable -> 1 even if reporting is ok" \
+  "1" "$(audit_exit_code 'registry unreadable' true)"
+assert_eq "worktree enumeration failed -> 1" \
+  "1" "$(audit_exit_code 'cannot enumerate worktrees' true)"
+
+# ── audit_exit_code: strict-mode contract, must not crash on missing args ──
+assert_eq "no-arg call -> 1 (fail closed)" \
+  "1" "$(audit_exit_code)"
+
+# ── audit_status_line: human-readable line distinguishes findings from failure ─
+assert_eq "ok line names the finding/warning counts, not pass/fail language" \
+  "AUDIT OK: ran to completion — 2 finding(s), 0 warning(s)" \
+  "$(audit_status_line 2 0 '' true)"
+assert_eq "ok line with warnings too" \
+  "AUDIT OK: ran to completion — 0 finding(s), 1 warning(s)" \
+  "$(audit_status_line 0 1 '' true)"
+assert_eq "reporting-channel failure line is explicit, not a finding count" \
+  "AUDIT FAILED: findings could not be durably reported" \
+  "$(audit_status_line 2 0 '' false)"
+assert_eq "structural failure line carries the reason" \
+  "AUDIT FAILED: registry unreadable" \
+  "$(audit_status_line 0 0 'registry unreadable' true)"
+assert_eq "structural failure wins over reporting status in the message" \
+  "AUDIT FAILED: registry unreadable" \
+  "$(audit_status_line 0 0 'registry unreadable' false)"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Root cause fix**: `scripts/generate-architecture.sh --validate` mode's `memory_log` call used namespace `"validation/"` (trailing slash). Munin's write-target grammar now rejects trailing/doubled slashes as ambiguous. Confirmed live against the production server:
  ```
  {"ok":false,"error":"validation_error","message":"Invalid namespace \"validation/\" ...
  Did you mean \"validation\"?"}
  ```
  The sibling `memory_write` call (`"validation/registry"`, no trailing slash) was never affected — that's why the *state write* always succeeded while the *log append* silently failed every run, amputating the one channel meant to carry findings to the owner.

- **Exit-status contract implemented** per owner directive: exit status now describes whether the AUDIT WORKED, not whether the fleet is clean.
  - Exit **0** whenever the audit runs to completion, no matter how many findings it produces. Findings are data.
  - Exit **non-zero** only when the audit itself couldn't do its job: registry unreadable, worktree enumeration impossible, or — the load-bearing case — findings couldn't be durably reported.
  - Decision logic extracted to `scripts/lib/validate-exit.sh` (`audit_exit_code` / `audit_status_line`), pure and unit-tested, deliberately never accepting a finding count as an argument so a future call site can't wire findings back into the exit decision.

- **Findings stay visible.** Every run still prints full results to stdout/journal. When the reporting channel is healthy, `validation/registry/latest` in Munin now carries an explicit `findings: N, warnings: N, severity: clean|warnings|issues` line plus the full per-component detail — this is what a Heimdall consumer reads to render "N findings" instead of "service failed".

- **security-scan.sh audited for the same conflation — does not have it.** Its existing exit logic (`SCAN_COMPLETE` + `WRITE_FAILURES` only) already treats finding severity as data; `security-scan-completeness.test.sh` already asserts exit 0 on a `high` finding. No change needed there.

## Live verification (huginmunin, read-only reproduction + real fix run)

Before fix — reproduced the exact live symptom:
```
Summary: 15 ok, 2 issues, 0 warnings
⚠ Failed to append validation event to Munin
EXIT_CODE=1
```

After fix — same fleet state, findings intact, exit 0, and the Munin log append that used to fail now lands (verified by reading it back via `memory_query`):
```
Summary: 15 ok, 2 issues, 0 warnings
📡 Results written to Munin (validation/registry/latest, findings=2 severity=issues)
AUDIT OK: ran to completion — 2 finding(s), 0 warning(s)
EXIT_CODE=0
```

The two findings (verdandi dirty checkout / deploy-target-role drift, munin-memory deploy marker) are real, pre-existing, and unrelated to this fix — they remain flagged, not loosened.

## No systemd unit change needed

Exit 0 now correctly maps to systemd `success` for "audit ran, here are N findings" — the default `SuccessExitStatus` semantics already match the new contract. No `grimnir-validate.service` edit required.

## Test plan

- [x] `make test` — 129/129 passed (117 pre-existing + 12 new in `test-validate-exit`)
- [x] `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh` — clean, 0 issues
- [x] Red/green: `scripts/tests/validate-exit.test.sh` first run failed with `No such file or directory` (lib didn't exist yet) before `scripts/lib/validate-exit.sh` was implemented
- [x] Live reproduction of the original bug and live verification of the fix on huginmunin (see above), including reading the persisted Munin log entry back to confirm it landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)