### PR TITLE
Require cross-service completion evidence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -805,6 +805,23 @@ maintenance contracts listed in [`authority.md`](authority.md).
    adjacent contract note. Update this directory when ownership or the
    system-level boundary changes, and update the owner's versioned material
    when wire semantics change.
+6. **Completion evidence follows the payload to its consumer.** Before calling
+   a change to a cross-service payload complete, the producing repository
+   records evidence that its fixture is accepted by the consumer's **actual acceptance rule**,
+   not merely by a producer-local shape assertion. For a data-reading feature,
+   also perform a bounded, read-only check against real data and inspect the
+   result. The evidence must cover representative
+   historical rows whenever a prior producer bug, migration, or optional field
+   could make old data differ from newly written data; prefer an identity or
+   embedded field that survived the earlier defect over a convenient derived
+   field that did not. This is a completion requirement for the changed seam,
+   not a claim that every fleet seam has been audited.
+7. **Ignored input is observable.** A consumer that receives a supported
+   cross-service payload field, filter, or row and cannot apply it must reject
+   or warn on the ignored input through the contract's observable result. It
+   must not silently return a plausible success or empty result. Unknown or
+   unsupported inputs remain subject to rule 4; an owner ticket and a
+   compatibility fixture are required when correcting an established seam.
 
 The initial execution plan and the three original integration-test priorities
 are recorded in [`ecosystem-review-plan.md`](ecosystem-review-plan.md). The

--- a/tests/scripts/test-cross-service-contract-doc.sh
+++ b/tests/scripts/test-cross-service-contract-doc.sh
@@ -31,6 +31,11 @@ assert_contains "has owner-first evolution rule" 'Owner-first, versioned change'
 assert_contains "has explicit consumer migration rule" 'Consumers migrate explicitly'
 assert_contains "requires proof before removal" 'Compatibility is proved before removal'
 assert_contains "fails closed for incompatible inputs" 'Fail closed at decision boundaries'
+assert_contains "requires consumer acceptance evidence before completion" 'actual acceptance rule'
+assert_contains "requires read-only real-data evidence before completion" 'read-only check against real data'
+assert_contains "requires historical-row compatibility evidence" 'historical.*row'
+assert_contains "rejects ignored cross-service input" 'cannot apply it must reject'
+assert_contains "warns on ignored cross-service input" 'warn on the ignored input'
 
 if [[ "$failures" -gt 0 ]]; then
   exit 1


### PR DESCRIPTION
Closes? No — advances #79 without claiming a fleet-wide audit.

## What changed

- Adds a completion-policy rule for changed cross-service seams: prove the consumer's actual acceptance rule, run a bounded read-only real-data check for data-reading features, cover affected historical rows, and make ignored supported input observable through rejection or warning.
- States explicitly that this policy does not claim every fleet seam has been audited.
- Adds regression assertions to retain all four obligations.

## Routed owner work

- Heimdall #40: expose panel rows discarded by the normalizer.
- Existing: gille-inference #227; Hugin #230 and gille-inference #263 for the capture/lookup seam.

## Verification

- Red: `bash tests/scripts/test-cross-service-contract-doc.sh` failed for the four absent obligations before the doc change.
- Green: focused guard, `make test`, and shellcheck all pass.
- M5 `mellum` structural check confirmed all five required policy dimensions; the gateway correctly escalated a direct review task, so its result was not treated as an independent substantive review.

Refs #79.