### PR TITLE
Diagnose zero-step GitHub Actions failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -87,10 +87,13 @@ test-claude-capacity-preflight: ## Classify cheap Claude probe failures and pres
 test-github-project-preflight: ## Classify GitHub Project scopes, absence, and API failures (issue #135)
 	@bash scripts/tests/github-project-preflight.test.sh
 
+test-github-actions-zero-step-preflight: ## Distinguish runner startup failures from workflow-step failures (issue #138)
+	@bash scripts/tests/github-actions-zero-step-preflight.test.sh
+
 test-validate-exit: ## Unit tests for the audit exit-status contract (findings vs. audit failure)
 	@bash scripts/tests/validate-exit.test.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/github-actions-zero-step-recovery.md
+++ b/docs/github-actions-zero-step-recovery.md
@@ -10,12 +10,14 @@ scripts/github-actions-zero-step-preflight.sh diagnose \
   --repo Magnus-Gille/skuld --run 30180932068 --job 89737176794
 ```
 
-The command makes exactly two GitHub API GETs (the nominated run and job), emits
+The command makes at most two GitHub API GETs (the nominated run and, only after
+that succeeds, the nominated job), emits
 one public-safe key/value alert record, and exits without a retry, poll, rerun,
 dispatch, comment, or any other GitHub mutation. Consumers deduplicate on the
 single `alert_key` field and emit that record once. In particular, they must not
 wrap it in a retry loop. `run_id`, `job_id`, and `affected_pr` occur once each so
-an owner can act on the exact evidence.
+an owner can act on the exact evidence. `api_attempts` reports the actual count:
+one when the run request fails, otherwise two.
 
 | Exit | Class | Meaning |
 | --- | --- | --- |

--- a/docs/github-actions-zero-step-recovery.md
+++ b/docs/github-actions-zero-step-recovery.md
@@ -1,0 +1,53 @@
+# GitHub Actions zero-step recovery
+
+`scripts/github-actions-zero-step-preflight.sh` is the read-only diagnostic for
+the failure shape in grimnir#138. It differentiates a job that did not start on a
+runner from a workflow that reached a test step; it is not a CI bypass and cannot
+make a blocked pull request mergeable.
+
+```sh
+scripts/github-actions-zero-step-preflight.sh diagnose \
+  --repo Magnus-Gille/skuld --run 30180932068 --job 89737176794
+```
+
+The command makes exactly two GitHub API GETs (the nominated run and job), emits
+one public-safe key/value alert record, and exits without a retry, poll, rerun,
+dispatch, comment, or any other GitHub mutation. Consumers deduplicate on the
+single `alert_key` field and emit that record once. In particular, they must not
+wrap it in a retry loop. `run_id`, `job_id`, and `affected_pr` occur once each so
+an owner can act on the exact evidence.
+
+| Exit | Class | Meaning |
+| --- | --- | --- |
+| 0 | `workflow_succeeded` | The nominated job completed successfully. |
+| 10 | `zero_step_runner_startup_or_capacity` | The job completed without any steps; no test failure was observed. |
+| 11 | `run_not_completed` | The nominated run/job is still current; wait rather than rerun. |
+| 13 | `github_api_unavailable` | Diagnostic evidence could not be retrieved. |
+| 14 | `malformed_api_evidence` / `evidence_mismatch` | Do not infer a cause from inconsistent API data. |
+| 20 | `workflow_step_failure` | At least one workflow step existed; investigate that workflow failure. |
+
+## Owner recovery action
+
+For exit 10, GitHub’s run/job API establishes only the symptom. It does **not**
+expose the account-level Actions billing, spending-limit, payment, or runner
+allocation decision that produced it. The authoritative recovery action is for
+the GitHub account owner to open the private repository’s **Settings → Billing
+and licensing → Plans and usage**, verify that Actions is enabled and that the
+account has an active payment method and usable Actions spending/credit limit,
+then check the Actions settings for any owner-managed runner/allocation policy.
+
+After the owner has restored capacity, manually rerun the exact blocked revision
+once. Merge only when a new Actions run contains real completed steps and passes;
+local green tests and this diagnostic are supporting evidence, never a substitute
+for the protected GitHub CI gate. If the billing UI is healthy, retain the
+diagnostic record and escalate it to GitHub Support as runner allocation evidence.
+
+## Validated evidence
+
+On 2026-07-26, `Magnus-Gille/skuld` PR #15’s run `30180932068` / job
+`89737176794` completed in five seconds with `steps: []`, `runner_id: 0`, an
+empty runner name, and a 22-byte empty ZIP log archive. The same signature was
+recorded for Verdandi PR #25 (run `30045605392`, job `89335895570`, plus one
+controlled zero-step rerun) and Ratatoskr PR #53 (run `30065051489`). This is why
+the classifier reports runner startup/capacity—not a test failure—while leaving
+the authoritative billing/allocation cause for the owner UI.

--- a/scripts/github-actions-zero-step-preflight.sh
+++ b/scripts/github-actions-zero-step-preflight.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# github-actions-zero-step-preflight.sh — read-only Actions failure classifier (#138).
+#
+# `diagnose` performs exactly one GET for the run and one GET for the nominated
+# job. It never calls a rerun endpoint, polls, modifies GitHub state, or sends a
+# notification. Its single stable alert record includes a deduplication key so a
+# caller can emit it once without treating a local test as replacement green CI.
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-gh}"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: github-actions-zero-step-preflight.sh diagnose --repo OWNER/REPO --run RUN_ID --job JOB_ID
+USAGE
+}
+
+safe_repo() { [[ "$1" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; }
+safe_id() { [[ "$1" =~ ^[1-9][0-9]*$ ]]; }
+
+json_value() {
+  local json="$1" expression="$2"
+  node -e '
+    const value = JSON.parse(process.argv[1]);
+    const expression = process.argv[2].split(".");
+    let current = value;
+    for (const key of expression) current = key === "length" ? current.length : current?.[key];
+    if (current === undefined || current === null) process.exit(1);
+    if (typeof current === "object") process.exit(1);
+    process.stdout.write(String(current));
+  ' "$json" "$expression"
+}
+
+api_get() {
+  local endpoint="$1" out code
+  set +e
+  out="$($GH_BIN api "$endpoint" 2>&1)"; code=$?
+  set -e
+  if [[ "$code" -ne 0 ]]; then
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
+record() {
+  local status="$1" class="$2" test_failure="$3" action="$4" repo="$5" run_id="$6" job_id="$7" affected_pr="$8"
+  printf 'status=%s\nclass=%s\ntest_failure=%s\naction=%s\nrepo=%s\nrun_id=%s\njob_id=%s\naffected_pr=%s\nalert_key=github-actions-zero-step:%s:%s:%s\nalert_once=emit\nretry=suppressed\napi_attempts=2\n' \
+    "$status" "$class" "$test_failure" "$action" "$repo" "$run_id" "$job_id" "$affected_pr" "$repo" "$run_id" "$job_id"
+}
+
+diagnose() {
+  local repo="$1" run_id="$2" job_id="$3" run job run_status job_status job_run_id steps conclusion pr_number affected_pr
+  if ! run="$(api_get "repos/$repo/actions/runs/$run_id")"; then
+    record unavailable github_api_unavailable unknown retry_manually_after_api_recovery "$repo" "$run_id" "$job_id" unknown
+    return 13
+  fi
+  if ! job="$(api_get "repos/$repo/actions/jobs/$job_id")"; then
+    record unavailable github_api_unavailable unknown retry_manually_after_api_recovery "$repo" "$run_id" "$job_id" unknown
+    return 13
+  fi
+  if ! run_status="$(json_value "$run" status)" || ! job_status="$(json_value "$job" status)" ||
+     ! job_run_id="$(json_value "$job" run_id)" || ! steps="$(json_value "$job" steps.length)"; then
+    record unavailable malformed_api_evidence unknown inspect_github_actions_ui "$repo" "$run_id" "$job_id" unknown
+    return 14
+  fi
+  pr_number="$(json_value "$run" pull_requests.0.number 2>/dev/null || printf unknown)"
+  affected_pr="unknown"; [[ "$pr_number" =~ ^[1-9][0-9]*$ ]] && affected_pr="$repo#$pr_number"
+  if [[ "$job_run_id" != "$run_id" ]]; then
+    record unavailable evidence_mismatch unknown inspect_github_actions_ui "$repo" "$run_id" "$job_id" "$affected_pr"
+    return 14
+  fi
+  if [[ "$run_status" != completed || "$job_status" != completed ]]; then
+    record pending run_not_completed unknown wait_for_current_run "$repo" "$run_id" "$job_id" "$affected_pr"
+    return 11
+  fi
+  conclusion="$(json_value "$job" conclusion 2>/dev/null || printf unknown)"
+  if [[ "$conclusion" == success ]]; then
+    record ready workflow_succeeded no none "$repo" "$run_id" "$job_id" "$affected_pr"
+    return 0
+  fi
+  if [[ "$steps" == 0 ]]; then
+    record blocked zero_step_runner_startup_or_capacity no owner_recovery_required "$repo" "$run_id" "$job_id" "$affected_pr"
+    return 10
+  fi
+  record failed workflow_step_failure yes investigate_workflow_failure "$repo" "$run_id" "$job_id" "$affected_pr"
+  return 20
+}
+
+mode="${1:-}"; shift || true
+case "$mode" in
+  diagnose)
+    repo=''; run_id=''; job_id=''
+    while [[ "$#" -gt 0 ]]; do
+      case "$1" in
+        --repo) repo="${2:-}"; shift 2 ;;
+        --run) run_id="${2:-}"; shift 2 ;;
+        --job) job_id="${2:-}"; shift 2 ;;
+        *) usage; exit 2 ;;
+      esac
+    done
+    if ! safe_repo "$repo" || ! safe_id "$run_id" || ! safe_id "$job_id"; then usage; exit 2; fi
+    diagnose "$repo" "$run_id" "$job_id"
+    ;;
+  *) usage; exit 2 ;;
+esac

--- a/scripts/github-actions-zero-step-preflight.sh
+++ b/scripts/github-actions-zero-step-preflight.sh
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 # github-actions-zero-step-preflight.sh — read-only Actions failure classifier (#138).
 #
-# `diagnose` performs exactly one GET for the run and one GET for the nominated
+# `diagnose` performs at most one GET for the run and one GET for the nominated
 # job. It never calls a rerun endpoint, polls, modifies GitHub state, or sends a
 # notification. Its single stable alert record includes a deduplication key so a
 # caller can emit it once without treating a local test as replacement green CI.
@@ -44,46 +44,46 @@ api_get() {
 }
 
 record() {
-  local status="$1" class="$2" test_failure="$3" action="$4" repo="$5" run_id="$6" job_id="$7" affected_pr="$8"
-  printf 'status=%s\nclass=%s\ntest_failure=%s\naction=%s\nrepo=%s\nrun_id=%s\njob_id=%s\naffected_pr=%s\nalert_key=github-actions-zero-step:%s:%s:%s\nalert_once=emit\nretry=suppressed\napi_attempts=2\n' \
-    "$status" "$class" "$test_failure" "$action" "$repo" "$run_id" "$job_id" "$affected_pr" "$repo" "$run_id" "$job_id"
+  local status="$1" class="$2" test_failure="$3" action="$4" repo="$5" run_id="$6" job_id="$7" affected_pr="$8" api_attempts="$9"
+  printf 'status=%s\nclass=%s\ntest_failure=%s\naction=%s\nrepo=%s\nrun_id=%s\njob_id=%s\naffected_pr=%s\nalert_key=github-actions-zero-step:%s:%s:%s\nalert_once=emit\nretry=suppressed\napi_attempts=%s\n' \
+    "$status" "$class" "$test_failure" "$action" "$repo" "$run_id" "$job_id" "$affected_pr" "$repo" "$run_id" "$job_id" "$api_attempts"
 }
 
 diagnose() {
   local repo="$1" run_id="$2" job_id="$3" run job run_status job_status job_run_id steps conclusion pr_number affected_pr
   if ! run="$(api_get "repos/$repo/actions/runs/$run_id")"; then
-    record unavailable github_api_unavailable unknown retry_manually_after_api_recovery "$repo" "$run_id" "$job_id" unknown
+    record unavailable github_api_unavailable unknown retry_manually_after_api_recovery "$repo" "$run_id" "$job_id" unknown 1
     return 13
   fi
   if ! job="$(api_get "repos/$repo/actions/jobs/$job_id")"; then
-    record unavailable github_api_unavailable unknown retry_manually_after_api_recovery "$repo" "$run_id" "$job_id" unknown
+    record unavailable github_api_unavailable unknown retry_manually_after_api_recovery "$repo" "$run_id" "$job_id" unknown 2
     return 13
   fi
   if ! run_status="$(json_value "$run" status)" || ! job_status="$(json_value "$job" status)" ||
      ! job_run_id="$(json_value "$job" run_id)" || ! steps="$(json_value "$job" steps.length)"; then
-    record unavailable malformed_api_evidence unknown inspect_github_actions_ui "$repo" "$run_id" "$job_id" unknown
+    record unavailable malformed_api_evidence unknown inspect_github_actions_ui "$repo" "$run_id" "$job_id" unknown 2
     return 14
   fi
   pr_number="$(json_value "$run" pull_requests.0.number 2>/dev/null || printf unknown)"
   affected_pr="unknown"; [[ "$pr_number" =~ ^[1-9][0-9]*$ ]] && affected_pr="$repo#$pr_number"
   if [[ "$job_run_id" != "$run_id" ]]; then
-    record unavailable evidence_mismatch unknown inspect_github_actions_ui "$repo" "$run_id" "$job_id" "$affected_pr"
+    record unavailable evidence_mismatch unknown inspect_github_actions_ui "$repo" "$run_id" "$job_id" "$affected_pr" 2
     return 14
   fi
   if [[ "$run_status" != completed || "$job_status" != completed ]]; then
-    record pending run_not_completed unknown wait_for_current_run "$repo" "$run_id" "$job_id" "$affected_pr"
+    record pending run_not_completed unknown wait_for_current_run "$repo" "$run_id" "$job_id" "$affected_pr" 2
     return 11
   fi
   conclusion="$(json_value "$job" conclusion 2>/dev/null || printf unknown)"
   if [[ "$conclusion" == success ]]; then
-    record ready workflow_succeeded no none "$repo" "$run_id" "$job_id" "$affected_pr"
+    record ready workflow_succeeded no none "$repo" "$run_id" "$job_id" "$affected_pr" 2
     return 0
   fi
   if [[ "$steps" == 0 ]]; then
-    record blocked zero_step_runner_startup_or_capacity no owner_recovery_required "$repo" "$run_id" "$job_id" "$affected_pr"
+    record blocked zero_step_runner_startup_or_capacity no owner_recovery_required "$repo" "$run_id" "$job_id" "$affected_pr" 2
     return 10
   fi
-  record failed workflow_step_failure yes investigate_workflow_failure "$repo" "$run_id" "$job_id" "$affected_pr"
+  record failed workflow_step_failure yes investigate_workflow_failure "$repo" "$run_id" "$job_id" "$affected_pr" 2
   return 20
 }
 

--- a/scripts/tests/github-actions-zero-step-preflight.test.sh
+++ b/scripts/tests/github-actions-zero-step-preflight.test.sh
@@ -16,6 +16,7 @@ cat >"$TMP/gh" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 endpoint="${2:-}"
+if [[ -n "${GH_STUB_CALLS:-}" ]]; then printf '%s\n' "$endpoint" >>"$GH_STUB_CALLS"; fi
 case "${GH_SCENARIO:?}:$endpoint" in
   zero:repos/Magnus-Gille/skuld/actions/runs/30180932068)
     printf '%s\n' '{"status":"completed","conclusion":"failure","pull_requests":[{"number":15}]}' ;;
@@ -41,7 +42,7 @@ chmod +x "$TMP/gh"
 
 run() {
   set +e
-  RESULT="$(GH_BIN="$TMP/gh" GH_SCENARIO="$1" "$SCRIPT" diagnose --repo Magnus-Gille/skuld --run 30180932068 --job 89737176794)"
+  RESULT="$(GH_BIN="$TMP/gh" GH_SCENARIO="$1" GH_STUB_CALLS="$TMP/calls-$1" "$SCRIPT" diagnose --repo Magnus-Gille/skuld --run 30180932068 --job 89737176794)"
   CODE=$?
   set -e
 }
@@ -73,6 +74,8 @@ assert_contains 'mismatched job is invalid evidence' "$RESULT" 'class=evidence_m
 run api
 assert_code 'API failure exits 13' 13 "$CODE"
 assert_contains 'API failure is distinct' "$RESULT" 'class=github_api_unavailable'
+assert_contains 'first API failure reports one attempted request' "$RESULT" 'api_attempts=1'
+assert_code 'first API failure makes one request' 1 "$(wc -l <"$TMP/calls-api" | tr -d '[:space:]')"
 
 echo "Results: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/tests/github-actions-zero-step-preflight.test.sh
+++ b/scripts/tests/github-actions-zero-step-preflight.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/github-actions-zero-step-preflight.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+assert_code() { if [[ "$2" -eq "$3" ]]; then pass "$1"; else fail "$1 (got $3, expected $2)"; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then pass "$1"; else fail "$1"; fi; }
+assert_once() { local count; count="$(grep -c "^$3=" <<<"$2" || true)"; if [[ "$count" -eq 1 ]]; then pass "$1"; else fail "$1 (found $count)"; fi; }
+
+cat >"$TMP/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+endpoint="${2:-}"
+case "${GH_SCENARIO:?}:$endpoint" in
+  zero:repos/Magnus-Gille/skuld/actions/runs/30180932068)
+    printf '%s\n' '{"status":"completed","conclusion":"failure","pull_requests":[{"number":15}]}' ;;
+  zero:repos/Magnus-Gille/skuld/actions/jobs/89737176794)
+    printf '%s\n' '{"run_id":30180932068,"status":"completed","conclusion":"failure","steps":[],"runner_id":0,"runner_name":""}' ;;
+  test:repos/Magnus-Gille/skuld/actions/runs/30180932068)
+    printf '%s\n' '{"status":"completed","conclusion":"failure","pull_requests":[{"number":15}]}' ;;
+  test:repos/Magnus-Gille/skuld/actions/jobs/89737176794)
+    printf '%s\n' '{"run_id":30180932068,"status":"completed","conclusion":"failure","steps":[{"name":"Run tests","conclusion":"failure"}],"runner_id":7,"runner_name":"GitHub Actions 1"}' ;;
+  pending:repos/Magnus-Gille/skuld/actions/runs/30180932068)
+    printf '%s\n' '{"status":"in_progress","conclusion":null,"pull_requests":[{"number":15}]}' ;;
+  pending:repos/Magnus-Gille/skuld/actions/jobs/89737176794)
+    printf '%s\n' '{"run_id":30180932068,"status":"in_progress","conclusion":null,"steps":[]}' ;;
+  mismatch:repos/Magnus-Gille/skuld/actions/runs/30180932068)
+    printf '%s\n' '{"status":"completed","conclusion":"failure","pull_requests":[]}' ;;
+  mismatch:repos/Magnus-Gille/skuld/actions/jobs/89737176794)
+    printf '%s\n' '{"run_id":123,"status":"completed","conclusion":"failure","steps":[]}' ;;
+  api:*) printf 'error connecting to api.github.com\n' >&2; exit 1 ;;
+  *) printf 'unexpected endpoint: %s\n' "$endpoint" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$TMP/gh"
+
+run() {
+  set +e
+  RESULT="$(GH_BIN="$TMP/gh" GH_SCENARIO="$1" "$SCRIPT" diagnose --repo Magnus-Gille/skuld --run 30180932068 --job 89737176794)"
+  CODE=$?
+  set -e
+}
+
+run zero
+assert_code 'zero-step runner failure exits 10' 10 "$CODE"
+assert_contains 'zero-step class is explicit' "$RESULT" 'class=zero_step_runner_startup_or_capacity'
+assert_contains 'zero-step says test did not run' "$RESULT" 'test_failure=no'
+assert_contains 'zero-step requires owner recovery' "$RESULT" 'action=owner_recovery_required'
+assert_contains 'zero-step suppresses retries' "$RESULT" 'retry=suppressed'
+assert_contains 'zero-step carries affected PR' "$RESULT" 'affected_pr=Magnus-Gille/skuld#15'
+assert_once 'zero-step reports run exactly once' "$RESULT" run_id
+assert_once 'zero-step reports job exactly once' "$RESULT" job_id
+assert_once 'zero-step reports affected PR exactly once' "$RESULT" affected_pr
+
+run test
+assert_code 'test failure exits 20' 20 "$CODE"
+assert_contains 'test failure is distinct' "$RESULT" 'class=workflow_step_failure'
+assert_contains 'test failure says tests ran' "$RESULT" 'test_failure=yes'
+
+run pending
+assert_code 'in-progress run exits 11' 11 "$CODE"
+assert_contains 'in-progress run is distinct' "$RESULT" 'class=run_not_completed'
+
+run mismatch
+assert_code 'mismatched job exits 14' 14 "$CODE"
+assert_contains 'mismatched job is invalid evidence' "$RESULT" 'class=evidence_mismatch'
+
+run api
+assert_code 'API failure exits 13' 13 "$CODE"
+assert_contains 'API failure is distinct' "$RESULT" 'class=github_api_unavailable'
+
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- adds a read-only run/job diagnostic that distinguishes zero-step runner startup/capacity symptoms from workflow-step failures
- emits a one-record deduplication key with run, job, and affected PR; it never reruns or polls
- documents owner-only billing/allocation recovery and validates the Skuld #15 evidence

## Validation

- `make test`
- `shellcheck scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh`
- live read-only check: Skuld run `30180932068` / job `89737176794` -> `zero_step_runner_startup_or_capacity`
- M5 bounded design review (`Mellum2-12B-A2.5B-Instruct-Q4_K_M.gguf`): PASS

## Issue status

This PR intentionally does **not** close #138. The GitHub Actions API establishes the zero-step symptom but cannot reveal the authoritative private billing/spending/allocation decision. The owner must verify that in GitHub Billing and Actions settings, then manually rerun the exact blocked revision and merge only after real workflow steps pass.