### PR TITLE
Detect registry-derived architecture overview drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-architecture-component-table test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-architecture-component-table test-architecture-component-table-regression test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -102,6 +102,9 @@ test-doc-index: ## Guard progressive-disclosure index completeness and retained 
 test-architecture-component-table: ## Keep the architecture overview's registry-derived facts current (issue #5)
 	@bash tests/scripts/test-architecture-component-table.sh
 
+test-architecture-component-table-regression: ## Keep the architecture overview guard fail-closed (issue #5)
+	@bash tests/scripts/test-architecture-component-table-regression.sh
+
 test-instruction-eval-sandbox: ## Pin the read-only Claude evaluator sandbox (issue #143)
 	@bash tests/scripts/test-instruction-eval-sandbox.sh
 
@@ -114,7 +117,7 @@ test-skills-eval-sandbox: ## Pin the skill-description evaluator sandbox (issue 
 test-telemetry-strategy-doc: ## Preserve the telemetry boundary and legacy journal-analysis retirement path (issue #6)
 	@bash tests/scripts/test-telemetry-strategy-doc.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-architecture-component-table test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-architecture-component-table test-architecture-component-table-regression test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc test
+.PHONY: docs clean security security-dry deploy test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-architecture-component-table test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc test
 
 docs: ## Generate full architecture document
 	@./scripts/generate-architecture.sh
@@ -99,6 +99,9 @@ test-validate-exit: ## Unit tests for the audit exit-status contract (findings v
 test-doc-index: ## Guard progressive-disclosure index completeness and retained constraints (issue #143)
 	@bash tests/scripts/test-doc-index.sh
 
+test-architecture-component-table: ## Keep the architecture overview's registry-derived facts current (issue #5)
+	@bash tests/scripts/test-architecture-component-table.sh
+
 test-instruction-eval-sandbox: ## Pin the read-only Claude evaluator sandbox (issue #143)
 	@bash tests/scripts/test-instruction-eval-sandbox.sh
 
@@ -111,7 +114,7 @@ test-skills-eval-sandbox: ## Pin the skill-description evaluator sandbox (issue 
 test-telemetry-strategy-doc: ## Preserve the telemetry boundary and legacy journal-analysis retirement path (issue #6)
 	@bash tests/scripts/test-telemetry-strategy-doc.sh
 
-test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc ## Run all test suites
+test: test-security-skip test-security-delta test-security-completeness test-security-namespace test-munin-rpc test-registry-smoke test-placement-validation test-deploy-source-revision test-deploy-persistent-paths test-deploy-systemd-render test-deploy-unit-target-guard test-failure-recovery-doc test-cross-service-contract-doc test-learning-task-contract-doc test-node-substrate-contract test-network-operating-model test-node-substrate-contract-doc test-maintenance-policy-contract test-maintenance-policy-contract-doc test-registry-checkout test-systemd-status test-runtime-state test-worktree-hygiene test-validate-exit test-claude-capacity-preflight test-github-project-preflight test-github-actions-policy test-github-actions-zero-step-preflight test-validation-staleness-evidence-doc test-doc-index test-architecture-component-table test-instruction-eval-sandbox test-skills-eval-sandbox test-telemetry-strategy-doc ## Run all test suites
 
 clean: ## Remove generated docs
 	rm -f docs/snapshot.md docs/full-architecture.md

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -138,7 +138,8 @@
 
 The generator should warn on discrepancies it can detect:
 - Port, host, and repository columns in `docs/architecture.md`'s component overview vs
-  networked components in `services.json` (via `test-architecture-component-table.sh`)
+  networked components in `services.json` (via `test-architecture-component-table.sh`; duplicate
+  matching rows fail, while extra curated rows such as the non-registry M5 gateway remain allowed)
 - Port in `services.json` vs port in component's source code / env config
 - Systemd units in `services.json` vs units actually present on the host
 - Component repos in `services.json` vs directories in `~/repos/`

--- a/docs/authority.md
+++ b/docs/authority.md
@@ -137,6 +137,8 @@
 ## Validation
 
 The generator should warn on discrepancies it can detect:
+- Port, host, and repository columns in `docs/architecture.md`'s component overview vs
+  networked components in `services.json` (via `test-architecture-component-table.sh`)
 - Port in `services.json` vs port in component's source code / env config
 - Systemd units in `services.json` vs units actually present on the host
 - Component repos in `services.json` vs directories in `~/repos/`

--- a/scripts/generate-architecture.sh
+++ b/scripts/generate-architecture.sh
@@ -170,6 +170,19 @@ if [[ "$VALIDATE_MODE" == "true" ]]; then
   FAIL=0
   RESULTS=""
 
+  # The curated architecture overview repeats only a small, reader-facing
+  # projection of services.json. Check its mechanical port/host/repository
+  # columns here so the scheduled validator reports a real discrepancy rather
+  # than relying on a later human noticing it (grimnir#5). Roles and other
+  # semantic prose deliberately remain outside this deterministic check.
+  if bash "$GRIMNIR_DIR/tests/scripts/test-architecture-component-table.sh"; then
+    RESULTS+="✅ architecture-component-table: registry-derived overview facts match\n"
+    PASS=$((PASS + 1))
+  else
+    RESULTS+="❌ architecture-component-table: registry-derived overview facts drifted; run make test-architecture-component-table\n"
+    FAIL=$((FAIL + 1))
+  fi
+
   # Read host-aware registry data. Captured (not piped via process
   # substitution) so a registry.js failure — malformed services.json, node
   # crash — is an explicit AUDIT_ERROR instead of silently yielding zero rows

--- a/tests/scripts/test-architecture-component-table-regression.sh
+++ b/tests/scripts/test-architecture-component-table-regression.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regression coverage for the architecture overview guard's fail-closed input
+# handling. A broken services.json must never be reported as a clean overview.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$REPO_ROOT/tests/scripts/test-architecture-component-table.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+printf '{ not valid JSON\n' > "$TMP_DIR/services.json"
+
+if REGISTRY="$TMP_DIR/services.json" bash "$GUARD" >/dev/null 2>&1; then
+  echo "FAIL: malformed registry was accepted by architecture component table guard" >&2
+  exit 1
+fi
+
+cp "$REPO_ROOT/docs/architecture.md" "$TMP_DIR/architecture.md"
+# shellcheck disable=SC2016 # Markdown backticks are literal table syntax.
+printf '%s\n' '| **Verdandi** | Tamper-evident audit log | 3036 | Pi 1 | `verdandi` |' >> "$TMP_DIR/architecture.md"
+
+if ARCHITECTURE="$TMP_DIR/architecture.md" bash "$GUARD" >/dev/null 2>&1; then
+  echo "FAIL: duplicate registry-derived overview row was accepted" >&2
+  exit 1
+fi
+
+echo "PASS: malformed registry and duplicate registry-derived row fail the architecture component table guard"

--- a/tests/scripts/test-architecture-component-table.sh
+++ b/tests/scripts/test-architecture-component-table.sh
@@ -27,7 +27,22 @@ host_label() {
   esac
 }
 
+# Capture the producer before iteration: a failing process substitution would
+# otherwise close its stdout and let the loop report a misleading clean pass.
+if ! component_rows="$(node -e '
+  const registry = require(process.argv[1]);
+  for (const component of registry.components) {
+    if (Number.isInteger(component.port)) {
+      console.log([component.repo, component.port, component.host].join("\t"));
+    }
+  }
+' "$REGISTRY")"; then
+  err "cannot read registry-backed component rows from $REGISTRY"
+  exit 1
+fi
+
 while IFS=$'\t' read -r repo port host; do
+  [[ -n "$repo" ]] || continue
   label="$(host_label "$host")" || {
     err "no architecture-table host label is declared for registry host $host ($repo)"
     continue
@@ -35,25 +50,21 @@ while IFS=$'\t' read -r repo port host; do
 
   # Match the whole row's authority-derived columns. Role and display name are
   # intentionally free-form, but the registry repo, port, and host must agree.
-  if ! awk -F'|' -v repo="$repo" -v port="$port" -v host="$label" '
+  row_count="$(awk -F'|' -v repo="$repo" -v port="$port" -v host="$label" '
     $0 ~ /^\|/ {
       for (i = 1; i <= NF; i++) {
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i)
       }
-      if ($4 == port && $5 == host && $6 == "`" repo "`") found = 1
+      if ($4 == port && $5 == host && $6 == "`" repo "`") matches += 1
     }
-    END { exit(found ? 0 : 1) }
-  ' "$ARCHITECTURE"; then
-    err "$repo must have an architecture overview row with port $port and host $label"
-  fi
-done < <(node -e '
-  const registry = require(process.argv[1]);
-  for (const component of registry.components) {
-    if (Number.isInteger(component.port)) {
-      console.log([component.repo, component.port, component.host].join("\t"));
-    }
-  }
-' "$REGISTRY")
+    END { print matches + 0 }
+  ' "$ARCHITECTURE")"
+  case "$row_count" in
+    1) ;;
+    0) err "$repo must have an architecture overview row with port $port and host $label" ;;
+    *) err "$repo has $row_count duplicate architecture overview rows with port $port and host $label" ;;
+  esac
+done <<< "$component_rows"
 
 if (( fail )); then
   exit 1

--- a/tests/scripts/test-architecture-component-table.sh
+++ b/tests/scripts/test-architecture-component-table.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Keep authority-derived facts in the curated architecture overview aligned
+# with services.json (grimnir#5). This deliberately covers only components
+# with HTTP ports: their rows are the mechanical port/host/repository view.
+# Roles, non-service components, and the M5 gateway remain curated content.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REGISTRY="${REGISTRY:-$REPO_ROOT/services.json}"
+ARCHITECTURE="${ARCHITECTURE:-$REPO_ROOT/docs/architecture.md}"
+
+[[ -f "$REGISTRY" ]] || { echo "FAIL: registry not found: $REGISTRY" >&2; exit 1; }
+[[ -f "$ARCHITECTURE" ]] || { echo "FAIL: architecture document not found: $ARCHITECTURE" >&2; exit 1; }
+
+fail=0
+err() { echo "FAIL: $*" >&2; fail=1; }
+
+# The overview uses stable reader-facing labels, while services.json owns the
+# actual host identifiers. Unknown registry hosts fail closed rather than being
+# silently rendered as a plausible label.
+host_label() {
+  case "$1" in
+    huginmunin.local) echo 'Pi 1' ;;
+    nas.local) echo 'Pi 2 (NAS)' ;;
+    *) return 1 ;;
+  esac
+}
+
+while IFS=$'\t' read -r repo port host; do
+  label="$(host_label "$host")" || {
+    err "no architecture-table host label is declared for registry host $host ($repo)"
+    continue
+  }
+
+  # Match the whole row's authority-derived columns. Role and display name are
+  # intentionally free-form, but the registry repo, port, and host must agree.
+  if ! awk -F'|' -v repo="$repo" -v port="$port" -v host="$label" '
+    $0 ~ /^\|/ {
+      for (i = 1; i <= NF; i++) {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i)
+      }
+      if ($4 == port && $5 == host && $6 == "`" repo "`") found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$ARCHITECTURE"; then
+    err "$repo must have an architecture overview row with port $port and host $label"
+  fi
+done < <(node -e '
+  const registry = require(process.argv[1]);
+  for (const component of registry.components) {
+    if (Number.isInteger(component.port)) {
+      console.log([component.repo, component.port, component.host].join("\t"));
+    }
+  }
+' "$REGISTRY")
+
+if (( fail )); then
+  exit 1
+fi
+
+echo "PASS: architecture component overview matches registry-backed port, host, and repo facts"


### PR DESCRIPTION
Refs #5; advances its deterministic architecture-overview detection phase.

Adds a read-only guard for the `docs/architecture.md` component overview: every networked `services.json` component must retain exactly one matching repository, port, and reader-facing host row. The scheduled `grimnir-validate` path reports failures, and `make test` covers malformed registry input plus duplicate matching rows.

Extra curated overview rows remain allowed because the table also intentionally describes non-registry infrastructure, including the M5 gateway. This PR does not claim semantic drift detection, timestamp/significance heuristics, cross-repository CLAUDE/service-list checks, live unit validation beyond existing validator behavior, or Hugin-based remediation. Those need separate authoritative inputs and false-positive evidence before automation.

Validation: focused red/green guard regressions; `shellcheck scripts/generate-architecture.sh tests/scripts/test-architecture-component-table.sh tests/scripts/test-architecture-component-table-regression.sh`; `make test`.