### PR TITLE
Add GitHub Project scope preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -81,10 +81,13 @@ test-worktree-hygiene: ## Unit + fixture tests for the worktree/deploy hygiene a
 test-claude-capacity-preflight: ## Classify cheap Claude probe failures and preserve deterministic fallback (issue #136)
 	@bash scripts/tests/claude-capacity-preflight.test.sh
 
+test-github-project-preflight: ## Classify GitHub Project scopes, absence, and API failures (issue #135)
+	@bash scripts/tests/github-project-preflight.test.sh
+
 test-validate-exit: ## Unit tests for the audit exit-status contract (findings vs. audit failure)
 	@bash scripts/tests/validate-exit.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/github-project-roadmap.md
+++ b/docs/github-project-roadmap.md
@@ -1,0 +1,54 @@
+# GitHub Project Roadmap preflight
+
+Roadmap board access is optional for creating an owning-repository ticket. Run a
+read-only check before a ticket batch:
+
+```sh
+scripts/github-project-preflight.sh preflight --owner Magnus-Gille --number 1 --require-write
+```
+
+The output is a public-safe `key=value` record. `status=ready` permits adding
+items. Otherwise `class` deterministically identifies `missing_read_scope`,
+`missing_write_scope`, `missing_project`, or `network_api_failure` (with an
+`api_failure`/`auth_failure` fallback for other failures). The preflight uses
+only `gh auth status` and `gh project view`; it never creates, edits, or adds an
+item.
+
+## Owner setup
+
+Project inspection requires `read:project`. Creating an item requires the
+write-capable `project` scope (which also permits reads). The owner refreshes
+the active GitHub CLI account; no token belongs in this repository:
+
+```sh
+gh auth refresh --hostname github.com --scopes read:project,project
+gh auth status
+```
+
+Confirm that `gh auth status` reports the intended **active account** and its
+`Token scopes` include `read:project` for read-only use, or `project` when
+items will be added. Then rerun the preflight above. A `missing_project` result
+means that the requested owner/project number cannot be read by that account,
+not that a ticket should be withheld.
+
+## Creating tickets without blocking on the board
+
+For a standard issue creation plus best-effort board addition:
+
+```sh
+scripts/github-project-preflight.sh ticket \
+  --repo Magnus-Gille/brokkr --title 'Example' --body-file /path/to/body.md \
+  --label from:grimnir --owner Magnus-Gille --number 1
+```
+
+The issue is created first. If Project access is unavailable, the command exits
+successfully after printing `board_addition=pending` and one
+`pending_board_addition=<issue-url>` line per created ticket. Preserve those
+lines and add them after the owner fixes scope or connectivity:
+
+```sh
+gh project item-add 1 --owner Magnus-Gille --url <issue-url>
+```
+
+This keeps the owning repository's ticket workflow usable while retaining an
+explicit, auditable list of missed Roadmap additions.

--- a/docs/github-project-roadmap.md
+++ b/docs/github-project-roadmap.md
@@ -41,8 +41,9 @@ scripts/github-project-preflight.sh ticket \
   --label from:grimnir --owner Magnus-Gille --number 1
 ```
 
-The issue is created first. If Project access is unavailable, the command exits
-successfully after printing `board_addition=pending` and one
+The issue is created first. If Project access is unavailable, or the subsequent
+`gh project item-add` call fails, the command exits successfully after printing
+`board_addition=pending`, a non-secret `board_addition_class`, and one
 `pending_board_addition=<issue-url>` line per created ticket. Preserve those
 lines and add them after the owner fixes scope or connectivity:
 

--- a/scripts/github-project-preflight.sh
+++ b/scripts/github-project-preflight.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# github-project-preflight.sh — scope-aware, read-only Roadmap Project check (#135).
+#
+# `preflight` makes no GitHub mutations. Its stable key=value record distinguishes
+# unavailable project scopes, a missing project, and an API/transport failure.
+# `ticket` deliberately creates the owning-repository issue first; when the board
+# cannot be updated it reports the issue as a pending board addition instead.
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  github-project-preflight.sh preflight --owner OWNER --number PROJECT_NUMBER [--require-write]
+  github-project-preflight.sh ticket --repo OWNER/REPO --title TITLE --body-file FILE \
+    --owner OWNER --number PROJECT_NUMBER [--label LABEL ...]
+USAGE
+}
+
+safe_owner() { [[ "$1" =~ ^[A-Za-z0-9-]+$ ]]; }
+safe_number() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+safe_repo() { [[ "$1" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; }
+
+failure_class() {
+  local detail
+  detail="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$detail" == *"missing required scopes"* ]] || [[ "$detail" == *"read:project"* ]]; then
+    printf '%s' missing_read_scope
+  elif [[ "$detail" == *"project not found"* ]] || [[ "$detail" == *"could not resolve to a project"* ]]; then
+    printf '%s' missing_project
+  elif [[ "$detail" == *"connecting to api.github.com"* ]] || [[ "$detail" == *"network"* ]] ||
+       [[ "$detail" == *"timeout"* ]] || [[ "$detail" == *"econn"* ]] || [[ "$detail" == *"http 5"* ]]; then
+    printf '%s' network_api_failure
+  else
+    printf '%s' api_failure
+  fi
+}
+
+scope_record() {
+  local out code
+  set +e
+  out="$($GH_BIN auth status --active --hostname github.com --json hosts 2>&1)"; code=$?
+  set -e
+  printf '%s\n' "$out"
+  return "$code"
+}
+
+has_scope() {
+  local normalized wanted="$2"
+  normalized="$(printf '%s' "$1" | tr -d " '")"
+  [[ ",$normalized," == *",$wanted,"* ]]
+}
+
+preflight() {
+  local owner="$1" number="$2" require_write="$3" auth scopes out code class
+  set +e
+  auth="$(scope_record)"; code=$?
+  set -e
+  if [[ "$code" -ne 0 ]]; then
+    printf 'status=unavailable\nclass=auth_failure\nproject_owner=%s\nproject_number=%s\n' "$owner" "$number"
+    return 14
+  fi
+  scopes="$(printf '%s' "$auth" | sed -n 's/.*"scopes":"\([^"]*\)".*/\1/p' | head -n 1)"
+  # A `project` token grants Project write access and therefore project reads;
+  # `read:project` is sufficient for inspection only.
+  if ! has_scope "$scopes" read:project && ! has_scope "$scopes" project; then
+    printf 'status=unavailable\nclass=missing_read_scope\nproject_owner=%s\nproject_number=%s\n' "$owner" "$number"
+    return 10
+  fi
+  if [[ "$require_write" == yes ]] && ! has_scope "$scopes" project; then
+    printf 'status=unavailable\nclass=missing_write_scope\nproject_owner=%s\nproject_number=%s\n' "$owner" "$number"
+    return 11
+  fi
+  set +e
+  out="$($GH_BIN project view "$number" --owner "$owner" 2>&1)"; code=$?
+  set -e
+  if [[ "$code" -ne 0 ]]; then
+    class="$(failure_class "$out")"
+    printf 'status=unavailable\nclass=%s\nproject_owner=%s\nproject_number=%s\n' "$class" "$owner" "$number"
+    case "$class" in missing_read_scope) return 10 ;; missing_project) return 12 ;; network_api_failure) return 13 ;; *) return 14 ;; esac
+  fi
+  printf 'status=ready\nclass=none\nproject_owner=%s\nproject_number=%s\n' "$owner" "$number"
+}
+
+ticket() {
+  local repo="$1" title="$2" body_file="$3" owner="$4" number="$5"; shift 5
+  local -a args=(issue create --repo "$repo" --title "$title" --body-file "$body_file")
+  local label issue_url result code
+  if [[ "$#" -gt 0 ]]; then
+    for label in "$@"; do args+=(--label "$label"); done
+  fi
+  issue_url="$($GH_BIN "${args[@]}")"
+  printf 'issue_url=%s\n' "$issue_url"
+  set +e
+  result="$(preflight "$owner" "$number" yes)"; code=$?
+  set -e
+  if [[ "$code" -eq 0 ]]; then
+    $GH_BIN project item-add "$number" --owner "$owner" --url "$issue_url" >/dev/null
+    printf 'board_addition=added\n'
+  else
+    printf '%s\n' "$result"
+    printf 'board_addition=pending\npending_board_addition=%s\n' "$issue_url"
+  fi
+}
+
+mode="${1:-}"; shift || true
+case "$mode" in
+  preflight)
+    owner=''; number=''; require_write=no
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in --owner) owner="${2:-}"; shift 2 ;; --number) number="${2:-}"; shift 2 ;; --require-write) require_write=yes; shift ;; *) usage; exit 2 ;; esac
+    done
+    if ! [[ -n "$owner" && -n "$number" ]] || ! safe_owner "$owner" || ! safe_number "$number"; then usage; exit 2; fi
+    preflight "$owner" "$number" "$require_write"
+    ;;
+  ticket)
+    repo=''; title=''; body_file=''; owner=''; number=''; labels=()
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --repo) repo="${2:-}"; shift 2 ;; --title) title="${2:-}"; shift 2 ;; --body-file) body_file="${2:-}"; shift 2 ;;
+        --owner) owner="${2:-}"; shift 2 ;; --number) number="${2:-}"; shift 2 ;; --label) labels+=("${2:-}"); shift 2 ;;
+        *) usage; exit 2 ;;
+      esac
+    done
+    if ! [[ -n "$title" && -r "$body_file" ]] || ! safe_repo "$repo" || ! safe_owner "$owner" || ! safe_number "$number"; then usage; exit 2; fi
+    if [[ "${#labels[@]}" -gt 0 ]]; then
+      ticket "$repo" "$title" "$body_file" "$owner" "$number" "${labels[@]}"
+    else
+      ticket "$repo" "$title" "$body_file" "$owner" "$number"
+    fi
+    ;;
+  *) usage; exit 2 ;;
+esac

--- a/scripts/github-project-preflight.sh
+++ b/scripts/github-project-preflight.sh
@@ -87,7 +87,7 @@ preflight() {
 ticket() {
   local repo="$1" title="$2" body_file="$3" owner="$4" number="$5"; shift 5
   local -a args=(issue create --repo "$repo" --title "$title" --body-file "$body_file")
-  local label issue_url result code
+  local label issue_url result item_add_result code class
   if [[ "$#" -gt 0 ]]; then
     for label in "$@"; do args+=(--label "$label"); done
   fi
@@ -97,8 +97,15 @@ ticket() {
   result="$(preflight "$owner" "$number" yes)"; code=$?
   set -e
   if [[ "$code" -eq 0 ]]; then
-    $GH_BIN project item-add "$number" --owner "$owner" --url "$issue_url" >/dev/null
-    printf 'board_addition=added\n'
+    set +e
+    item_add_result="$($GH_BIN project item-add "$number" --owner "$owner" --url "$issue_url" 2>&1)"; code=$?
+    set -e
+    if [[ "$code" -eq 0 ]]; then
+      printf 'board_addition=added\n'
+    else
+      class="$(failure_class "$item_add_result")"
+      printf 'board_addition=pending\nboard_addition_class=%s\npending_board_addition=%s\n' "$class" "$issue_url"
+    fi
   else
     printf '%s\n' "$result"
     printf 'board_addition=pending\npending_board_addition=%s\n' "$issue_url"

--- a/scripts/tests/github-project-preflight.test.sh
+++ b/scripts/tests/github-project-preflight.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/github-project-preflight.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then pass "$1"; else fail "$1"; fi; }
+assert_code() { if [[ "$2" -eq "$3" ]]; then pass "$1"; else fail "$1 (got $3, expected $2)"; fi; }
+
+cat >"$TMP/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${GH_SCENARIO:?}" in
+  ticket-pending)
+    if [[ "$1 $2" == "issue create" ]]; then printf 'https://github.com/Magnus-Gille/brokkr/issues/99\n';
+    elif [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo"}]}}\n';
+    else printf 'unexpected gh invocation: %s %s\n' "$1" "$2" >&2; exit 1; fi ;;
+  ready)
+    if [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project, project"}]}}\n'; else printf 'Roadmap\n'; fi ;;
+  missing-read)
+    if [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo"}]}}\n'; else printf 'error: your authentication token is missing required scopes [read:project]\n' >&2; exit 1; fi ;;
+  missing-write)
+    if [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project"}]}}\n'; else printf 'Roadmap\n'; fi ;;
+  missing-project)
+    if [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project, project"}]}}\n'; else printf 'project not found\n' >&2; exit 1; fi ;;
+  network)
+    if [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project, project"}]}}\n'; else printf 'error connecting to api.github.com\n' >&2; exit 1; fi ;;
+esac
+STUB
+chmod +x "$TMP/gh"
+
+run() {
+  set +e
+  if [[ -n "${2:-}" ]]; then
+    RESULT="$(PATH="$TMP:$PATH" GH_SCENARIO="$1" "$SCRIPT" preflight --owner Magnus-Gille --number 1 "$2")"
+  else
+    RESULT="$(PATH="$TMP:$PATH" GH_SCENARIO="$1" "$SCRIPT" preflight --owner Magnus-Gille --number 1)"
+  fi
+  CODE=$?
+  set -e
+}
+run ready --require-write; assert_code 'ready exits zero' 0 "$CODE"; assert_contains 'ready is usable' "$RESULT" 'status=ready'
+run missing-read; assert_code 'missing read scope exits 10' 10 "$CODE"; assert_contains 'missing read scope is explicit' "$RESULT" 'class=missing_read_scope'
+run missing-write --require-write; assert_code 'missing write scope exits 11' 11 "$CODE"; assert_contains 'missing write scope is explicit' "$RESULT" 'class=missing_write_scope'
+run missing-project; assert_code 'missing project exits 12' 12 "$CODE"; assert_contains 'missing project is explicit' "$RESULT" 'class=missing_project'
+run network; assert_code 'network failure exits 13' 13 "$CODE"; assert_contains 'network failure is explicit' "$RESULT" 'class=network_api_failure'
+
+printf 'body\n' >"$TMP/body.md"
+set +e
+ticket_output="$(PATH="$TMP:$PATH" GH_SCENARIO=ticket-pending "$SCRIPT" ticket --repo Magnus-Gille/brokkr --title Example --body-file "$TMP/body.md" --owner Magnus-Gille --number 1)"; ticket_code=$?
+set -e
+assert_code 'ticket creation survives unavailable board' 0 "$ticket_code"
+assert_contains 'ticket reports pending board addition' "$ticket_output" 'pending_board_addition=https://github.com/Magnus-Gille/brokkr/issues/99'
+
+echo "Results: $PASS passed, $FAIL failed"; [[ "$FAIL" -eq 0 ]]

--- a/scripts/tests/github-project-preflight.test.sh
+++ b/scripts/tests/github-project-preflight.test.sh
@@ -19,6 +19,12 @@ case "${GH_SCENARIO:?}" in
     if [[ "$1 $2" == "issue create" ]]; then printf 'https://github.com/Magnus-Gille/brokkr/issues/99\n';
     elif [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo"}]}}\n';
     else printf 'unexpected gh invocation: %s %s\n' "$1" "$2" >&2; exit 1; fi ;;
+  ticket-add-fails)
+    if [[ "$1 $2" == "issue create" ]]; then printf 'https://github.com/Magnus-Gille/brokkr/issues/100\n';
+    elif [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project, project"}]}}\n';
+    elif [[ "$1 $2 $3" == "project view 1" ]]; then printf 'Roadmap\n';
+    elif [[ "$1 $2 $3" == "project item-add 1" ]]; then printf 'error connecting to api.github.com\n' >&2; exit 1;
+    else printf 'unexpected gh invocation: %s %s\n' "$1" "$2" >&2; exit 1; fi ;;
   ready)
     if [[ "$1 $2" == "auth status" ]]; then printf '{"hosts":{"github.com":[{"active":true,"scopes":"repo, read:project, project"}]}}\n'; else printf 'Roadmap\n'; fi ;;
   missing-read)
@@ -55,5 +61,13 @@ ticket_output="$(PATH="$TMP:$PATH" GH_SCENARIO=ticket-pending "$SCRIPT" ticket -
 set -e
 assert_code 'ticket creation survives unavailable board' 0 "$ticket_code"
 assert_contains 'ticket reports pending board addition' "$ticket_output" 'pending_board_addition=https://github.com/Magnus-Gille/brokkr/issues/99'
+
+set +e
+item_add_output="$(PATH="$TMP:$PATH" GH_SCENARIO=ticket-add-fails "$SCRIPT" ticket --repo Magnus-Gille/brokkr --title Example --body-file "$TMP/body.md" --owner Magnus-Gille --number 1 2>"$TMP/item-add.err")"; item_add_code=$?
+set -e
+assert_code 'ticket creation survives item-add failure' 0 "$item_add_code"
+assert_contains 'item-add failure has a deterministic class' "$item_add_output" 'board_addition_class=network_api_failure'
+assert_contains 'item-add failure reports pending board addition' "$item_add_output" 'pending_board_addition=https://github.com/Magnus-Gille/brokkr/issues/100'
+if [[ ! -s "$TMP/item-add.err" ]]; then pass 'item-add failure does not leak stderr'; else fail 'item-add failure does not leak stderr'; fi
 
 echo "Results: $PASS passed, $FAIL failed"; [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #135.\n\nAdds a read-only, scope-aware GitHub Project preflight with deterministic missing-scope, missing-project, and network/API classifications. Documents owner refresh/verification and provides a ticket helper that reports pending Roadmap additions without blocking issue creation.\n\nVerification: make test; shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh.