### PR TITLE
fix(deploy): refuse a byte-for-byte unit whose target contradicts deploy_path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -42,6 +42,9 @@ test-deploy-persistent-paths: ## Fail closed before rsync can delete an in-targe
 test-deploy-systemd-render: ## Render and preflight host-specific systemd runtime identity (issue #107)
 	@bash scripts/tests/deploy-systemd-render.test.sh
 
+test-deploy-unit-target-guard: ## Fail closed before restart when a unit's WorkingDirectory/EnvironmentFile contradicts deploy_path (issue #146)
+	@bash scripts/tests/deploy-unit-target-guard.test.sh
+
 test-failure-recovery-doc: ## Regression test: assert docs/failure-recovery.md defines the undo convention (issue #46)
 	@bash tests/scripts/test-failure-recovery-doc.sh
 
@@ -78,7 +81,7 @@ test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene a
 test-validate-exit: ## Unit tests for the audit exit-status contract (findings vs. audit failure)
 	@bash scripts/tests/validate-exit.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -137,6 +137,19 @@ set use `scripts/guarded-deploy.sh` for the same outer identity boundary; see
   or boundary health later fails, restore the host-local snapshots and verify the same controller
   and health gates before restoring the captured prior marker. See
   [`systemd-runtime-rendering.md`](systemd-runtime-rendering.md#rollback).
+- **Byte-for-byte ("install-ready") systemd units** (the majority of the fleet — components without
+  a `systemd_runtime` block): before any install, the deployer refuses to proceed if a unit's
+  `WorkingDirectory` or `EnvironmentFile` does not resolve under the component's registry
+  `deploy_path` — a deploy that rsyncs code to one path and points systemd at another must never
+  reach a stop/restart (issue #146; this is precisely the shape of the 2026-07-25 munin-memory
+  outage, where `services.json` said `/home/magnus/munin-memory` and the owning repo's unit said
+  `/srv/grimnir/munin-memory`). Once that agrees, and immediately before the subsequent install, the
+  deployer preflights the unit's declared `User=` (system scope only) and every `EnvironmentFile=`
+  for presence on the target, then — if a unit is already installed at the destination — copies it to
+  `<destination>.bak.<UTC timestamp>` and prints the backup path before overwriting. Any of these
+  checks failing aborts before daemon-reload, stop, or restart, and the deployment stays markerless.
+  Reversal recipe: restore the printed `.bak.<timestamp>` file to `<destination>`, `daemon-reload`,
+  and redeploy the previously captured `.deployed-commit` SHA.
 
 ### Auto dependency bumps
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -277,8 +277,8 @@ unit_rows() {
 }
 
 preflight_local_unit_sources() {
-  local local_path=$1 units_json=$2 fallback_name=$3 fallback_type=$4 fallback_scope=$5 render_enabled=${6:-false}
-  local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file
+  local local_path=$1 units_json=$2 fallback_name=$3 fallback_type=$4 fallback_scope=$5 render_enabled=${6:-false} deploy_path=${7:-}
+  local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file source
 
   rows="$(unit_rows "$units_json" "$fallback_name" "$fallback_type" "$fallback_scope")"
   while IFS='|' read -r unit_name unit_kind unit_actual_scope unit_timer_semantics; do
@@ -287,13 +287,44 @@ preflight_local_unit_sources() {
     if ! preflight_local_install_ready_unit_source "$local_path" "$unit_file" true "$render_enabled"; then
       return 1
     fi
+    # Byte-for-byte units carry literal WorkingDirectory/EnvironmentFile
+    # paths (render_enabled units use <deploy-path>/<home> placeholders
+    # resolved and validated at render time instead). Refuse before any
+    # remote call when either contradicts this component's deploy_path
+    # (issue #146).
+    if [[ "$render_enabled" != "true" ]] && source=$(resolve_local_unit_source "$local_path" "$unit_file"); then
+      if ! preflight_unit_target_containment "$source" "$unit_file" "$deploy_path" "$fallback_name"; then
+        return 1
+      fi
+    fi
     if [[ "$unit_kind" == "timer" ]]; then
       companion_file="${unit_name}.service"
       if ! preflight_local_install_ready_unit_source "$local_path" "$companion_file" false "$render_enabled"; then
         return 1
       fi
+      if [[ "$render_enabled" != "true" ]] && source=$(resolve_local_unit_source "$local_path" "$companion_file"); then
+        if ! preflight_unit_target_containment "$source" "$companion_file" "$deploy_path" "$fallback_name"; then
+          return 1
+        fi
+      fi
     fi
   done <<< "$rows"
+}
+
+# Build the remote User/EnvironmentFile preflight + pre-overwrite backup
+# fragment for one byte-for-byte unit source (see
+# prepare_unit_target_preflight_and_backup_command). Returns empty when the
+# unit has no local source (an absent optional timer companion): rsync
+# mirrors deletions and git-pull mode pulls the identical commit, so remote
+# presence always matches local presence and there is nothing to guard.
+build_unit_target_guard() {
+  local local_path=$1 unit_file=$2 privileged=$3
+  local source WORKING_DIRECTORY ENV_FILES UNIT_USER
+
+  source=$(resolve_local_unit_source "$local_path" "$unit_file") || return 0
+  read_unit_service_directives "$source"
+  prepare_unit_target_preflight_and_backup_command "$privileged" "$unit_file" "$UNIT_USER" \
+    "${ENV_FILES[@]+"${ENV_FILES[@]}"}"
 }
 
 health_path_rows() {
@@ -428,15 +459,20 @@ deploy_service() {
     fi
     dirty_state="clean"
     echo "Source: ${local_path} (${branch} @ ${commit}, ${dirty_state})"
+  fi
 
-    # Central deploy installs declared units byte-for-byte. Reject a missing
-    # source or a component-owned template before build, marker invalidation,
-    # host resolution, or any remote mutation.
-    if ! preflight_local_unit_sources "$local_path" "$units_json" "$name" "$unit_type" "$unit_scope" "$render_enabled"; then
-      results+=("${RED}✗${NC} ${name}")
-      fail=$((fail + 1))
-      return
-    fi
+  # Central deploy installs declared units byte-for-byte. Reject a missing
+  # source, a component-owned template, or a unit whose WorkingDirectory /
+  # EnvironmentFile contradicts this component's registry deploy_path --
+  # before build, marker invalidation, host resolution, or any remote
+  # mutation, in both deploy modes. This is the ordering fix for issue #146:
+  # the incident stopped a healthy service and only then discovered the
+  # rsync-target vs. unit-target contradiction; the same check now runs
+  # before either target is ever touched.
+  if ! preflight_local_unit_sources "$local_path" "$units_json" "$name" "$unit_type" "$unit_scope" "$render_enabled" "$deploy_path"; then
+    results+=("${RED}✗${NC} ${name}")
+    fail=$((fail + 1))
+    return
   fi
 
   if ! remote_host=$(resolve_host "$host"); then
@@ -566,6 +602,7 @@ deploy_service() {
   local rows unit_name unit_kind unit_actual_scope unit_timer_semantics unit_file companion_file
   local timer_entry timer_name timer_semantics timer_next_check
   local q_unit_src q_unit_root q_user_dest q_system_dest q_unit_label unit_guard companion_guard
+  local unit_target_guard companion_target_guard
   local user_needs_reload=false system_needs_reload=false
   local user_services=() system_services=() user_timers=() system_timers=()
 
@@ -584,8 +621,11 @@ deploy_service() {
         cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
         cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
         unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
+        unit_target_guard=$(build_unit_target_guard "$local_path" "$unit_file" false)
         cmd+="${unit_guard} && "
-        cmd+="install -D -m644 \"\$unit_src\" \"\$HOME\"/${q_user_dest} && "
+        cmd+="dest=\"\$HOME\"/${q_user_dest} && "
+        cmd+="${unit_target_guard}"
+        cmd+="install -D -m644 \"\$unit_src\" \"\$dest\" && "
       fi
       user_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
@@ -596,9 +636,10 @@ deploy_service() {
           q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
           q_unit_root=$(posix_shell_quote "$companion_file")
           q_user_dest=$(posix_shell_quote ".config/systemd/user/${companion_file}")
+          companion_target_guard=$(build_unit_target_guard "$local_path" "$companion_file" false)
           cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
           companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
-          cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && install -D -m644 \"\$companion_src\" \"\$HOME\"/${q_user_dest}; fi && "
+          cmd+="if [ -n \"\$companion_src\" ]; then dest=\"\$HOME\"/${q_user_dest} && ${companion_guard} && ${companion_target_guard}install -D -m644 \"\$companion_src\" \"\$dest\"; fi && "
         fi
         user_timers+=("${unit_name}|${unit_timer_semantics}")
       fi
@@ -607,8 +648,11 @@ deploy_service() {
         cmd+="unit_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && unit_src=\"\$f\" && break; done; "
         cmd+="[ -n \"\$unit_src\" ] || { printf 'ERROR: unit file missing: %s\\n' ${q_unit_label} >&2; exit 1; }; "
         unit_guard=$(prepare_remote_install_ready_unit_check_command unit_src "$unit_file")
+        unit_target_guard=$(build_unit_target_guard "$local_path" "$unit_file" true)
         cmd+="${unit_guard} && "
-        cmd+="sudo install -D -m644 \"\$unit_src\" ${q_system_dest} && "
+        cmd+="dest=${q_system_dest} && "
+        cmd+="${unit_target_guard}"
+        cmd+="sudo install -D -m644 \"\$unit_src\" \"\$dest\" && "
       fi
       system_needs_reload=true
       if [[ "$unit_kind" == "service" ]]; then
@@ -619,9 +663,10 @@ deploy_service() {
           q_unit_src=$(posix_shell_quote "systemd/${companion_file}")
           q_unit_root=$(posix_shell_quote "$companion_file")
           q_system_dest=$(posix_shell_quote "/etc/systemd/system/${companion_file}")
+          companion_target_guard=$(build_unit_target_guard "$local_path" "$companion_file" true)
           cmd+="companion_src=''; for f in ${q_unit_src} ${q_unit_root}; do [ -f \"\$f\" ] && companion_src=\"\$f\" && break; done; "
           companion_guard=$(prepare_remote_install_ready_unit_check_command companion_src "$companion_file")
-          cmd+="if [ -n \"\$companion_src\" ]; then ${companion_guard} && sudo install -D -m644 \"\$companion_src\" ${q_system_dest}; fi && "
+          cmd+="if [ -n \"\$companion_src\" ]; then dest=${q_system_dest} && ${companion_guard} && ${companion_target_guard}sudo install -D -m644 \"\$companion_src\" \"\$dest\"; fi && "
         fi
         system_timers+=("${unit_name}|${unit_timer_semantics}")
       fi

--- a/scripts/lib/deploy-safety.sh
+++ b/scripts/lib/deploy-safety.sh
@@ -77,6 +77,153 @@ prepare_remote_install_ready_unit_check_command() {
     "$source_var" "$source_var" "$quoted_label" "$source_var"
 }
 
+# Extract the directives a byte-for-byte unit's [Service] section declares
+# that matter for issue #146 (the deploy that rsynced code to one path and
+# installed a unit pointing systemd at another, then restarted a healthy
+# service into a broken one). Prints exactly:
+#   line 1:            the last WorkingDirectory= value, or empty
+#   0+ following lines: "ENV:<value>" for each EnvironmentFile= value, in
+#                       declaration order, with a leading "-" (systemd's
+#                       "optional file" marker) stripped
+#   last line:          "USER:<value>", the last User= value, or "USER:"
+# Only [Service] is inspected; [Unit]/[Install]/[Timer] directives are
+# irrelevant to WorkingDirectory/EnvironmentFile/User semantics.
+unit_service_directives() {
+  local source=$1
+  SOURCE_PATH="$source" node --input-type=commonjs -e '
+    var fs = require("fs");
+    var text = fs.readFileSync(process.env.SOURCE_PATH, "utf8");
+    var section = "";
+    var workingDirectory = "";
+    var user = "";
+    var environmentFiles = [];
+    text.split(/\r?\n/).forEach(function (raw) {
+      var line = raw.trim();
+      if (!line || line[0] === "#" || line[0] === ";") return;
+      var sectionMatch = line.match(/^\[([A-Za-z]+)\]$/);
+      if (sectionMatch) { section = sectionMatch[1]; return; }
+      if (section !== "Service") return;
+      var equals = line.indexOf("=");
+      if (equals < 1) return;
+      var key = line.slice(0, equals).trim();
+      var value = line.slice(equals + 1).trim();
+      if (key === "WorkingDirectory") {
+        workingDirectory = value;
+      } else if (key === "User") {
+        user = value;
+      } else if (key === "EnvironmentFile") {
+        value.split(/\s+/).forEach(function (token) {
+          if (!token) return;
+          if (token[0] === "-") token = token.slice(1);
+          environmentFiles.push(token);
+        });
+      }
+    });
+    process.stdout.write(workingDirectory + "\n");
+    environmentFiles.forEach(function (file) { process.stdout.write("ENV:" + file + "\n"); });
+    process.stdout.write("USER:" + user + "\n");
+  '
+}
+
+# Parse unit_service_directives output (see above) into the caller's
+# variables: WORKING_DIRECTORY (string), ENV_FILES (array), UNIT_USER
+# (string). Bash has no multi-value return, so callers source this into their
+# own locals via the printed lines.
+read_unit_service_directives() {
+  local source=$1 line first=true
+  WORKING_DIRECTORY=""
+  ENV_FILES=()
+  UNIT_USER=""
+  while IFS= read -r line; do
+    if $first; then
+      WORKING_DIRECTORY=$line
+      first=false
+    elif [[ "$line" == ENV:* ]]; then
+      ENV_FILES+=("${line#ENV:}")
+    elif [[ "$line" == USER:* ]]; then
+      UNIT_USER="${line#USER:}"
+    fi
+  done < <(unit_service_directives "$source")
+}
+
+# A byte-for-byte unit's WorkingDirectory/EnvironmentFile are literal paths
+# (unlike render_enabled units, which use <deploy-path>/<home> placeholders
+# resolved and validated against the registry at render time). Refuse a
+# deploy before ANY remote call -- before host resolution, marker
+# invalidation, build, or rsync -- when either directive does not resolve
+# under this component's registry deploy_path. This is the exact munin-memory
+# incident (issue #146): services.json said deploy_path=/home/magnus/munin-
+# memory, the owning repo's unit said WorkingDirectory=/srv/grimnir/munin-
+# memory, and nothing refused the contradiction before systemd was told to
+# restart into a path that did not exist on the host.
+preflight_unit_target_containment() {
+  local source=$1 unit_file=$2 deploy_path=$3 component=$4
+  local WORKING_DIRECTORY ENV_FILES env_file
+  # shellcheck disable=SC2034 # set by read_unit_service_directives; User= is not a path, unused here
+  local UNIT_USER
+
+  read_unit_service_directives "$source"
+
+  if [[ -n "$WORKING_DIRECTORY" && "$WORKING_DIRECTORY" == /* ]] &&
+     [[ "$WORKING_DIRECTORY" != "$deploy_path" && "$WORKING_DIRECTORY" != "$deploy_path"/* ]]; then
+    printf 'ERROR: unit %s (component %s) declares WorkingDirectory=%s, which does not resolve under the registry deploy_path %s. A deploy that rsyncs code to %s and installs a unit pointing at %s must never restart the service -- reconcile services.json and the unit before redeploying (issue #146).\n' \
+      "$unit_file" "$component" "$WORKING_DIRECTORY" "$deploy_path" "$deploy_path" "$WORKING_DIRECTORY" >&2
+    return 1
+  fi
+
+  for env_file in "${ENV_FILES[@]+"${ENV_FILES[@]}"}"; do
+    if [[ "$env_file" == /* ]] &&
+       [[ "$env_file" != "$deploy_path" && "$env_file" != "$deploy_path"/* ]]; then
+      printf 'ERROR: unit %s (component %s) declares EnvironmentFile=%s, which does not resolve under the registry deploy_path %s. A deploy that rsyncs code to %s and installs a unit pointing at %s must never restart the service -- reconcile services.json and the unit before redeploying (issue #146).\n' \
+        "$unit_file" "$component" "$env_file" "$deploy_path" "$deploy_path" "$env_file" >&2
+      return 1
+    fi
+  done
+}
+
+# Build the remote-shell fragment that runs immediately before a byte-for-
+# byte unit is installed: preflight the declared User (system scope only --
+# a user-scope unit already runs as the deploying account, so User= there is
+# not a privilege boundary) and every declared EnvironmentFile, then back up
+# whatever unit is currently at $dest (a remote-shell variable the caller
+# must set before splicing this fragment in) to a predictable, timestamped
+# path and print it. The returned fragment ends in "&& " so callers chain it
+# directly ahead of the install command. All three checks -- and the backup
+# -- run strictly before install, which runs strictly before daemon-reload
+# and restart, so a violation or missing dependency never stops a running
+# service (issue #146).
+prepare_unit_target_preflight_and_backup_command() {
+  local privileged=$1 unit_file=$2 user=$3
+  shift 3
+  local env_files=("$@")
+  local sudo_prefix='' env_file q_check fail_msg
+
+  [[ "$privileged" == "true" ]] && sudo_prefix='sudo '
+
+  if [[ "$privileged" == "true" && -n "$user" ]]; then
+    q_check=$(posix_shell_quote "$user")
+    fail_msg=$(posix_shell_quote "ERROR: unit ${unit_file} declares User=${user} which does not exist on the deploy target")
+    printf 'getent passwd %s >/dev/null || { echo %s >&2; exit 1; }; ' "$q_check" "$fail_msg"
+  fi
+
+  for env_file in "${env_files[@]+"${env_files[@]}"}"; do
+    [[ -n "$env_file" ]] || continue
+    q_check=$(posix_shell_quote "$env_file")
+    fail_msg=$(posix_shell_quote "ERROR: unit ${unit_file} requires EnvironmentFile=${env_file} which is not present on the deploy target")
+    printf '[ -f %s ] || { echo %s >&2; exit 1; }; ' "$q_check" "$fail_msg"
+  done
+
+  fail_msg=$(posix_shell_quote "ERROR: failed to back up existing unit ${unit_file} before install")
+  # shellcheck disable=SC2016 # $dest/$backup/$(date ...) expand on the remote host, not now
+  printf '%s' "if ${sudo_prefix}test -f \"\$dest\"; then "
+  # shellcheck disable=SC2016 # $dest/$(date ...) expand on the remote host, not now
+  printf '%s' 'backup="$dest.bak.$(date -u +%Y%m%dT%H%M%SZ)"; '
+  printf '%s' "${sudo_prefix}cp -p -- \"\$dest\" \"\$backup\" || { echo ${fail_msg} >&2; exit 1; }; "
+  # shellcheck disable=SC2016 # $dest/$backup expand on the remote host, not now
+  printf '%s' 'echo "Backed up prior unit: $dest -> $backup"; '
+  printf '%s' 'fi && '
+}
+
 # Rsync deployments are release directories, never Git checkouts. Remove any
 # stale repository metadata before syncing: `.git` can be either a directory or
 # a worktree pointer file, and leaving the latter can point the Pi at a path

--- a/scripts/tests/deploy-unit-target-guard.test.sh
+++ b/scripts/tests/deploy-unit-target-guard.test.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #146: a deploy that rsyncs code to the
+# registry's deploy_path but installs a systemd unit whose WorkingDirectory /
+# EnvironmentFile point somewhere else must abort BEFORE any service is
+# stopped -- never restart into a broken unit. This is the exact shape that
+# took munin-memory down for ~10 minutes on 2026-07-25: services.json said
+# deploy_path=/home/magnus/munin-memory, the owning repo's byte-for-byte unit
+# said WorkingDirectory=/srv/grimnir/munin-memory, and nothing reconciled the
+# two before systemd was told to restart into a path that did not exist.
+#
+# Also covers the companion remote preflight (declared User= exists,
+# EnvironmentFile is present) and the pre-overwrite unit backup, both of
+# which must sit strictly before the install/reload/restart chain.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY="$SCRIPT_DIR/../deploy.sh"
+# shellcheck source=scripts/lib/deploy-safety.sh
+source "$SCRIPT_DIR/../lib/deploy-safety.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+commit_fixture_repo() {
+  local repo_path=$1
+  git init -q -b main "$repo_path"
+  git -C "$repo_path" add .
+  GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t \
+    git -C "$repo_path" commit -q -m seed
+}
+
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/repos"
+
+cat > "$TMP_DIR/bin/ssh" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SSH_CAPTURE"
+command=${*: -1}
+if [[ "$command" == *"DEPLOY_MARKER_INVALIDATED"* ]]; then
+  echo "DEPLOY_MARKER_INVALIDATED:unknown"
+elif [[ "$command" == *"DEPLOY_OK"* ]]; then
+  echo "DEPLOY_OK"
+fi
+exit 0
+EOF
+
+cat > "$TMP_DIR/bin/rsync" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$RSYNC_CAPTURE"
+exit 0
+EOF
+
+cat > "$TMP_DIR/bin/npm" << 'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "$TMP_DIR/bin/ssh" "$TMP_DIR/bin/rsync" "$TMP_DIR/bin/npm"
+
+SSH_CAPTURE="$TMP_DIR/ssh.calls"
+RSYNC_CAPTURE="$TMP_DIR/rsync.args"
+export SSH_CAPTURE RSYNC_CAPTURE
+
+# ---------------------------------------------------------------------------
+# Part 1: the exact munin-memory case. Registry deploy_path is a "pre-
+# relocation" host path; the owning repo's unit is "post-relocation". The
+# deploy must refuse before any remote call at all.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$TMP_DIR/repos/munin-memory/systemd"
+cat > "$TMP_DIR/repos/munin-memory/systemd/munin-memory.service" << 'EOF'
+[Unit]
+Description=Munin Memory MCP Server
+
+[Service]
+Type=simple
+User=grimnir
+WorkingDirectory=/srv/grimnir/munin-memory
+ExecStart=/usr/bin/node dist/index.js
+EnvironmentFile=/srv/grimnir/munin-memory/.env
+
+[Install]
+WantedBy=multi-user.target
+EOF
+printf '%s\n' '{"name":"munin-memory"}' > "$TMP_DIR/repos/munin-memory/package.json"
+commit_fixture_repo "$TMP_DIR/repos/munin-memory"
+MUNIN_SHA=$(git -C "$TMP_DIR/repos/munin-memory" rev-parse HEAD)
+
+cat > "$TMP_DIR/munin-registry.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "munin-memory", "repo": "munin-memory", "host": "h1", "port": 3030,
+      "deploy": true, "scan": false, "deploy_path": "/home/magnus/munin-memory",
+      "persistent_paths": [], "needs_build": true,
+      "systemd_units": [{ "name": "munin-memory", "type": "service" }]
+    }
+  ]
+}
+EOF
+
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+rc=0
+REGISTRY_PATH="$TMP_DIR/munin-registry.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+  PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "munin-memory=$TMP_DIR/repos/munin-memory@$MUNIN_SHA" \
+    >"$TMP_DIR/munin-reject.out" 2>&1 || rc=$?
+
+if [[ "$rc" != 0 ]]; then
+  pass "munin-memory-shaped WorkingDirectory/deploy_path contradiction: deploy fails"
+else
+  fail "munin-memory-shaped WorkingDirectory/deploy_path contradiction: deploy must fail"
+fi
+if [[ ! -e "$SSH_CAPTURE" && ! -e "$RSYNC_CAPTURE" ]]; then
+  pass "munin-memory-shaped contradiction: invokes neither ssh nor rsync (no service was ever touched)"
+else
+  fail "munin-memory-shaped contradiction: must invoke neither ssh nor rsync -- a live service must never be stopped on the way to discovering this"
+  sed -n '1,80p' "$TMP_DIR/munin-reject.out"
+fi
+if grep -Fq -- "WorkingDirectory=/srv/grimnir/munin-memory" "$TMP_DIR/munin-reject.out" &&
+   grep -Fq -- "/home/magnus/munin-memory" "$TMP_DIR/munin-reject.out"; then
+  pass "munin-memory-shaped contradiction: diagnostic names both the unit path and the registry deploy_path"
+else
+  fail "munin-memory-shaped contradiction: diagnostic must name both the unit's WorkingDirectory and the registry deploy_path"
+  sed -n '1,80p' "$TMP_DIR/munin-reject.out"
+fi
+
+# ---------------------------------------------------------------------------
+# Part 2: EnvironmentFile-only contradiction (WorkingDirectory correct, but
+# EnvironmentFile resolves outside deploy_path) must also be caught.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$TMP_DIR/repos/env-mismatch/systemd"
+cat > "$TMP_DIR/repos/env-mismatch/systemd/alpha.service" << 'EOF'
+[Service]
+Type=simple
+WorkingDirectory=/srv/alpha
+ExecStart=/usr/bin/node dist/index.js
+EnvironmentFile=/etc/alpha/.env
+EOF
+printf '%s\n' '{"name":"alpha"}' > "$TMP_DIR/repos/env-mismatch/package.json"
+commit_fixture_repo "$TMP_DIR/repos/env-mismatch"
+ENV_SHA=$(git -C "$TMP_DIR/repos/env-mismatch" rev-parse HEAD)
+
+cat > "$TMP_DIR/env-mismatch-registry.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "env-mismatch", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+rc=0
+REGISTRY_PATH="$TMP_DIR/env-mismatch-registry.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+  PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "alpha=$TMP_DIR/repos/env-mismatch@$ENV_SHA" \
+    >"$TMP_DIR/env-reject.out" 2>&1 || rc=$?
+
+if [[ "$rc" != 0 && ! -e "$SSH_CAPTURE" && ! -e "$RSYNC_CAPTURE" ]]; then
+  pass "EnvironmentFile-only contradiction fails before any remote call"
+else
+  fail "EnvironmentFile-only contradiction must fail before any remote call"
+fi
+if grep -Fq -- "EnvironmentFile=/etc/alpha/.env" "$TMP_DIR/env-reject.out" &&
+   grep -Fq -- "/srv/alpha" "$TMP_DIR/env-reject.out"; then
+  pass "EnvironmentFile-only contradiction names both the unit path and the registry deploy_path"
+else
+  fail "EnvironmentFile-only contradiction must name both paths"
+  sed -n '1,80p' "$TMP_DIR/env-reject.out"
+fi
+
+# ---------------------------------------------------------------------------
+# Part 3: a consistent unit (WorkingDirectory/EnvironmentFile genuinely under
+# deploy_path) must not be rejected by the new guard.
+# ---------------------------------------------------------------------------
+
+mkdir -p "$TMP_DIR/repos/consistent/systemd"
+cat > "$TMP_DIR/repos/consistent/systemd/alpha.service" << 'EOF'
+[Service]
+Type=simple
+User=magnus
+WorkingDirectory=/srv/alpha
+ExecStart=/usr/bin/node dist/index.js
+EnvironmentFile=/srv/alpha/.env
+EOF
+printf '%s\n' '{"name":"alpha"}' > "$TMP_DIR/repos/consistent/package.json"
+commit_fixture_repo "$TMP_DIR/repos/consistent"
+CONSISTENT_SHA=$(git -C "$TMP_DIR/repos/consistent" rev-parse HEAD)
+
+cat > "$TMP_DIR/consistent-registry.json" << 'EOF'
+{
+  "components": [
+    {
+      "name": "alpha", "repo": "consistent", "host": "h1", "port": null,
+      "deploy": true, "scan": false, "deploy_path": "/srv/alpha",
+      "persistent_paths": [], "needs_build": false,
+      "systemd_units": [{ "name": "alpha", "type": "service" }]
+    }
+  ]
+}
+EOF
+
+rm -f "$SSH_CAPTURE" "$RSYNC_CAPTURE"
+rc=0
+REGISTRY_PATH="$TMP_DIR/consistent-registry.json" LOCAL_REPOS_ROOT="$TMP_DIR/repos" \
+  PATH="$TMP_DIR/bin:$PATH" bash "$DEPLOY" "alpha=$TMP_DIR/repos/consistent@$CONSISTENT_SHA" \
+    >"$TMP_DIR/consistent.out" 2>&1 || rc=$?
+
+if [[ "$rc" == 0 ]]; then
+  pass "consistent WorkingDirectory/EnvironmentFile under deploy_path is not rejected by the new guard"
+else
+  fail "consistent WorkingDirectory/EnvironmentFile under deploy_path must not be rejected"
+  sed -n '1,120p' "$TMP_DIR/consistent.out"
+fi
+
+# The remote install/backup/restart chain for the consistent case must place
+# the User/EnvironmentFile preflight and the pre-overwrite backup strictly
+# before install, and install strictly before daemon-reload/restart.
+final_call="$(grep -F 'DEPLOY_OK' "$SSH_CAPTURE" | tail -1)"
+case "$final_call" in
+  *"getent passwd 'magnus'"*"install -D -m644"*"daemon-reload"*"restart"*)
+    pass "remote User= preflight precedes install, which precedes reload/restart"
+    ;;
+  *)
+    fail "remote User= preflight must precede install, which must precede reload/restart"
+    printf '%s\n' "$final_call"
+    ;;
+esac
+case "$final_call" in
+  *"test -f \"\$dest\""*"install -D -m644"*)
+    pass "pre-overwrite backup check precedes install"
+    ;;
+  *)
+    fail "pre-overwrite backup check must precede install"
+    printf '%s\n' "$final_call"
+    ;;
+esac
+# shellcheck disable=SC2016 # literal remote-shell fragment expected in capture
+if grep -Fq -- '.bak.$(date -u +%Y%m%dT%H%M%SZ)' "$SSH_CAPTURE"; then
+  pass "backup path is timestamped and predictable"
+else
+  fail "backup path must be timestamped and predictable"
+fi
+
+# ---------------------------------------------------------------------------
+# Part 4: direct behavioral proof of the remote User/EnvironmentFile preflight
+# and backup fragment -- executed for real via sh -c against a fixture
+# filesystem and a faked getent/date, independent of deploy.sh's mocked ssh.
+# ---------------------------------------------------------------------------
+
+FIXTURE="$TMP_DIR/target-guard-fixture"
+mkdir -p "$FIXTURE/etc/systemd/system"
+printf '%s\n' 'old unit' > "$FIXTURE/etc/systemd/system/alpha.service"
+
+cat > "$TMP_DIR/bin/getent" << 'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "passwd" ]] || exit 2
+case "$2" in
+  realuser) exit 0 ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "$TMP_DIR/bin/getent"
+
+# Part 4 runs the generated fragment for real with privileged=true (the
+# system-scope shape). Provide a no-op passthrough so "sudo test"/"sudo cp"
+# run directly as the current user against the fixture filesystem rather than
+# prompting for a real password.
+cat > "$TMP_DIR/bin/sudo" << 'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+chmod +x "$TMP_DIR/bin/sudo"
+
+frag=$(prepare_unit_target_preflight_and_backup_command true alpha.service realuser \
+  "$FIXTURE/etc/systemd/system/alpha.env")
+printf '%s\n' present > "$FIXTURE/etc/systemd/system/alpha.env"
+
+rc=0
+PATH="$TMP_DIR/bin:$PATH" dest="$FIXTURE/etc/systemd/system/alpha.service" \
+  sh -c "$frag echo GUARD_OK" >"$TMP_DIR/guard.out" 2>&1 || rc=$?
+if [[ "$rc" == 0 ]] && grep -Fq "GUARD_OK" "$TMP_DIR/guard.out"; then
+  pass "target guard passes when User exists and EnvironmentFile is present"
+else
+  fail "target guard must pass when User exists and EnvironmentFile is present"
+  cat "$TMP_DIR/guard.out"
+fi
+backup_path=$(find "$FIXTURE/etc/systemd/system" -name 'alpha.service.bak.*')
+if [[ -n "$backup_path" ]] && grep -Fq "old unit" "$backup_path"; then
+  pass "existing unit is backed up to a predictable timestamped path before overwrite"
+else
+  fail "existing unit must be backed up to a predictable timestamped path before overwrite"
+fi
+if grep -Fq "Backed up prior unit: $FIXTURE/etc/systemd/system/alpha.service -> " "$TMP_DIR/guard.out"; then
+  pass "backup path is printed"
+else
+  fail "backup path must be printed"
+fi
+
+rc=0
+frag=$(prepare_unit_target_preflight_and_backup_command true alpha.service missinguser)
+PATH="$TMP_DIR/bin:$PATH" dest="$FIXTURE/etc/systemd/system/alpha.service" \
+  sh -c "$frag echo GUARD_OK" >"$TMP_DIR/guard-baduser.out" 2>&1 || rc=$?
+if [[ "$rc" != 0 ]] && ! grep -Fq "GUARD_OK" "$TMP_DIR/guard-baduser.out" &&
+   grep -Fq "User=missinguser" "$TMP_DIR/guard-baduser.out"; then
+  pass "target guard fails closed when the declared User does not exist on the target"
+else
+  fail "target guard must fail closed when the declared User does not exist on the target"
+  cat "$TMP_DIR/guard-baduser.out"
+fi
+
+rc=0
+frag=$(prepare_unit_target_preflight_and_backup_command true alpha.service realuser \
+  "$FIXTURE/etc/systemd/system/absent.env")
+PATH="$TMP_DIR/bin:$PATH" dest="$FIXTURE/etc/systemd/system/alpha.service" \
+  sh -c "$frag echo GUARD_OK" >"$TMP_DIR/guard-badenv.out" 2>&1 || rc=$?
+if [[ "$rc" != 0 ]] && ! grep -Fq "GUARD_OK" "$TMP_DIR/guard-badenv.out" &&
+   grep -Fq "EnvironmentFile=$FIXTURE/etc/systemd/system/absent.env" "$TMP_DIR/guard-badenv.out"; then
+  pass "target guard fails closed when the declared EnvironmentFile is absent from the target"
+else
+  fail "target guard must fail closed when the declared EnvironmentFile is absent from the target"
+  cat "$TMP_DIR/guard-badenv.out"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #146. The 2026-07-25 munin-memory outage happened because `scripts/deploy.sh` rsynced code to `services.json`'s `deploy_path` and then installed a systemd unit whose `WorkingDirectory`/`EnvironmentFile` pointed somewhere else entirely, then restarted into it — stopping a healthy service before ever discovering the contradiction.

- **Fails closed before any remote call.** `preflight_unit_target_containment` (new, `scripts/lib/deploy-safety.sh`) parses a unit's `WorkingDirectory`/`EnvironmentFile` and aborts — before host resolution, marker invalidation, build, or rsync — when either does not resolve under the component's registry `deploy_path`, naming both paths in the diagnostic. Wired into `preflight_local_unit_sources` (`scripts/deploy.sh`), which now runs for **both** deploy modes (previously skipped entirely for `git-pull`).
- **Preflights `User=` and `EnvironmentFile=` on the target, before any stop/restart.** `prepare_unit_target_preflight_and_backup_command` (new) emits the remote-shell fragment spliced in immediately before each unit install: `getent passwd` for the declared `User=` (system scope only — a user-scope unit already runs as the deploying account, so `User=` isn't a privilege boundary there), and presence checks for every `EnvironmentFile=`.
- **Backs up the existing unit before overwriting it.** Same fragment: if a unit is already installed at the destination, it's copied to a predictable, timestamped `<destination>.bak.<UTC timestamp>` and the path is printed — strictly before daemon-reload/stop/restart. Both scopes handled (system via `sudo test`/`sudo cp`, user unprivileged).
- **Regression test** (`scripts/tests/deploy-unit-target-guard.test.sh`, wired into `make test`) reproduces the exact munin-memory shape and three more angles — see test plan.
- **`docs/failure-recovery.md`** documents the byte-for-byte backup/guard convention alongside the existing rendered-unit convention, per issue #146's explicit reference to that doc.

**Not in scope** (per the issue): reconciling the actual `/srv/grimnir` relocation — this PR only makes the deployer refuse the contradiction, it doesn't pick a side.

## A live second instance found while testing

Running the new guard read-only against every deployable component's *current* unit files (no deploy, no ssh mutation) surfaced a second, still-latent instance of the identical contradiction: `mimir.service` in the `mimir` repo currently declares `User=mimir` / `WorkingDirectory=/home/mimir/mimir-server`, but `services.json`'s `deploy_path` is `/home/magnus/mimir-server`, and the unit **currently installed** on `nas.local` (read-only verified) still matches the registry — the repo's unit has silently drifted, exactly like munin-memory before its outage. `mimir`'s next deploy would have hit the same class of failure; with this PR merged it will instead refuse cleanly. Filed as [mimir#29](https://github.com/Magnus-Gille/mimir/issues/29) (`from:grimnir`) rather than fixed here, per the same "don't pick a side" scope boundary.

## Test plan

- [x] Red: wrote `scripts/tests/deploy-unit-target-guard.test.sh` first; ran against pre-fix code — failed for the right reason (deploy proceeded past rsync into `==> Installing production dependencies...OK`, no path-containment check existed, `prepare_unit_target_preflight_and_backup_command: command not found`).
- [x] Green: all 14 assertions in the new test pass after the fix.
- [x] `make test` — full suite green (732 `PASS`, 0 `FAIL`, exit 0).
- [x] `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh` — clean, exit 0.
- [x] Sanity-checked the new guard read-only against every real `deploy:true` component's actual unit files on disk (`~/repos/<repo>`) — hugin, ratatoskr, skuld, grimnir, verdandi all pass; munin-memory correctly fails (the reported incident); mimir correctly fails (newly discovered, see above); heimdall correctly skipped (render_enabled, has its own equivalent check).
- [x] Read-only `ssh huginmunin.local` / `ssh nas.local` to confirm real installed-unit shapes match expectations (no unit installs, no restarts, no host mutation).
- [x] No deploy run, no service restarted, no unit modified on any host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)