### PR TITLE
registry: add munin-zero as a managed node

### DIFF
--- a/scripts/tests/registry-smoke.test.sh
+++ b/scripts/tests/registry-smoke.test.sh
@@ -91,6 +91,31 @@ assert_eq "valid registry -> exit 0" "0" "$(run_validator "$TMP_DIR/valid.json")
 REPO_REGISTRY="$SCRIPT_DIR/../../services.json"
 assert_eq "real services.json -> exit 0" "0" "$(run_validator "$REPO_REGISTRY")"
 
+# Managed legacy nodes remain observable without becoming workload deployment
+# targets. This is the Grimnir-side regression for issue #190.
+NODE_JSON="$(REGISTRY_PATH="$REPO_REGISTRY" QUERY=nodes-json node --input-type=commonjs "$SCRIPT_DIR/../lib/registry.js")"
+if NODE_JSON="$NODE_JSON" node -e '
+  const nodes = JSON.parse(process.env.NODE_JSON);
+  const node = nodes.find((candidate) => candidate.node_id === "node-munin-zero");
+  if (!node || node.name !== "munin-zero" || node.hostname !== "munin-zero.local" || node.role !== "memory-appliance" || node.status !== "active" || node.monitor !== true) process.exit(1);
+'; then
+  echo "  PASS: munin-zero is an active monitored managed node"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: munin-zero is an active monitored managed node"
+  FAIL=$((FAIL + 1))
+fi
+if REGISTRY_PATH="$REPO_REGISTRY" node -e '
+  const registry = require(process.env.REGISTRY_PATH);
+  if (registry.components.some((component) => component.target_node_id === "node-munin-zero")) process.exit(1);
+'; then
+  echo "  PASS: munin-zero is not a component deployment target"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: munin-zero is not a component deployment target"
+  FAIL=$((FAIL + 1))
+fi
+
 # ── Repository authority is bounded and machine-readable (#112) ───────────
 cat > "$TMP_DIR/bad-repository-authority.json" << 'EOF'
 {

--- a/services.json
+++ b/services.json
@@ -283,6 +283,18 @@
       "llm_servers": [],
       "monitor": false,
       "notes": "E-paper display / skald-display MCP node — NOT an inference node. Back online 2026-06-16."
+    },
+    {
+      "name": "munin-zero",
+      "node_id": "node-munin-zero",
+      "hostname": "munin-zero.local",
+      "ssh_alias": null,
+      "hardware": "Raspberry Pi Zero 2 W (armv7l), 512MB",
+      "role": "memory-appliance",
+      "status": "active",
+      "llm_servers": [],
+      "monitor": true,
+      "notes": "Legacy/secondary Munin Memory appliance — best-effort, LAN-only on the home network, managed by Brokkr for OS/firmware maintenance and health observation. No Grimnir workload is deployed here; do not use as a component deployment target. Tailscale is not installed."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- register `munin-zero` as an active, monitored legacy Raspberry Pi Zero 2 W node
- keep it in Brokkr's best-effort node-tier maintenance/health-observation scope
- explicitly prevent it from becoming a Grimnir component deployment target
- add registry smoke regressions for both properties

This implements Grimnir issue #190. The registry remains desired topology; live node capability remains Brokkr-owned evidence.

## Validation

- `git diff --check`
- `REGISTRY_PATH=services.json node --input-type=commonjs scripts/lib/validate-registry.js`
- `bash scripts/tests/registry-smoke.test.sh`
- `make test`

The Pi was separately updated and reboot-verified on 2026-08-12; no private addresses, credentials, or device identifiers are committed here.