### PR TITLE
docs: update M5 security hardening handoff

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,300 +1,119 @@
 # Grimnir System — Status
 
-**Last session:** 2026-07-28 (Codex) — W0–W5 software runway complete; ADR-008 mutation remains globally disarmed
-**Latest status revision before this handoff:** grimnir `16edee0`
+**Last session:** 2026-08-01 (Codex) — M5 security hardening is implemented through reviewed,
+owner-gated rollout points
+**Status base:** Grimnir `beb6282ca7d74d13517ef335172e6fd2dba8370a`
 
-## Autonomy runway update — 2026-07-28
+## Current phase
 
-- The approved ADR-008 constitution and owner-authorization/timing corrections are merged in
-  Grimnir PRs #171, #173, and #175. The six R-exact configuration classes and the R-forward
-  no-reboot maintenance class remain globally disarmed.
-- Disarmed implementation seams are merged across gille-inference PRs #111, #114, #116, and #118;
-  Hugin PRs #334, #335, #337, and #338; Brokkr PRs #71, #75, #77, and #79; and Heimdall
-  PR #45.
-- Brokkr #77 closed W2c with exact-path supervised evidence: one clean scenario and all ten required
-  fault scenarios passed. Its source-bound installer publishes disabled units only and was not run
-  against a production target. No trust root, target binding, service enablement, package mutation,
-  live canary, deployment, or autonomy arming occurred.
-- W3's circular producer/consumer dependency is resolved. Brokkr PR #79 supplies the software-only
-  `maintenance-execution-result/v1` contract, pure journal projection, eight-fixture corpus, and
-  permanently disabled delivery adapter. Heimdall PR #45 consumes it through a dedicated fail-closed
-  token, bounded monotonic SQLite projection, and separate read-only card.
-- Heimdall #45 merged as `3838f18` after independent Codex/Sol review, root review, green CI, 1,149
-  Node tests, 44 Python tests, and 18 focused observer tests. It was deployed through Grimnir's
-  exact-source gate; dependency audit reported zero vulnerabilities and the deployment health gate
-  passed. This deployment configured neither the dedicated observer token nor Brokkr delivery.
-- M5 was dogfooded on Brokkr #79 and Heimdall #45. Its observations were validated rather than
-  accepted mechanically; grounded false positives were recorded on gille-inference #25 as learning
-  evidence.
+The W0–W5 software runway remains complete and ADR-008 mutation authority remains globally
+disarmed. The 2026-08-01 security program hardened the public inference edge, service identities,
+agent policy, substrate tests, and staged access controls. Completed deployments are verified;
+remaining production or merge mutations are held behind exact owner approvals and attended safety
+ceremonies.
 
-### Current phase
+No credential, private address, backup locator, or private account detail belongs in this handoff.
 
-The architecture is at **L4 ceremony-ready, mutation globally disarmed**. Repository code now
-establishes bounded admission, exact source/config identity, watchdog/recovery paths, deterministic
-promotion predicates, fault-injection proof, and deployed read-only observation. It does not yet
-establish live mutation evidence. L5
-continuous-improvement plumbing exists for proposal/admission/recovery, but evidence-driven policy
-changes are not proven safe in production.
+## Verified outcomes
 
-### Exact next steps
+### gille-inference
 
-1. Stop for the separate owner ceremony that binds exact revisions, private targets, trust roots,
-   and delegated budget before any install, enablement, arming, or live canary.
-2. Run Brokkr #69 and #70 live canary/windows/drills only after that ceremony, then use their real
-   evidence—not fixtures or merge state—to decide whether promotion remains blocked.
-3. Enter L5 only after L4 production evidence proves that measurement, hold/disarm, watchdog, and
-   R-forward recovery claims survive real operating windows.
+- Issue #150 is complete and deployed: the public inference edge uses HTTPS.
+- Issue #151 is complete and deployed at
+  `c45a0654f6768ad9a0d9fd7854166cc19efcd5cb`: gateway, tunnel, and inference workloads use
+  dedicated service identities with isolation and live health/authentication checks.
+- Issue #152's code merged in PR #170 as
+  `a2c119dc0dde6f7aa44d60c9db25d2d71a399297`. Its deployment is superseded by current main
+  `ff797087c4ab763883eae1f2e839a413b0497945`, which also contains the diagnostic hardening below;
+  production deployment awaits exact owner approval.
+- Issue #168 closed through PR #171, merged as
+  `ff797087c4ab763883eae1f2e839a413b0497945`. Adoption-report failures now expose stable,
+  content-free reasons and have regression coverage across the supported result space.
+- Issue #166 has a reviewed branch at
+  `75a2f85a7625b4be731ebaae25bc73039a29fce9`; PR publication was blocked by the execution
+  platform, so it remains unmerged.
+- Issue #169 was already fixed by PR #170. Tracker reconciliation was blocked; do not fabricate
+  another implementation.
 
-## Current work
+### Brokkr
 
-- **W0–W5** are now merged across 16 PRs in five owning repositories. W3's read-only Heimdall
-  observer is deployed; all mutation lanes, Brokkr delivery, promotion, and the first canary remain
-  disarmed behind Brokkr #69's separate owner ceremony.
-- **Grimnir #170 / PR #171** defines a W0-only, globally disarmed autonomy constitution. The
-  approved contract has seven exact classes: six R-exact routing/configuration classes (with
-  micro-routing required for both L4 and L5) and one L4 R-forward no-reboot
-  security/bugfix-maintenance class. Its ADR-008 domain journals are
-  authoritative and Verdandi optional only for those classes; legacy actors retain mandatory
-  Verdandi and no automatic rollback. No controller, lane, or deployment is armed by this record.
-- **Skuld #14 / PR #16** is root-Codex + authenticated-M5 approved and passes 104 local tests, build,
-  lint, and diff check. It cannot merge under the green-CI rule: GitHub Actions run `30187798237`
-  failed twice with **zero executed steps**, including an explicit rerun. This is tracked in
-  Grimnir #140. No AI model is required for CI; restore hosted Actions or use an isolated disposable
-  Linux runner with no production credentials. Do not execute pull-request code on production M5.
-- **Brokkr #35** remains the next substrate-autonomy contract: privileged adapter, workload/reboot
-  lifecycle, retry-journal binding, and executable forward recovery.
-- **Grimnir #79** remains open for fleet-wide enforcement. PR #166 completed the bounded named-seam
-  refresh: Ratatoskr → Heimdall is verified; no active Verdandi emitter or grounded service-owned
-  Munin status-shape defect was found, so no owner ticket was fabricated.
-- Grimnir #139's central read-only GitHub Actions policy remains implemented. Its live fleet
-  findings are routed to owning repositories.
+- Issue #89's safe full-disk-encryption preparation merged through PR #93 as
+  `bd23a1118b275d04dc534066ba9d9ff274374b19`. The destructive live migration is deliberately
+  postponed to an attended post-travel window with verified backup and rollback ceremony.
+- Issue #90 / PR #95 passed review and green checks at former exact head
+  `5d669bd5412def50f0e5075010da85d4e72ef7e0`, but main advanced and that head is no longer
+  mergeable. Its prior approval request is withdrawn while the owning agent updates it for a new
+  exact-head review. No staged or live firewall, SSH, or Samba mutation has occurred.
+- Issue #91 / PR #96 is reviewed PASS, green, and ready at exact head
+  `f870f69a90640c2688a0edfc9220a638dbf514ec`. Merge requires owner approval. The issue remains
+  open for owner-attended private binding, official policy validation, live apply, probes, and
+  rollback; no live tailnet or firewall mutation has occurred.
+- Issues #84 and #94 were fixed by PR #85; Brokkr main reached
+  `c53b79d7808c74b33c6a485010559566e396f929`. Issue #92 was reconciled and closed after the
+  current tests verified the underlying timestamp behavior.
 
-## Approved-decision follow-up — 2026-07-26
+### Agent policy
 
-All four approved production decisions were executed behind exact-source, rollback, Codex-review,
-direct authenticated M5-review, and green-CI gates.
+- claude-config #22, #24, and #26 completed through PR #23
+  (`d61b37e9165da7b6f3386fc4326c8e3d66dd4195`), PR #25
+  (`61b064ae7e14d3acbc54fcc71213488ac7237d9e`), and PR #27
+  (`bae16253b15fc20ae941d130c8bc05d8adf02d99`).
+- Portable policy, tainted-session boundaries, and instruction-audit gates are active. Current
+  audits are healthy except the known archived LumiKin #61 wrapper drift.
 
-| repo | PR | merge | production outcome |
-|---|---:|---|---|
-| munin-memory | #294 | `408a9ea` | `/home` unit contract deployed; service healthy, same DB inode, 9,445 entries, SQLite `quick_check=ok` |
-| brokkr | #55 | `2d2a111` | public-safe control-node overlay deployed; three timers present and active |
-| brokkr | #57, #61 | `ed8c285`, `e68e65c` | dedicated NAS identity deployed with password/interactive login denied, fixed command, and root-owned group-readable authorization |
-| heimdall | #44 | `10686f1` | exact deployment completed; restricted NAS collection reads 19 sections and reports storage healthy |
-| brokkr | #56, #62 | `262b2e5`, `acc7f97` | bounded M5 Time Machine destination telemetry deployed; timer active, 535 bands observed, authenticated Heimdall state `pass` |
-| brokkr | #63 | `c62a882` | M5 operational checkout reconciled to the owning public repository; exact `origin/main` verified and prior locator preserved owner-only for rollback |
-| mimir | #36 | `8cd26ce` | fixed metadata-only backup/sync freshness surface deployed; real backup and sync produced probe-readable records |
-| brokkr | #65 | `8ec4284` | Mimir v1 records consumed through the restricted 19-section probe; final Heimdall collection stored both metrics with zero active Mimir alerts |
+## Owner approvals still required
 
-Three production-shape failures were allowed to fail closed and were corrected rather than bypassed:
-PAM rejected the locked dedicated account, OpenSSH privilege-dropping could not read root-only
-authorization, and the real Time Machine path contained whitespace. Consumer verification also
-found a stale public-key companion after the private key itself had been verified. Each failed
-attempt removed its managed artifacts before the corrected exact revision was installed.
-Final Brokkr CI also caught a macOS-only test temp path: allocation failed on Linux, the harness
-continued with an empty variable, and it attempted permission changes under `/bin`. Runner
-permissions prevented mutation. PR #65 now uses the platform temp root, validates the allocated
-directory before any path operation, and starts with `set -euo pipefail`.
+Enter these exact phrases in the active Codex chat when ready:
 
-Brokkr #54, #58, #59, #60, and #64, Mimir #35, and Heimdall #23 are closed. Their completed roadmap
-items are Done. Heimdall now has grounded disk, Munin, Time Machine, and Mimir backup/sync evidence
-through least-authority producers and the restricted consumer.
+1. `Approve merge Brokkr PR #96 at f870f69`
+2. `Approve M5 deploy gille-inference ff79708`
 
-## Autonomous fleet sweep — initial snapshot
+Do not reuse the withdrawn PR #95 approval. Wait for the owning agent's updated exact head and a
+fresh review before requesting a replacement phrase.
 
-The sections below preserve the earlier 2026-07-26 sweep evidence. Where deployment state differs,
-the approved-decision follow-up above is authoritative.
+An attempted iMessage notification failed safely because Messages automation could not acquire a
+window. No message was delivered, and no alternate personal contact locator was stored or used.
 
-### Accepted, merged, and published
+## Safety gates and blockers
 
-| repo | PR | merge | outcome |
-|---|---:|---|---|
-| gille-inference | #104 | `be77a8b` | dated fail-closed delegator cost catalogue; deployed and verified |
-| gille-inference | #105 | `5dae436` | structural owner-only code-loop MCP contract; deployed and live-probed |
-| gille-inference | #106 | `e33926f` | `code-edit` characterized as a measured gap; deployed, guarded route adoption published |
-| heimdall | #43 | `fd75348` | readable Telegram task notifications; deployed and live-probed |
+- Deploy gille-inference only from exact accepted revision
+  `ff797087c4ab763883eae1f2e839a413b0497945`, after the owner approval above. Re-run health,
+  authentication, inference, and adoption-recorder probes after deployment.
+- Brokkr PR #95 is being updated after main advanced. It needs a new exact-head review and a new
+  explicit approval phrase before merge; live network hardening remains a separate attended action.
+- Brokkr PR #96 may be merged after its exact approval, but issue #91 stays open until the owner
+  validates private device bindings and completes apply/probe/rollback from a physically safe
+  two-session ceremony.
+- Full-disk encryption remains an attended post-travel operation. Do not start it remotely or
+  unattended.
+- gille-inference #166 needs a normal PR publication path before merge review can complete. Issue
+  #169 only needs tracker reconciliation against the already-merged fix.
+- The broader L4 autonomy ceremony is still pending. No controller, mutation lane, or live canary
+  is armed by this security program.
 
-Gille's guarded routing publication adopted candidate
-`sha256:08b08fe477b2dc567758600afb2b88387f6df7a5fac2a6d4b23112a556740427`.
-`code-edit` remains frontier/null with truthful 1/15 evidence; no forced promotion occurred.
-The same deterministic artifact moved `classify` and `extract` to Qwen on 9/9 evidence and added six
-newly enumerated aliases as fail-safe frontier routes. Watchdog record
-`2c5280bd-eb5a-4a5a-8e83-6873fefb0d6a` is pending its observation window; the immediate dry-run had
-zero post-adoption samples and took no action.
+## M5 adoption evidence
 
-### Accepted and merged; deployment intentionally withheld
+- The macOS temporary-directory leaf used `qwen3-coder-next-80b` and was **partial**: useful input
+  required frontier verification and correction before acceptance.
+- The tailnet policy leaf used `mellum` and was **pass** after deterministic verification.
+- Adoption-recorder rejection before the `ff797087` deployment is expected evidence of the old
+  production behavior, not proof that the merged diagnostic fix failed.
 
-| repo | PR | merge | outcome / deployment gate |
-|---|---:|---|---|
-| munin-memory | #289 | `b0b8bbf` | delete preview binds the complete lineage |
-| munin-memory | #290 | `bba63cc` | idempotent status round-trip + lifecycle preservation |
-| munin-memory | #291 | `f563413` | malformed query/list/CAS arguments now fail closed |
-| munin-memory | #292 | `3129043` | preview-first, source-grounded manual consolidation |
-| heimdall | #44 | `10686f1` | explicit restricted storage identity; #23 remains open for Brokkr #51 |
-| grimnir | #166 | `ba6c5ed` | verified named seam evidence; #79 remains open fleet-wide |
-| brokkr | #49 | `bd60261` | bounded maintenance controller |
-| brokkr | #50 | `d59eaca` | safe library-only Debian mutation/evidence seam; #35 remains open |
-| brokkr | #52 | `3681664` | content-bound restricted NAS probe contract; live identity approval pending |
+## Exact next steps
 
-All Munin deployments remain blocked by Grimnir #146's `/home` versus `/srv` unit-path authority
-conflict. Heimdall #44 is withheld until Brokkr #51 supplies and verifies its restricted NAS
-identity; deploying it earlier would expose a known critical state without restoring backup/storage
-visibility. Brokkr #50 performs no live effects and deliberately refuses controller composition
-until retry attempt IDs can be bound to immutable mutation journals.
+1. Obtain the two current exact approvals above in Codex chat; wait for a replacement PR #95 phrase.
+2. Merge Brokkr PRs #95 and #96 only at their newly/currently reviewed heads and after green CI; do not combine
+   merge approval with live application authority.
+3. Deploy gille-inference `ff797087c4ab763883eae1f2e839a413b0497945` through its exact-source
+   gate and run the post-deploy probes.
+4. Reconcile gille-inference #166/#169 without duplicating completed work.
+5. Schedule attended post-travel windows for Brokkr #89, #90, and #91 live ceremonies.
+6. Keep W0–W5 mutation classes disarmed until their separate owner ceremony and real production
+   evidence gates are satisfied.
 
-### Evidence-only closure and genuine blockers
+## Verification standard
 
-- Munin #287 was closed as not reproduced after production commitments/handoff evidence proved
-  consistent; no patch was fabricated.
-- Ratatoskr #57 closed via PR #59 / `73943d1`: a bounded production alert lifecycle proved
-  absent → accepted/visible once → resolved once → absent. The committed record retains only
-  timestamp/count/result metadata, so no runtime deployment was needed.
-- Brokkr #44 conflicts with repository safety policy: its exact committed profile would contain
-  private host/account/token-source locators forbidden in git. Owner must either approve those
-  specific non-secret locators or revise acceptance to a committed schema/example plus untracked
-  overlay.
-- Brokkr #35 still needs the privileged adapter contract, exact apt/dpkg allowlist, workload
-  ownership/health hooks, reboot continuation, retry-journal binding, and executable forward
-  recovery.
-- Brokkr #51's first implementation was rejected because it could install an arbitrary untracked
-  “19-section” script and never executed the remote mutation body in tests. Accepted PR #52 instead
-  tracks the fixed command, closes the config grammar, pins host keys, binds staged/installed
-  digests, and executes apply/reapply/drift/revoke hermetically. The live credential mutation still
-  requires owner approval.
-- Gille #96 remains open for provider/billing decisions for unpriced models; #98 remains open for
-  dedicated key naming/quota plus rotation/revocation evidence.
-
-Every accepted PR in this sweep received exact-diff root Codex review, direct authenticated M5
-review, and the repository's full available verification. Claude was unavailable due its monthly
-limit, so the user-authorized Codex + M5 fallback was used.
-
-## The headline
-
-Heimdall was the session's centre of gravity and its open alerts went from **9 of unknown truth to 5,
-all verified true**, then to a state where every remaining alert is either actionable or a known
-miscalibration with a filed ticket. The root cause was not any single bug: **production Heimdall had
-been running the committed *demonstration* config since the 2026-07-19 public release**, with RFC 5737
-documentation addresses and demo host names. Backup and disk probes were dark for three days.
-
-A second theme ran through the whole session: **the issue tracker is not evidence about the running
-system, in either direction.** Four issues were open after their work was done; one (#69) asserted a
-service was missing while it was running fine.
-
-## Completed this session
-
-### Merged and deployed
-
-| repo | PR | commit | change |
-|---|---|---|---|
-| heimdall | #25 | `945847c` | alarm correctness + display reduction; deployed |
-| grimnir | #148 | `0e03def` | audit exit semantics + fixed Munin reporting channel; live on Pi |
-| grimnir | #150 | `87dfc6f` | deploy refuses a unit whose target contradicts `deploy_path` |
-| brokkr | #43 | `99afdb3` | `pipefail` bug that silently aborted `maintenance-os` daily; deployed |
-| hugin | #321 | `3be19f7` | Heimdall descriptor 7,754 → ~690 bytes; **not deployed** (see blockers) |
-| munin-memory | #260 | `cd80e33` | bounded `memory_orient` in every detail mode |
-| munin-memory | #261 | `e8caef0` | exact-anchor retrieval floor |
-| munin-memory | #265 | `2eaa4e5` | release v0.6.1; deployed to huginmunin |
-| gille-inference | #92 | `125b0f3` | canonicalize task-type identity for authority gates |
-| gille-inference | #93 | `7c628ff` | stamped vs defaulted delegator attribution |
-
-Deployed and certified: gille-inference `125b0f3` (owner-run), munin-memory v0.6.1, heimdall
-`945847c`, brokkr `99afdb3`, grimnir `0e03def` on the Pi checkout.
-
-### Heimdall — what was actually wrong
-
-- **`commits_behind = -1`** (`drift.js:280`, `else { commitsBehind = -1 }`) produced 6 of the 9 alerts.
-  Drift now resolves to `up-to-date | drift | ahead | unknown`, per repo rather than per systemd unit,
-  with "not measurable" rendered distinctly from "behind".
-- **Zombie alerts** bound to a dead host identity (`huginmunin` stopped reporting 2026-07-23 while the
-  same machine reported as `control-node`). Reconciled via `fleet.host_aliases` plus a staleness reaper.
-- **Real failures were silent** while false ones were loud: `brokkr-maintenance-os` (exit 1 daily) and
-  `grimnir-validate` raised no alert at all.
-- **Production ran the demo config.** `HEIMDALL_CONFIG_PATH` and `GRIMNIR_SERVICES_JSON` were both
-  unset, so RFC 5737 addresses were live. Fixed with a non-repo overlay at
-  `/home/magnus/.heimdall/config.json` (mode 0600) plus `HEIMDALL_STORAGE_SSH_USER=magnus` and
-  `HEIMDALL_STORAGE_SSH_HOST`. **Three separate places defaulted to documentation addresses**; all
-  three had to be fixed before a single metric flowed. The resulting fresh NAS rows were later shown
-  to rely on implicit personal-identity fallback, not a valid restricted probe; Heimdall #23 and
-  Brokkr #51 own that correction.
-
-### Deploy safety
-
-`grimnir#150` was written because `make deploy` **took Munin Memory down for ~10 minutes**: it rsynced
-code to the registry `deploy_path` and installed a unit pointing at `/srv/grimnir/munin-memory`, a path
-that does not exist on the host. Recovery worked only because a March-era `.bak` happened to survive.
-
-The guard immediately found **two more armed instances**: `mimir` (unit says `User=mimir`,
-`/home/mimir/mimir-server` — neither exists on the NAS; filed mimir#29) and `brokkr` (unit runs from
-`~/.local/lib/brokkr` while the registry says `/home/magnus/repos/brokkr` — a silent no-op deploy).
-
-### Backlog reconciliation
-
-Audited all 35 open grimnir issues: **1 delivered, 11 partial, 23 open**. Corrected #102 (NOT
-delivered — `hugin#289` open, so acceptance criterion 4 unmet), #78 (2 of 3 "remaining" repos already
-gone), #90 (only `claude-config#11` outstanding). Closed **#69 as invalid** and recorded the trial
-dates in `docs/skuld-trial-decision.md` (PR #147) — they were blank placeholders, so the day-28 gate
-could never come due.
-
-### Cross-fleet dependency sweep
-
-Issue **#16** was re-audited against each named repository's current `main` lockfile on 2026-07-26.
-The original all-dev/build-time premise was false: production audit findings remain in munin-memory,
-hugin, and verdandi. Roadmap-linked owning tickets are munin-memory#285, hugin#322, and verdandi#29.
-Heimdall's remediation PR #39 merged as `a02420f`, was deployed exactly, and its collector, live
-health revision, and remote production audit all verified clean. #16 remains open until the three
-remaining owner deliverables land. Mimir, Ratatoskr, Skuld, and Fortnox MCP have no production audit
-findings; their remaining findings are dev-only.
-
-## Important incidents and learnings
-
-- **The deploy outage (grimnir#146).** The `/srv/grimnir` relocation is half-done: the owning repo
-  declares post-relocation units while the registry and hosts are pre-relocation, and nothing failed
-  closed. Finish or revert the relocation; it belongs with Epic C / brokkr#12.
-- **#69 nearly cost a working service.** It claimed skuld was never installed; the owner had approved
-  cutting it. Skuld runs as a **user-scope** timer — `systemctl list-units` reports zero and reads as
-  absence. Verifying against the host is the only reason a live daily briefing was not archived.
-  **"Not in `systemctl list-units`" is not evidence a service is absent.**
-- **Thresholds encoded assumptions nobody had checked.** Three tickets (heimdall#27, #28, #29) share one
-  shape: a constant standing in for a property that should be read from the thing being monitored — a
-  demo config assumed real, a 6h backup threshold against a **weekly** schedule
-  (`AutoBackupInterval = 604800`), an 80% disk rule against a volume deliberately run near-full by quota.
-- **M5 splits by task shape, again.** Bounded structural extraction was reliable and produced a real
-  review finding; anything reasoning-shaped failed (it returned an inverted answer on brokkr control
-  flow and was discarded). Under four concurrent agents, two independently recovered from "server is
-  busy" by **trimming the prompt** rather than waiting — pointing at admission behaviour, not raw
-  capacity. Recorded on gille-inference#25.
-
-## Next steps (priority order)
-
-1. **Skuld PR #16 / Grimnir #140** — choose private-repo CI funding or an isolated self-hosted
-   runner; merge only after a check actually executes and passes.
-2. **Brokkr #35** — finish the privileged adapter, workload/reboot lifecycle, retry-journal binding,
-   and executable forward recovery.
-3. **Mechanical promotion and rollback** — use the now-authenticated storage and service evidence as
-   promotion predicates, then extend unattended maintenance only where immutable journals and
-   watchdog rollback are in place.
-4. **Gille #96/#98** — resolve provider pricing/billing and dedicated key/quota/rotation policy;
-   continue the #85 watchdog only after its observation window has real samples.
-5. **Time-gated trials** — reassess Grimnir #159 after 28 immutable validator runs and Hugin #165
-   on 2026-08-22; do not manufacture early conclusions.
-
-## Blockers / owner input
-
-- **Private-repo GitHub Actions** still fails before any step executes. Grimnir #140 is explicitly an
-  owner infrastructure choice. CI needs compute, not an inference model. Preferred: restore hosted
-  Actions. Alternative: an isolated disposable Linux VM with no production credentials.
-- All production authority decisions supplied for this follow-up are resolved: the NAS identity,
-  `/home` Munin path, public-safe Brokkr overlay, and M5-local Time Machine producer are live.
-
-## Verification at close
-
-- Every merged PR had green CI plus independent review with executed verification — regressions
-  mutation-tested to confirm they fail without the fix, not merely inspected.
-- Heimdall's `test/live-alert-state.test.js` replays the nine real alerts and asserts each corrected
-  outcome (8/8 passing), including that an audit reporting 2 findings raises **no** failure alert.
-- `grimnir-validate` verified live under systemd: exit **0**, `Result=success`,
-  `AUDIT OK: ran to completion — 2 finding(s)`, and `Results written to Munin (findings=2 severity=issues)`
-  after months of a silent trailing-slash failure (`validation/` vs `validation`).
-- NAS rows did update after being frozen since 2026-07-22, but this session established that the
-  collector borrowed an implicit personal SSH identity. Treat that as failure evidence, not restored
-  monitoring, until Heimdall #23 / Brokkr #51 complete.
-- grimnir `make test` 117 passed / 0 failed plus the new 12-test exit-contract suite; shellcheck clean.
+Every completed code path above was reviewed against an exact revision and exercised with focused
+and repository-level checks in its owning repo. Merge state is not deployment evidence; staging is
+not live application; code review is not owner authorization. Resume from the explicit gates above
+rather than inferring authority from this status file.

--- a/STATUS.md
+++ b/STATUS.md
@@ -29,6 +29,12 @@ No credential, private address, backup locator, or private account detail belong
 - Issue #168 closed through PR #171, merged as
   `ff797087c4ab763883eae1f2e839a413b0497945`. Adoption-report failures now expose stable,
   content-free reasons and have regression coverage across the supported result space.
+- The exact `ff797087c4ab763883eae1f2e839a413b0497945` deployment preflight passed source binding,
+  67 focused tests, typechecks, diff validation, and the documented dry-run. Official verification
+  confirmed that production still runs `c45a0654f6768ad9a0d9fd7854166cc19efcd5cb` and passed its
+  source spot checks, then failed closed only because `DEPLOY_PUBLIC_HTTP_URL` and
+  `DEPLOY_PUBLIC_HTTPS_URL` were unavailable. Their non-secret private locator values must be
+  exported in the private operator environment and never pasted into chat or committed.
 - Issue #166 has a reviewed branch at
   `75a2f85a7625b4be731ebaae25bc73039a29fce9`; PR publication was blocked by the execution
   platform, so it remains unmerged.
@@ -40,10 +46,12 @@ No credential, private address, backup locator, or private account detail belong
 - Issue #89's safe full-disk-encryption preparation merged through PR #93 as
   `bd23a1118b275d04dc534066ba9d9ff274374b19`. The destructive live migration is deliberately
   postponed to an attended post-travel window with verified backup and rollback ceremony.
-- Issue #90 / PR #95 passed review and green checks at former exact head
-  `5d669bd5412def50f0e5075010da85d4e72ef7e0`, but main advanced and that head is no longer
-  mergeable. Its prior approval request is withdrawn while the owning agent updates it for a new
-  exact-head review. No staged or live firewall, SSH, or Samba mutation has occurred.
+- Issue #90 / PR #95 is refreshed on base
+  `c53b79d7808c74b33c6a485010559566e396f929`, reviewed PASS, green, and mergeable at exact head
+  `6cec78c3a0b616a061cfd150503a32b276e3fcd3`. Its security patch-id is unchanged and its body says
+  `Part of #90`. Code merge does not close #90: the issue remains open until the owner-attended live
+  apply, probes, and rollback evidence satisfy acceptance. No staged or live firewall, SSH, or
+  Samba mutation has occurred.
 - Issue #91 / PR #96 is reviewed PASS, green, and ready at exact head
   `f870f69a90640c2688a0edfc9220a638dbf514ec`. Merge requires owner approval. The issue remains
   open for owner-attended private binding, official policy validation, live apply, probes, and
@@ -65,11 +73,9 @@ No credential, private address, backup locator, or private account detail belong
 
 Enter these exact phrases in the active Codex chat when ready:
 
-1. `Approve merge Brokkr PR #96 at f870f69`
-2. `Approve M5 deploy gille-inference ff79708`
-
-Do not reuse the withdrawn PR #95 approval. Wait for the owning agent's updated exact head and a
-fresh review before requesting a replacement phrase.
+1. `Approve merge Brokkr PR #95 at 6cec78c`
+2. `Approve merge Brokkr PR #96 at f870f69`
+3. `Approve M5 deploy gille-inference ff79708`
 
 An attempted iMessage notification failed safely because Messages automation could not acquire a
 window. No message was delivered, and no alternate personal contact locator was stored or used.
@@ -79,8 +85,9 @@ window. No message was delivered, and no alternate personal contact locator was 
 - Deploy gille-inference only from exact accepted revision
   `ff797087c4ab763883eae1f2e839a413b0497945`, after the owner approval above. Re-run health,
   authentication, inference, and adoption-recorder probes after deployment.
-- Brokkr PR #95 is being updated after main advanced. It needs a new exact-head review and a new
-  explicit approval phrase before merge; live network hardening remains a separate attended action.
+- Brokkr PR #95 may be merged only at reviewed head
+  `6cec78c3a0b616a061cfd150503a32b276e3fcd3` after its exact approval. Issue #90 remains open for
+  the separate owner-attended live apply, probes, and rollback evidence.
 - Brokkr PR #96 may be merged after its exact approval, but issue #91 stays open until the owner
   validates private device bindings and completes apply/probe/rollback from a physically safe
   two-session ceremony.
@@ -101,8 +108,8 @@ window. No message was delivered, and no alternate personal contact locator was 
 
 ## Exact next steps
 
-1. Obtain the two current exact approvals above in Codex chat; wait for a replacement PR #95 phrase.
-2. Merge Brokkr PRs #95 and #96 only at their newly/currently reviewed heads and after green CI; do not combine
+1. Obtain the three current exact approvals above in Codex chat.
+2. Merge Brokkr PRs #95 and #96 only at their reviewed heads and after green CI; do not combine
    merge approval with live application authority.
 3. Deploy gille-inference `ff797087c4ab763883eae1f2e839a413b0497945` through its exact-source
    gate and run the post-deploy probes.


### PR DESCRIPTION
## What changed

Replaces the stale execution snapshot in `STATUS.md` with a concise, sanitized 2026-08-01 handoff for the M5 security-hardening program, then refreshes it with the latest reviewed approval gates.

The status now records:

- verified deployed and merged outcomes across gille-inference, Brokkr, and claude-config
- exact reviewed revisions and the distinction between code, merge, deployment, and live-apply state
- Brokkr PR #95 refreshed/reviewed/green at `6cec78c`, while issue #90 remains open for attended live evidence
- Brokkr PR #96 reviewed/green at `f870f69`, while issue #91 remains open for attended live evidence
- the fail-closed gille-inference `ff797087` deployment preflight without private locator values
- the three current exact component approval phrases
- attended safety gates for disk encryption, network policy, and firewall changes
- content-free M5 adoption evidence and the expected pre-deployment recorder rejection

No credentials, private addresses, locator values, backup locators, private account data, or personal contact locator are included.

## Why

The prior status dated from 2026-07-28 and no longer represented the security program's current execution state. A compact cross-surface handoff prevents stale approvals, merge state, or a successful preflight from being mistaken for production authority.

## Impact

Documentation only. This PR does not merge component PRs, deploy services, change credentials, apply network policy, or arm autonomy.

## Verification

- `make test` — pass, including the full repository suite
- `git diff --check` — pass
- privacy scan for addresses, contact locators, URLs, filesystem locators, private-key markers, and bearer values — clean
- M5 `mellum` bounded completeness check on the initial handoff — pass; output independently verified
- no duplicate M5 task was manufactured for this factual refresh
- M5 adoption evidence recorder — expected rejection until gille-inference `ff797087` is deployed

Exact base: `beb6282ca7d74d13517ef335172e6fd2dba8370a`

Exact head: `de8c6a2270161d435babfc630e89592421fc9347`